### PR TITLE
走行中の一時停止・再開機能を追加 (mapoi_pause / mapoi_resume)

### DIFF
--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
@@ -45,6 +45,8 @@ private Q_SLOTS:
   void LocalizationButton();
   void RunGoalButton();
   void RunRouteButton();
+  void PauseButton();
+  void ResumeButton();
   void StopButton();
 
 protected:
@@ -67,6 +69,8 @@ protected:
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr nav2_initialpose_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr nav2_goal_pose_pub_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr mapoi_cancel_pub_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr mapoi_pause_pub_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr mapoi_resume_pub_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr mapoi_route_pub_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr mapoi_highlight_goal_pub_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr mapoi_highlight_route_pub_;

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -37,6 +37,8 @@ void MapoiPanel::onInitialize()
   connect(ui_->LocalizationButton, SIGNAL(clicked()), this, SLOT(LocalizationButton()));
   connect(ui_->RunGoalButton, SIGNAL(clicked()), this, SLOT(RunGoalButton()));
   connect(ui_->RunRouteButton, SIGNAL(clicked()), this, SLOT(RunRouteButton()));
+  connect(ui_->PauseButton,    SIGNAL(clicked()), this, SLOT(PauseButton()));
+  connect(ui_->ResumeButton,   SIGNAL(clicked()), this, SLOT(ResumeButton()));
   connect(ui_->StopButton, SIGNAL(clicked()), this, SLOT(StopButton()));
 
   parentWidget()->setVisible(true);
@@ -66,6 +68,8 @@ void MapoiPanel::onInitialize()
   nav2_goal_pose_pub_ = node_->create_publisher<geometry_msgs::msg::PoseStamped>("goal_pose", 1);
 
   mapoi_cancel_pub_ = node_->create_publisher<std_msgs::msg::String>("mapoi_cancel", 1);
+  mapoi_pause_pub_  = node_->create_publisher<std_msgs::msg::String>("mapoi_pause",  1);
+  mapoi_resume_pub_ = node_->create_publisher<std_msgs::msg::String>("mapoi_resume", 1);
   mapoi_route_pub_ = node_->create_publisher<std_msgs::msg::String>("mapoi_route", 1);
   mapoi_highlight_goal_pub_ = node_->create_publisher<std_msgs::msg::String>("mapoi_highlight_goal", 1);
   mapoi_highlight_route_pub_ = node_->create_publisher<std_msgs::msg::String>("mapoi_highlight_route", 1);
@@ -207,6 +211,24 @@ void MapoiPanel::RunRouteButton()
   RCLCPP_INFO(LOGGER, "A route was set: %s", msg.data.c_str());
 }
 
+void MapoiPanel::PauseButton()
+{
+  std_msgs::msg::String msg;
+  msg.data = "mapoi_panel";
+  mapoi_pause_pub_->publish(msg);
+  ui_->NavStatusLabel->setText(QString::fromStdString("一時停止中"));
+  RCLCPP_INFO(LOGGER, "Pause requested");
+}
+
+void MapoiPanel::ResumeButton()
+{
+  std_msgs::msg::String msg;
+  msg.data = "mapoi_panel";
+  mapoi_resume_pub_->publish(msg);
+  ui_->NavStatusLabel->setText(QString::fromStdString("再開中..."));
+  RCLCPP_INFO(LOGGER, "Resume requested");
+}
+
 void MapoiPanel::StopButton()
 {
   std_msgs::msg::String msg;
@@ -331,6 +353,8 @@ void MapoiPanel::NavStatusCallback(std_msgs::msg::String::SharedPtr msg)
     } else if (status == "canceled") {
       current_nav_mode_ = "idle";
       ui_->NavStatusLabel->setText(QString::fromStdString("走行キャンセル"));
+    } else if (status == "paused") {
+      ui_->NavStatusLabel->setText(QString::fromStdString("一時停止中"));
     }
   }, Qt::QueuedConnection);
 }

--- a/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
+++ b/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
@@ -87,6 +87,26 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="PauseButton">
+       <property name="text">
+        <string>一時停止</string>
+       </property>
+       <property name="autoDefault">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="ResumeButton">
+       <property name="text">
+        <string>再開</string>
+       </property>
+       <property name="autoDefault">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="StopButton">
        <property name="acceptDrops">
         <bool>false</bool>

