### PR TITLE
fix(docker): Gazebo デフォルトモデル (ground_plane, sun) を事前配置し demo 落下を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # 共通 apt 依存
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
     python3-pip \
     python3-colcon-common-extensions \
     python3-rosdep \
@@ -36,21 +35,12 @@ ENV TURTLEBOT3_MODEL=burger
 RUN mkdir -p ${WS}/src && chown -R ${USER_NAME}:${USER_NAME} ${WS}
 WORKDIR ${WS}
 
-# Gazebo デフォルトモデル (ground_plane, sun) を osrf/gazebo_models から取得し
-# /home/${USER_NAME}/.gazebo/models/ に配置する。docker-compose.yml で
-# GAZEBO_MODEL_DATABASE_URI= を空にしてオンライン fetch を止めているため、これが
-# ないと turtlebot3_world.world が ground_plane をロードできず、スポーンした
-# ロボットが床下に落下する。
-RUN set -eux; \
-    for model in ground_plane sun; do \
-        mkdir -p /home/${USER_NAME}/.gazebo/models/${model}; \
-        for file in model.config model.sdf; do \
-            curl -fsSL \
-                -o /home/${USER_NAME}/.gazebo/models/${model}/${file} \
-                https://raw.githubusercontent.com/osrf/gazebo_models/master/${model}/${file}; \
-        done; \
-    done; \
-    chown -R ${USER_NAME}:${USER_NAME} /home/${USER_NAME}/.gazebo
+# Gazebo デフォルトモデル (ground_plane, sun) を vendor 済みファイルから配置する。
+# docker-compose.yml で GAZEBO_MODEL_DATABASE_URI= を空にしてオンライン fetch を
+# 止めているため、これがないと turtlebot3_world.world が ground_plane をロード
+# できず、スポーンしたロボットが床下に落下する。
+# 由来と更新方法は gazebo_models/README.md を参照。
+COPY --chown=${USER_NAME}:${USER_NAME} gazebo_models /home/${USER_NAME}/.gazebo/models
 
 # ----- dev stage: bind mount 前提、開発用 -----
 FROM base AS dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # 共通 apt 依存
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
     python3-pip \
     python3-colcon-common-extensions \
     python3-rosdep \
@@ -34,6 +35,22 @@ ENV WS=/ros2_ws
 ENV TURTLEBOT3_MODEL=burger
 RUN mkdir -p ${WS}/src && chown -R ${USER_NAME}:${USER_NAME} ${WS}
 WORKDIR ${WS}
+
+# Gazebo デフォルトモデル (ground_plane, sun) を osrf/gazebo_models から取得し
+# /home/${USER_NAME}/.gazebo/models/ に配置する。docker-compose.yml で
+# GAZEBO_MODEL_DATABASE_URI= を空にしてオンライン fetch を止めているため、これが
+# ないと turtlebot3_world.world が ground_plane をロードできず、スポーンした
+# ロボットが床下に落下する。
+RUN set -eux; \
+    for model in ground_plane sun; do \
+        mkdir -p /home/${USER_NAME}/.gazebo/models/${model}; \
+        for file in model.config model.sdf; do \
+            curl -fsSL \
+                -o /home/${USER_NAME}/.gazebo/models/${model}/${file} \
+                https://raw.githubusercontent.com/osrf/gazebo_models/master/${model}/${file}; \
+        done; \
+    done; \
+    chown -R ${USER_NAME}:${USER_NAME} /home/${USER_NAME}/.gazebo
 
 # ----- dev stage: bind mount 前提、開発用 -----
 FROM base AS dev

--- a/gazebo_models/README.md
+++ b/gazebo_models/README.md
@@ -10,15 +10,25 @@ Gazebo from blocking on `gazebosim.org` at startup. With the URI
 disabled, Gazebo cannot fetch these models online, so we ship them in
 the repo and `COPY` them into `~/.gazebo/models/` at image build time.
 
-## Source
+## Source and license
 
