### PR TITLE
fix(mapoi_server): test_depend の launch_testing_ros2 → launch_testing_ros 誤記を修正

### DIFF
--- a/mapoi_server/package.xml
+++ b/mapoi_server/package.xml
@@ -30,7 +30,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
-  <test_depend>launch_testing_ros2</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Closes #16

## 現象

\`mapoi_server/package.xml:33\` の \`<test_depend>launch_testing_ros2</test_depend>\` は rosdep で解決できず、\`rosdep install\` 時に以下のエラーが出ていた:

\`\`\`
ERROR: the following packages/stacks could not have their rosdep keys resolved
mapoi_server: Cannot locate rosdep definition for [launch_testing_ros2]
\`\`\`

## 原因

パッケージ名の誤記。正しくは末尾 "2" 無しの \`launch_testing_ros\`。

## 修正

\`launch_testing_ros2\` → \`launch_testing_ros\` に変更（1 行）。

## 動作確認

\`\`\`
$ rosdep resolve launch_testing_ros
#apt
ros-humble-launch-testing-ros
\`\`\`

rosdep エラー解消を確認。もともと \`rosdep install -r\` の \`-r\` (continue on error) でスルーされていたため機能影響はなかった（runtime 依存ではなく test_depend のみ）が、警告を解消。