--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -34,6 +34,8 @@ public:
   using NavigateToPose = nav2_msgs::action::NavigateToPose;
   using GoalHandleNavigateToPose = rclcpp_action::ClientGoalHandle<NavigateToPose>;
 
+  enum class NavMode { IDLE, GOAL, ROUTE };
+
   explicit MapoiNavServer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
 private:
@@ -46,11 +48,15 @@ private:
 
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr mapoi_route_sub_;
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr mapoi_cancel_sub_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr mapoi_pause_sub_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr mapoi_resume_sub_;
 
   void mapoi_initialpose_poi_cb(const std_msgs::msg::String::SharedPtr msg);
   void mapoi_goal_pose_poi_cb(const std_msgs::msg::String::SharedPtr msg);
   void mapoi_route_cb(const std_msgs::msg::String::SharedPtr msg);
   void mapoi_cancel_cb(const std_msgs::msg::String::SharedPtr msg);
+  void mapoi_pause_cb(const std_msgs::msg::String::SharedPtr msg);
+  void mapoi_resume_cb(const std_msgs::msg::String::SharedPtr msg);
 
   // Service Callbacks
   void on_pois_info_received(rclcpp::Client<mapoi_interfaces::srv::GetPoisInfo>::SharedFuture future);
@@ -74,6 +80,16 @@ private:
   GoalHandleNavigateToPose::SharedPtr current_ntp_goal_handle_;
   rclcpp::Client<mapoi_interfaces::srv::GetPoisInfo>::SharedPtr pois_info_client_;
   rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedPtr route_client_;
+
+  // --- Pause / Resume state ---
+  NavMode nav_mode_ = NavMode::IDLE;
+  bool is_paused_ = false;
+  geometry_msgs::msg::PoseStamped paused_goal_pose_;
+  std::vector<geometry_msgs::msg::PoseStamped> current_route_waypoints_;
+  uint32_t current_waypoint_index_ = 0;
+  std::vector<geometry_msgs::msg::PoseStamped> paused_waypoints_;
+
+  void reset_nav_state();
 
   std::mutex data_mutex_;
   std::vector<mapoi_interfaces::msg::PointOfInterest> pois_list_;

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -31,6 +31,12 @@ MapoiNavServer::MapoiNavServer(const rclcpp::NodeOptions & options)
   mapoi_cancel_sub_ = this->create_subscription<std_msgs::msg::String>(
     "mapoi_cancel", 1, std::bind(&MapoiNavServer::mapoi_cancel_cb, this, std::placeholders::_1));
 
+  // pause / resume subscribers
+  mapoi_pause_sub_ = this->create_subscription<std_msgs::msg::String>(
+    "mapoi_pause", 1, std::bind(&MapoiNavServer::mapoi_pause_cb, this, _1));
+  mapoi_resume_sub_ = this->create_subscription<std_msgs::msg::String>(
+    "mapoi_resume", 1, std::bind(&MapoiNavServer::mapoi_resume_cb, this, _1));
+
   this->action_client_ = rclcpp_action::create_client<FollowWaypoints>(this, "follow_waypoints");
   this->nav_to_pose_client_ = rclcpp_action::create_client<NavigateToPose>(this, "navigate_to_pose");
 
@@ -159,6 +165,10 @@ void MapoiNavServer::mapoi_goal_pose_poi_cb(const std_msgs::msg::String::SharedP
             return;
           }
 
+          paused_goal_pose_ = goal_pose;
+          nav_mode_ = NavMode::GOAL;
+          is_paused_ = false;
+
           auto goal_msg = NavigateToPose::Goal();
           goal_msg.pose = goal_pose;
 
@@ -229,6 +239,11 @@ void MapoiNavServer::on_route_received(rclcpp::Client<mapoi_interfaces::srv::Get
     return;
   }
 