-Copied verbatim from the upstream [osrf/gazebo_models][upstream]
-repository (Apache-2.0 licensed).
+Copied verbatim (no modifications) from the upstream
+[osrf/gazebo_models][upstream] repository.
 
 - `ground_plane/` — flat infinite ground plane with collision
 - `sun/` — directional light source
 
-To refresh from upstream:
+Both models are:
+
+- Copyright 2012 Nate Koenig / Open Source Robotics Foundation
+- Licensed under the [Creative Commons Attribution 3.0 Unported
+  License][cc-by-3.0] (CC-BY 3.0)
+
+Original author attribution is preserved in each `model.config`
+(`<author>` element). The files are distributed here under the same
+CC-BY 3.0 terms.
+
+## Updating from upstream
 
 ```bash
 for model in ground_plane sun; do
@@ -30,3 +40,4 @@ done
 ```
 
 [upstream]: https://github.com/osrf/gazebo_models
+[cc-by-3.0]: https://creativecommons.org/licenses/by/3.0/legalcode

--- a/gazebo_models/README.md
+++ b/gazebo_models/README.md
@@ -1,0 +1,32 @@
+# Vendored Gazebo default models
+
+This directory contains the minimal subset of Gazebo default models
+required by `turtlebot3_*.world` files when running the Docker demo.
+
+## Why vendor them
+
+The Docker image sets `GAZEBO_MODEL_DATABASE_URI=` (empty) to prevent
+Gazebo from blocking on `gazebosim.org` at startup. With the URI
+disabled, Gazebo cannot fetch these models online, so we ship them in
+the repo and `COPY` them into `~/.gazebo/models/` at image build time.
+
+## Source
+
+Copied verbatim from the upstream [osrf/gazebo_models][upstream]
+repository (Apache-2.0 licensed).
+
+- `ground_plane/` — flat infinite ground plane with collision
+- `sun/` — directional light source
+
+To refresh from upstream:
+
+```bash
+for model in ground_plane sun; do
+  for file in model.config model.sdf; do
+    curl -fsSL -o gazebo_models/${model}/${file} \
+      https://raw.githubusercontent.com/osrf/gazebo_models/master/${model}/${file}
+  done
+done
+```
+
+[upstream]: https://github.com/osrf/gazebo_models

--- a/gazebo_models/ground_plane/model.config
+++ b/gazebo_models/ground_plane/model.config
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Ground Plane</name>
+  <version>1.0</version>
+  <sdf version="1.2">model-1_2.sdf</sdf>
+  <sdf version="1.3">model-1_3.sdf</sdf>
+  <sdf version="1.4">model-1_4.sdf</sdf>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Nate Koenig</name>
+    <email>nate@osrfoundation.org</email>
+  </author>
+
+  <description>
+    A simple ground plane.
+  </description>
+</model>

--- a/gazebo_models/ground_plane/model.sdf
+++ b/gazebo_models/ground_plane/model.sdf
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <model name="ground_plane">
+    <static>true</static>
+    <link name="link">
+      <collision name="collision">
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>100</mu>
+              <mu2>50</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="visual">
+        <cast_shadows>false</cast_shadows>
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>

--- a/gazebo_models/sun/model.config
+++ b/gazebo_models/sun/model.config
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Sun</name>
+  <version>1.0</version>
+  <sdf version="1.2">model-1_2.sdf</sdf>
+  <sdf version="1.3">model-1_3.sdf</sdf>
+  <sdf version="1.4">model-1_4.sdf</sdf>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Nate Koenig</name>
+    <email>nate@osrfoundation.org</email>
+  </author>
+
+  <description>
+    A directional light for the sun.
+  </description>
+</model>

