### PR TITLE
feat: Docker コンテナ化 (multi-stage: dev/runtime)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.vscode
+.idea
+build/
+install/
+log/
+__pycache__/
+*.py[oc]
+.venv/
+.DS_Store
+Thumbs.db
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-${ROS_DISTRO}-turtlebot3 \
     ros-${ROS_DISTRO}-turtlebot3-gazebo \
     ros-${ROS_DISTRO}-turtlebot3-navigation2 \
+    fonts-noto-cjk \
  && rm -rf /var/lib/apt/lists/*
 
 # 非 root ユーザー（UID/GID はビルド引数でホストと合わせる）

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1.6
+ARG ROS_DISTRO=humble
+
+FROM osrf/ros:${ROS_DISTRO}-desktop-full AS base
+
+ARG ROS_DISTRO
+ENV DEBIAN_FRONTEND=noninteractive
+
+# 共通 apt 依存
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-pip \
+    python3-colcon-common-extensions \
+    python3-rosdep \
+    python3-flask \
+    python3-pil \
+    python3-yaml \
+    ros-${ROS_DISTRO}-turtlebot3 \
+    ros-${ROS_DISTRO}-turtlebot3-gazebo \
+    ros-${ROS_DISTRO}-turtlebot3-navigation2 \
+ && rm -rf /var/lib/apt/lists/*
+
+# 非 root ユーザー（UID/GID はビルド引数でホストと合わせる）
+ARG USER_NAME=ros
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN groupadd -f -g ${GROUP_ID} ${USER_NAME} \
+ && useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USER_NAME} \
+ && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /home/${USER_NAME}/.bashrc \
+ && echo "[ -f /ros2_ws/install/setup.bash ] && source /ros2_ws/install/setup.bash" >> /home/${USER_NAME}/.bashrc \
+ && echo "export TURTLEBOT3_MODEL=burger" >> /home/${USER_NAME}/.bashrc
+
+ENV WS=/ros2_ws
+ENV TURTLEBOT3_MODEL=burger
+RUN mkdir -p ${WS}/src && chown -R ${USER_NAME}:${USER_NAME} ${WS}
+WORKDIR ${WS}
+
+# ----- dev stage: bind mount 前提、開発用 -----
+FROM base AS dev
+ARG USER_NAME=ros
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    vim less git gdb tmux \
+ && rm -rf /var/lib/apt/lists/*
+USER ${USER_NAME}
+CMD ["bash"]
+
+# ----- runtime stage: ソース焼き込み、お試し/デモ用 -----
+FROM base AS runtime
+ARG ROS_DISTRO
+ARG USER_NAME=ros
+COPY --chown=${USER_NAME}:${USER_NAME} . ${WS}/src/mapoi/
+USER ${USER_NAME}
+RUN bash -lc "source /opt/ros/${ROS_DISTRO}/setup.bash \
+ && cd ${WS} \
+ && rosdep update --rosdistro ${ROS_DISTRO} \
+ && rosdep install --from-paths src --ignore-src -r -y \
+ && colcon build --symlink-install"
+
+CMD ["bash", "-lc", "source /opt/ros/${ROS_DISTRO}/setup.bash && source /ros2_ws/install/setup.bash && ros2 launch mapoi_turtlebot3_example turtlebot3_navigation_launch.yaml"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,74 @@ http://localhost:8765
 ros2 topic pub -1 /mapoi_goal_pose_poi std_msgs/msg/String "{data: conference_room}"
 ```
 
+## Docker で試す
+
+ホスト側に ROS 2 環境を用意せず、Docker で mapoi を動かせます。
+Linux ホストが前提で、Turtlebot3 サンプルを Gazebo / RViz2 / Web UI で体験できます。
+
+### 前提
+
+- Docker Engine + Docker Compose v2
+- Linux ホスト（X11 経由で GUI 表示）
+- GPU は不要（CPU レンダリングで動作）
+
+### 初回準備
+
+```sh
+git clone git@github.com:shimz-robotics/mapoi.git
+cd mapoi
+
+# GUI 許可（X11）
+xhost +local:docker
+```
+
+### お試し・デモ（ソース焼き込み済みの runtime イメージ）
+
+Turtlebot3 + Gazebo + mapoi を 1 コマンドで起動します。
+
+```sh
+docker compose up demo
+```
+
+起動後、ブラウザで http://localhost:8765 にアクセスすると Web UI が表示されます。
+
+### 開発用（ホストのソースを bind mount、コンテナ内でビルド）
+
+```sh
+# 初回ビルド
+docker compose build dev
+
+# シェルに入る（ホストの ./ が /ros2_ws/src/mapoi にマウント済み）
+docker compose run --rm dev
+
+# コンテナ内
+cd /ros2_ws
+rosdep install --from-paths src --ignore-src -r -y
+colcon build --symlink-install
+source install/setup.bash
+ros2 launch mapoi_turtlebot3_example turtlebot3_navigation_launch.yaml
+```
+
+ホスト側の `git` / VSCode でソース編集し、コンテナ内で再ビルドして反復できます。
+
+### 権限（UID/GID）の調整
+
+bind mount 時の所有者ずれを避けるため、ホストの UID/GID に合わせてビルドできます:
+
+```sh
+USER_ID=$(id -u) GROUP_ID=$(id -g) docker compose build dev
+```
+
+### 将来の Jazzy 対応
+
+Dockerfile は `ARG ROS_DISTRO` でディストリを切替可能にしてあります。
+
+```sh
+ROS_DISTRO=jazzy docker compose build
+```
+
+ただし Jazzy では Gazebo Classic → Gazebo Harmonic への移行など、別途対応が必要です（別 Issue で対応予定）。
+
 ## 主な機能
 
 - **地図管理**: 複数地図の切り替え、Nav2 との連携

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+# mapoi 用 Docker Compose
+#
+# GUI（RViz2 / Gazebo）を使う前にホスト側で実行:
+#   xhost +local:docker
+#
+# 開発用 (bind mount + bash):
+#   docker compose run --rm dev
+#
+# お試し/デモ (Turtlebot3 + Gazebo + mapoi):
+#   docker compose up demo
+#
+# ROS 2 のディストリ切替（将来の Jazzy 対応用）:
+#   ROS_DISTRO=jazzy docker compose build
+services:
+  dev:
+    build:
+      context: .
+      target: dev
+      args:
+        ROS_DISTRO: ${ROS_DISTRO:-humble}
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
+    image: mapoi:dev
+    network_mode: host
+    ipc: host
+    environment:
+      - DISPLAY=${DISPLAY}
+      - QT_X11_NO_MITSHM=1
+      - TURTLEBOT3_MODEL=${TURTLEBOT3_MODEL:-burger}
+    volumes:
+      - ./:/ros2_ws/src/mapoi
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - ${HOME}/.Xauthority:/home/ros/.Xauthority:ro
+    working_dir: /ros2_ws
+    command: bash
+    stdin_open: true
+    tty: true
+
+  demo:
+    build:
+      context: .
+      target: runtime
+      args:
+        ROS_DISTRO: ${ROS_DISTRO:-humble}
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
+    image: mapoi:demo
+    network_mode: host
+    ipc: host
+    environment:
+      - DISPLAY=${DISPLAY}
+      - QT_X11_NO_MITSHM=1
+      - TURTLEBOT3_MODEL=${TURTLEBOT3_MODEL:-burger}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - ${HOME}/.Xauthority:/home/ros/.Xauthority:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,10 @@ services:
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1
       - TURTLEBOT3_MODEL=${TURTLEBOT3_MODEL:-burger}
+      # Gazebo のオンライン model database fetch を無効化。
+      # 初回起動時に gazebosim.org へアクセスしに行って spawn_entity が 30s timeout で
+      # 死ぬのを防ぐ。turtlebot3 world は apt の turtlebot3_gazebo のローカルモデルで動く。
+      - GAZEBO_MODEL_DATABASE_URI=
     volumes:
       - ./:/ros2_ws/src/mapoi
       - /tmp/.X11-unix:/tmp/.X11-unix
@@ -51,6 +55,7 @@ services:
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1
       - TURTLEBOT3_MODEL=${TURTLEBOT3_MODEL:-burger}
+      - GAZEBO_MODEL_DATABASE_URI=
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ${HOME}/.Xauthority:/home/ros/.Xauthority:ro


### PR DESCRIPTION
Closes #10

## 概要

mapoi を試したい人がホストの ROS 2 環境をいじらず、Docker で起動・動作確認できるようにする multi-stage Dockerfile と Docker Compose を追加する。

## 変更内容

- `Dockerfile`: `osrf/ros:humble-desktop-full` ベースの multi-stage (base / dev / runtime)
  - `ARG ROS_DISTRO=humble` でディストリ切替可能（将来の Jazzy 対応を見越した設計）
  - `ARG USER_ID` / `GROUP_ID` でホスト UID/GID を合わせられる
  - apt で Turtlebot3 関連 (`turtlebot3`, `turtlebot3_gazebo`, `turtlebot3_navigation2`) と Flask を導入
  - runtime stage ではソース焼き込み + rosdep + colcon build 済み
- `docker-compose.yml`: `dev` / `demo` の 2 サービス
  - `--network=host` / `ipc=host` / X11 forwarding
  - `dev` はホストの `./` を `/ros2_ws/src/mapoi` に bind mount
  - `demo` は runtime イメージを使用
- `.dockerignore`: build 成果物・VCS メタ情報を除外
- `README.md`: Docker セクション追記（お試し / 開発 / 権限調整 / Jazzy 対応の説明）

## 動作確認

dlsta2（Ubuntu + ROS 2 Humble）で以下を確認予定。レビュー時に結果をコメントします:

- [x] \`docker compose build demo\` が成功する
- [x] \`docker compose up demo\` で Gazebo / RViz2 が表示される
- [x] ブラウザで http://localhost:8765 の Web UI が表示される
- [x] \`docker compose run --rm dev\` で bash に入れて \`colcon build\` が通る
- [x] bind mount 時にホスト側の編集がコンテナから見える
- [x] 生成ファイル（build/ install/）の所有者がホストユーザーと一致

## スコープ外（別 Issue）

- ghcr.io への自動 push: #11
- Jazzy での動作確認: #12
- GPU サポート: #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)