+  current_route_waypoints_ = waypoints;
+  current_waypoint_index_ = 0;
+  nav_mode_ = NavMode::ROUTE;
+  is_paused_ = false;
+
   // Send waypoints to Nav2 with action client
   while(!this->action_client_->wait_for_action_server(1s)) {
         if (!rclcpp::ok()) {
@@ -271,7 +286,7 @@ void MapoiNavServer::feedback_callback(
   GoalHandleFollowWaypoints::SharedPtr,
   const std::shared_ptr<const FollowWaypoints::Feedback> feedback)
 {
-  (void)feedback;
+  current_waypoint_index_ = feedback->current_waypoint;
 }
 
 void MapoiNavServer::result_callback(const GoalHandleFollowWaypoints::WrappedResult & result)
@@ -279,16 +294,23 @@ void MapoiNavServer::result_callback(const GoalHandleFollowWaypoints::WrappedRes
   current_goal_handle_.reset();
   switch (result.code) {
     case rclcpp_action::ResultCode::SUCCEEDED:
+      reset_nav_state();
       publish_nav_status("succeeded");
       RCLCPP_INFO(this->get_logger(), "Navigation SUCCEEDED!");
       break;
     case rclcpp_action::ResultCode::ABORTED:
+      reset_nav_state();
       publish_nav_status("aborted");
       RCLCPP_ERROR(this->get_logger(), "Navigation ABORTED");
       break;
     case rclcpp_action::ResultCode::CANCELED:
-      publish_nav_status("canceled");
-      RCLCPP_WARN(this->get_logger(), "Navigation CANCELED");
+      if (is_paused_) {
+        RCLCPP_INFO(this->get_logger(), "Cancel confirmed (pause triggered). Waiting for resume.");
+      } else {
+        reset_nav_state();
+        publish_nav_status("canceled");
+        RCLCPP_WARN(this->get_logger(), "Navigation CANCELED");
+      }
       break;
     default:
       RCLCPP_ERROR(this->get_logger(), "Unknown result code");
@@ -312,16 +334,23 @@ void MapoiNavServer::ntp_result_callback(const GoalHandleNavigateToPose::Wrapped
   current_ntp_goal_handle_.reset();
   switch (result.code) {
     case rclcpp_action::ResultCode::SUCCEEDED:
+      reset_nav_state();
       publish_nav_status("succeeded");
       RCLCPP_INFO(this->get_logger(), "NavigateToPose SUCCEEDED!");
       break;
     case rclcpp_action::ResultCode::ABORTED:
+      reset_nav_state();
       publish_nav_status("aborted");
       RCLCPP_ERROR(this->get_logger(), "NavigateToPose ABORTED");
       break;
     case rclcpp_action::ResultCode::CANCELED:
-      publish_nav_status("canceled");
-      RCLCPP_WARN(this->get_logger(), "NavigateToPose CANCELED");
+      if (is_paused_) {
+        RCLCPP_INFO(this->get_logger(), "Cancel confirmed (pause triggered). Waiting for resume.");
+      } else {
+        reset_nav_state();
+        publish_nav_status("canceled");
+        RCLCPP_WARN(this->get_logger(), "NavigateToPose CANCELED");
+      }
       break;
     default:
       RCLCPP_ERROR(this->get_logger(), "NavigateToPose unknown result code");
@@ -352,6 +381,115 @@ void MapoiNavServer::mapoi_cancel_cb(const std_msgs::msg::String::SharedPtr msg)
   }
   if (!canceled) {
     RCLCPP_WARN(this->get_logger(), "No active navigation goal to cancel.");
+  }
+  reset_nav_state();
+}
+
+void MapoiNavServer::reset_nav_state()
+{
+  nav_mode_ = NavMode::IDLE;
+  is_paused_ = false;
+  paused_goal_pose_ = geometry_msgs::msg::PoseStamped{};
+  current_route_waypoints_.clear();
+  paused_waypoints_.clear();
+  current_waypoint_index_ = 0;
+}
+
+void MapoiNavServer::mapoi_pause_cb(const std_msgs::msg::String::SharedPtr msg)
+{
+  (void)msg;
+
+  if (is_paused_) {
+    RCLCPP_WARN(this->get_logger(), "Already paused — ignoring mapoi_pause.");
+    return;
+  }
+
+  if (nav_mode_ == NavMode::GOAL && current_ntp_goal_handle_) {
+    RCLCPP_INFO(this->get_logger(), "Pausing NavigateToPose goal.");
+    nav_to_pose_client_->async_cancel_goal(current_ntp_goal_handle_);
+    is_paused_ = true;
+    publish_nav_status("paused");
+
+  } else if (nav_mode_ == NavMode::ROUTE && current_goal_handle_) {
+    uint32_t from = std::min(
+      current_waypoint_index_,
+      static_cast<uint32_t>(current_route_waypoints_.size()));
+    paused_waypoints_ = std::vector<geometry_msgs::msg::PoseStamped>(
+      current_route_waypoints_.begin() + from,
+      current_route_waypoints_.end());
+    RCLCPP_INFO(this->get_logger(),
+      "Pausing FollowWaypoints: saving %zu remaining waypoints (from index %u).",
+      paused_waypoints_.size(), from);
+    action_client_->async_cancel_goal(current_goal_handle_);
+    is_paused_ = true;
+    publish_nav_status("paused");
+
+  } else {
+    RCLCPP_WARN(this->get_logger(), "mapoi_pause received but no active navigation.");
+  }
+}
+
+void MapoiNavServer::mapoi_resume_cb(const std_msgs::msg::String::SharedPtr msg)
+{
+  (void)msg;
+
+  if (!is_paused_) {
+    RCLCPP_WARN(this->get_logger(), "Not paused — ignoring mapoi_resume.");
+    return;
+  }
+  is_paused_ = false;
+
+  if (nav_mode_ == NavMode::GOAL) {
+    if (!nav_to_pose_client_->wait_for_action_server(2s)) {
+      RCLCPP_ERROR(this->get_logger(), "NavigateToPose action server not available for resume.");
+      is_paused_ = true;
+      return;
+    }
+    RCLCPP_INFO(this->get_logger(), "Resuming NavigateToPose goal.");
+
+    auto goal_msg = NavigateToPose::Goal();
+    goal_msg.pose = paused_goal_pose_;
+
+    auto send_goal_options = rclcpp_action::Client<NavigateToPose>::SendGoalOptions();
+    send_goal_options.goal_response_callback =
+      std::bind(&MapoiNavServer::ntp_goal_response_callback, this, _1);
+    send_goal_options.result_callback =
+      std::bind(&MapoiNavServer::ntp_result_callback, this, _1);
+
+    nav_to_pose_client_->async_send_goal(goal_msg, send_goal_options);
+
+  } else if (nav_mode_ == NavMode::ROUTE) {
+    if (paused_waypoints_.empty()) {
+      RCLCPP_ERROR(this->get_logger(), "Cannot resume: no saved waypoints.");
+      return;
+    }
+    if (!action_client_->wait_for_action_server(2s)) {
+      RCLCPP_ERROR(this->get_logger(), "FollowWaypoints action server not available for resume.");
+      is_paused_ = true;
+      return;
+    }
+    current_route_waypoints_ = paused_waypoints_;
+    paused_waypoints_.clear();
+    current_waypoint_index_ = 0;
+
+    RCLCPP_INFO(this->get_logger(),
+      "Resuming FollowWaypoints with %zu remaining waypoints.", current_route_waypoints_.size());
+
+    auto goal_msg = FollowWaypoints::Goal();
+    goal_msg.poses = current_route_waypoints_;
+
+    auto send_goal_options = rclcpp_action::Client<FollowWaypoints>::SendGoalOptions();
+    send_goal_options.goal_response_callback =
+      std::bind(&MapoiNavServer::goal_response_callback, this, _1);
+    send_goal_options.feedback_callback =
+      std::bind(&MapoiNavServer::feedback_callback, this, _1, _2);
+    send_goal_options.result_callback =
+      std::bind(&MapoiNavServer::result_callback, this, _1);
+
+    action_client_->async_send_goal(goal_msg, send_goal_options);
+
+  } else {
+    RCLCPP_WARN(this->get_logger(), "mapoi_resume: inconsistent state (paused but IDLE).");
   }
 }
 

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -48,6 +48,8 @@ class MapoiWebNode(Node):
         self.goal_poi_pub_ = self.create_publisher(String, 'mapoi_goal_pose_poi', 10)
         self.route_pub_ = self.create_publisher(String, 'mapoi_route', 10)
         self.cancel_pub_ = self.create_publisher(String, 'mapoi_cancel', 10)
+        self.pause_pub_  = self.create_publisher(String, 'mapoi_pause',  10)
+        self.resume_pub_ = self.create_publisher(String, 'mapoi_resume', 10)
         self.initialpose_poi_pub_ = self.create_publisher(String, 'mapoi_initialpose_poi', 10)
 
         # TF for robot pose
@@ -341,6 +343,22 @@ class MapoiWebNode(Node):
             node.cancel_pub_.publish(msg)
             node.nav_status_ = 'canceled'
             node.get_logger().info('Nav canceled')
+            return jsonify({'success': True})
+
+        @app.route('/api/nav/pause', methods=['POST'])
+        def api_nav_pause():
+            msg = String()
+            msg.data = 'webui'
+            node.pause_pub_.publish(msg)
+            node.get_logger().info('Nav pause requested')
+            return jsonify({'success': True})
+
+        @app.route('/api/nav/resume', methods=['POST'])
+        def api_nav_resume():
+            msg = String()
+            msg.data = 'webui'
+            node.resume_pub_.publish(msg)
+            node.get_logger().info('Nav resume requested')
             return jsonify({'success': True})
 
         @app.route('/api/nav/status')


### PR DESCRIPTION
## 概要

`mapoi_goal_pose_poi` および `mapoi_route` による走行中に、一時停止・再開できる機能を追加します。

## 背景・動機

既存の `mapoi_cancel` はキャンセル後に再開できなかった。走行を中断して後で同じ地点・同じルートの続きから再開したいユースケースに対応するため本機能を追加。

## 設計方針

Nav2 にはネイティブな pause API がないため、**pause = cancel + 状態保存**、**resume = 保存状態で再ゴール送信** の方式を採用。

### 状態機械

```
IDLE ──[mapoi_goal_pose_poi]──► NAVIGATING_GOAL ──[mapoi_pause]──► PAUSED_GOAL
IDLE ──[mapoi_route]──────────► NAVIGATING_ROUTE ──[mapoi_pause]──► PAUSED_ROUTE
PAUSED_* ──[mapoi_resume]──────────────────────────────────────────► 対応する NAVIGATING_*
任意 ──[mapoi_cancel / succeeded / aborted]──────────────────────────► IDLE
```

## 変更内容

- **mapoi_server**: `mapoi_pause` / `mapoi_resume` トピックを追加。`NavMode` enum と `is_paused_` フラグで状態管理。`feedback_callback` で `current_waypoint_index_` を追跡し、pause 時に残ウェイポイントを保存して resume 時に再送信。pause 起因の CANCELED 結果は result_callback でスキップ。
- **mapoi_rviz_plugins**: RViz パネルに「一時停止」「再開」ボタンを追加。`mapoi_nav_status` の "paused" 表示に対応。
- **mapoi_webui**: `/api/nav/pause` (POST) と `/api/nav/resume` (POST) エンドポイントを追加。

## 動作確認方法

`mapoi_turtlebot3_example` を使用して確認します。

### 1. シミュレーション環境の起動

```bash
export TURTLEBOT3_MODEL=burger
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation_launch.yaml
```

### 2. ルート走行の一時停止・再開テスト

別ターミナルで以下を順に実行します。

```bash
# ルート走行開始（elevator_hall → corridor_a → conference_room）
ros2 topic pub -1 /mapoi_route std_msgs/msg/String "{data: route_2}"

# ステータス確認（"navigating" になること）
ros2 topic echo /mapoi_nav_status --once

# 走行中に一時停止
ros2 topic pub -1 /mapoi_pause std_msgs/msg/String "{data: test}"

# ステータス確認（"paused" になること）
ros2 topic echo /mapoi_nav_status --once

# 再開（中断したウェイポイントから続きを走行）
ros2 topic pub -1 /mapoi_resume std_msgs/msg/String "{data: test}"
```

### 3. 単独ゴールの一時停止・再開テスト

```bash
# conference_room へ走行開始
ros2 topic pub -1 /mapoi_goal_pose_poi std_msgs/msg/String "{data: conference_room}"

# 走行中に一時停止
ros2 topic pub -1 /mapoi_pause std_msgs/msg/String "{data: test}"

# 再開
ros2 topic pub -1 /mapoi_resume std_msgs/msg/String "{data: test}"
```

### 使用するサンプルマップの POI・ルート（turtlebot3_dqn_stage1）

| POI名 | 説明 |
| --- | --- |
| `elevator_hall` | エレベーターホール（初期位置） |
| `meeting_room_a` | 会議室A |
| `conference_room` | 大会議室 |
| `corridor_a` | 廊下 |

| ルート名 | ウェイポイント |
| --- | --- |
| `route_1` | meeting_room_a → conference_room → meeting_room_a |
| `route_2` | elevator_hall → corridor_a → conference_room |

🤖 Generated with [Claude Code](https://claude.com/claude-code)