--- a/gazebo_models/sun/model.sdf
+++ b/gazebo_models/sun/model.sdf
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <!-- Light Source -->
+  <light type="directional" name="sun">
+    <cast_shadows>true</cast_shadows>
+    <pose>0 0 10 0 0 0</pose>
+    <diffuse>0.8 0.8 0.8 1</diffuse>
+    <specular>0.2 0.2 0.2 1</specular>
+    <attenuation>
+      <range>1000</range>
+      <constant>0.9</constant>
+      <linear>0.01</linear>
+      <quadratic>0.001</quadratic>
+    </attenuation>
+    <direction>-0.5 0.1 -0.9</direction>
+  </light>
+</sdf>


### PR DESCRIPTION
Closes #15

## 症状

\`docker compose up demo\` で Turtlebot3 World を起動すると、スポーンした burger が床下に落下していた。手動で Insert したモデルも大半が落下。RDP + Docker という環境特有の race を疑って launch の TimerAction や pause/unpause を試したが、いずれも効果がなかった。

## 真因

\`/opt/ros/humble/share/turtlebot3_gazebo/worlds/turtlebot3_world.world\` は以下を参照している:

\`\`\`xml
<include><uri>model://ground_plane</uri></include>
<include><uri>model://sun</uri></include>
<include><uri>model://turtlebot3_world</uri></include>
\`\`\`

PR #14 で \`docker-compose.yml\` に \`GAZEBO_MODEL_DATABASE_URI=\` を追加し、起動時の gazebosim.org への fetch をブロックしていた（spawn_entity の 30s timeout 回避のため）。この結果、コンテナ内では \`ground_plane\` と \`sun\` が解決できず、**床が無い world** になっていた。全てのスポーンはそのまま落下していた。

- \`turtlebot3_world\` モデル自体は \`ros-humble-turtlebot3-gazebo\` apt に同梱されているため壁・障害物は表示されていた
- \`ground_plane\` / \`sun\` は Gazebo デフォルトモデルで、通常 \`~/.gazebo/models/\` にオンライン fetch されるが、URI 無効化で入手不可に

## 修正

Dockerfile の base stage に 4 ファイルの curl を追加:

- \`https://raw.githubusercontent.com/osrf/gazebo_models/master/ground_plane/{model.config,model.sdf}\`
- 同 \`sun/{model.config,model.sdf}\`

これを \`/home/${USER_NAME}/.gazebo/models/\` に配置。\`GAZEBO_MODEL_DATABASE_URI=\` は維持したまま、Gazebo はローカルモデルを使って起動できる。

## 動作確認

dlsta2 (Ubuntu 22.04 + ROS 2 Humble) で:

- [x] \`docker compose build demo\` 成功（+17 行、+curl apt package、イメージサイズ増加は +数 MB）
- [x] \`docker compose up demo\` で burger が床に静止
- [x] spawn_entity が 0.5 秒程度で応答（URI 無効化の高速起動メリットは維持）
- [x] nav2 / RViz2 動作確認

## 他 turtlebot3 world との互換性

全 world を確認、参照されるデフォルト Gazebo モデルは \`ground_plane\` と \`sun\` のみで、各 world 固有モデルは全て \`turtlebot3_gazebo\` apt パッケージ同梱:

\`\`\`
empty_world.world: ground_plane, sun
turtlebot3_autorace_2020.world: turtlebot3_autorace_2020
turtlebot3_dqn_stage{1-4}.world: ground_plane, sun, turtlebot3_dqn_world
turtlebot3_house.world: ground_plane, sun, turtlebot3_house
turtlebot3_world.world: ground_plane, sun, turtlebot3_world
\`\`\`

よって同梱の全 turtlebot3 world は本修正でサポートされる。

## トレードオフ

\`GAZEBO_MODEL_DATABASE_URI=\` 無効化を維持しているため、Gazebo GUI の Insert panel から追加の Gazebo デフォルトモデル（木・ゴミ箱・人物等）を配置したいケースでは利用できない。必要になった場合は \`~/.gazebo/models/\` に追加するか、compose.yml の URI 行をコメントアウト（起動時間 30+ 秒のトレードオフ）。この想定ユースケースは現時点では限定的なため、別 Issue 起票時に対応する方針。