### PR TITLE
feat: ghcr.io への Docker イメージ自動配布 workflow を追加

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,11 +38,14 @@ jobs:
             org.opencontainers.image.description=mapoi - ROS 2 Navigation2 用の地図・POI 管理メタパッケージ (demo image)
             org.opencontainers.image.licenses=MIT
 
+      # push: workflow_dispatch をデフォルトブランチ以外で実行した場合は tags が
+      # 空になるため、その場合は build check のみで push しない。
+      # 通常の push（main / v* tag）と main 上の手動 dispatch では push する。
       - uses: docker/build-push-action@v5
         with:
           context: .
           target: runtime
-          push: true
+          push: ${{ github.event_name != 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,51 @@
+name: Build and push Docker image to ghcr.io
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=humble,enable={{is_default_branch}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{version}}-humble
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=mapoi - ROS 2 Navigation2 用の地図・POI 管理メタパッケージ (demo image)
+            org.opencontainers.image.licenses=MIT
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: runtime
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            ROS_DISTRO=humble

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG ROS_DISTRO=humble
 FROM osrf/ros:${ROS_DISTRO}-desktop-full AS base
 
 ARG ROS_DISTRO
+ENV ROS_DISTRO=${ROS_DISTRO}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # 共通 apt 依存

--- a/README.md
+++ b/README.md
@@ -38,32 +38,55 @@ http://localhost:8765
 ros2 topic pub -1 /mapoi_goal_pose_poi std_msgs/msg/String "{data: conference_room}"
 ```
 
-## Docker で試す
+## Docker で試す（demo）
 
-ホスト側に ROS 2 環境を用意せず、Docker で mapoi を動かせます。
+Docker イメージは **demo / 動作確認用**です。自作ロボットに組み込む場合は
+次節「自分のロボットへの導入方法」を参照してください（将来 apt/rosdep での
+提供を予定しています）。
+
 Linux ホストが前提で、Turtlebot3 サンプルを Gazebo / RViz2 / Web UI で体験できます。
 
 ### 前提
 
-- Docker Engine + Docker Compose v2
+- Docker Engine + Docker Compose v2（ソースからビルドする場合）
 - Linux ホスト（X11 経由で GUI 表示）
 - GPU は不要（CPU レンダリングで動作）
 
-### 初回準備
+### ビルド済みイメージから試す（最速）
+
+ghcr.io に公開されたイメージを pull するだけで起動できます。
+
+```sh
+xhost +local:docker
+docker run --rm -it --network host --ipc host \
+  -e DISPLAY=$DISPLAY \
+  -e GAZEBO_MODEL_DATABASE_URI= \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v $HOME/.Xauthority:/home/ros/.Xauthority:ro \
+  ghcr.io/shimz-robotics/mapoi:latest
+```
+
+起動後、ブラウザで http://localhost:8765 にアクセスすると Web UI が表示されます。
+
+利用可能なタグ:
+
+| タグ | 説明 |
+| --- | --- |
+| `latest` | 推奨版（現状 ROS 2 Humble ベース、随時更新） |
+| `humble` | ROS 2 Humble ベースで pin したい場合 |
+| `vX.Y.Z` | リリースタグ版（primary distro） |
+| `vX.Y.Z-humble` | リリースタグ版の humble ビルド |
+
+中身の ROS 2 バージョンは `docker inspect ghcr.io/shimz-robotics/mapoi:latest | grep ROS_DISTRO` で確認できます。
+
+### ソースから docker compose build（開発者向け）
+
+ローカル変更を含めて試したい場合は、リポジトリを clone して compose でビルドします。
 
 ```sh
 git clone git@github.com:shimz-robotics/mapoi.git
 cd mapoi
-
-# GUI 許可（X11）
 xhost +local:docker
-```
-
-### お試し・デモ（ソース焼き込み済みの runtime イメージ）
-
-Turtlebot3 + Gazebo + mapoi を 1 コマンドで起動します。
-
-```sh
 docker compose up demo
 ```
 
@@ -118,6 +141,9 @@ ROS_DISTRO=jazzy docker compose build
 - **マーカー表示**: RViz2 上での POI 可視化、ハイライト表示、半径表示
 
 ## 自分のロボットへの導入方法
+
+現状は本リポジトリを clone して colcon build で組み込んでください。
+**将来的に apt/rosdep での提供を予定しています**（別 Issue で対応）。
 
 ### 1. 地図ディレクトリの作成
 

--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ ghcr.io に公開されたイメージを pull するだけで起動できます
 xhost +local:docker
 docker run --rm -it --network host --ipc host \
   -e DISPLAY=$DISPLAY \
+  -e QT_X11_NO_MITSHM=1 \
   -e GAZEBO_MODEL_DATABASE_URI= \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
-  -v $HOME/.Xauthority:/home/ros/.Xauthority:ro \
   ghcr.io/shimz-robotics/mapoi:latest
 ```
 
 起動後、ブラウザで http://localhost:8765 にアクセスすると Web UI が表示されます。
+
+X11 接続が拒否される場合は `xhost +local:` を試してください（ローカル unix socket 経由の全接続を許可）。配布イメージ内のユーザーは UID 1000 固定のため、`$HOME/.Xauthority` の bind mount は行わず、X11 アクセス許可は `xhost` に委ねています。
 
 利用可能なタグ:
 


### PR DESCRIPTION
## Summary

- `docker pull` 一発で demo を試せるよう、ghcr.io に Docker イメージを自動配布する GitHub Actions workflow を追加
- Docker イメージの用途は **demo / 動作確認用**に限定。自作ロボットへの組込は colcon build を案内し、将来 apt/rosdep 対応 (別 Issue) で置き換える方針を README に明記
- `Dockerfile` に `ENV ROS_DISTRO=\${ROS_DISTRO}` を追加し、`docker inspect` で distro 確認可能に

## タグ戦略

| タグ | 種類 | トリガー | 用途 |
| --- | --- | --- | --- |
| `latest` | mutable | main push | 推奨版（現状 humble、Jazzy 成熟後に段階的に切替） |
| `humble` | mutable | main push | humble で pin したい場合 |
| `vX.Y.Z` | immutable | `v*` git tag push | リリース版の推奨イメージ |
| `vX.Y.Z-humble` | immutable | `v*` git tag push | リリース版 humble ビルド |

`jazzy` / `vX.Y.Z-jazzy` は Jazzy 対応 PR (#12) で matrix build 化時に追加予定。

## 後続 Issue

- **apt/rosdep 対応**（別 Issue 起票予定）: ROS Index への bloom-release。完了後に README「自分のロボットへの導入方法」節を `apt install ros-humble-mapoi-server` ベースに更新
- **Jazzy 対応 (#12)**: Gazebo Harmonic 対応、docker workflow の matrix build 化、`latest` の primary distro を humble → jazzy に切替（移行期間を設けて事前 announce）

## Test plan

- [ ] GitHub Actions で workflow の syntax check が通る
- [ ] main merge 後、Actions タブで `docker-build.yml` の run が success
- [ ] ghcr.io に `latest` / `humble` タグが生えている
- [ ] dlsta2 で `docker pull ghcr.io/shimz-robotics/mapoi:latest` が成功
- [ ] `docker inspect ghcr.io/shimz-robotics/mapoi:latest | grep ROS_DISTRO` で `humble` が見える
- [ ] `docker run` で Gazebo 起動、turtlebot3 スポーン（床に落ちない）、RViz2 起動
- [ ] http://localhost:8765 で Web UI にアクセスして POI 操作ができる

Close #11