### PR TITLE
chore: package.xml 整備 (v0.1.0 release 前準備)

### DIFF
--- a/mapoi_interfaces/package.xml
+++ b/mapoi_interfaces/package.xml
@@ -6,6 +6,9 @@
   <description>msg and srv files used by mapoi packages</description>
   <maintainer email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</maintainer>
   <license>MIT</license>
+  <url type="repository">https://github.com/shimz-robotics/mapoi</url>
+  <url type="bugtracker">https://github.com/shimz-robotics/mapoi/issues</url>
+  <author email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/mapoi_rviz_plugins/package.xml
+++ b/mapoi_rviz_plugins/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>mapoi_rviz_plugins</name>
-  <version>1.0.0</version>
+  <version>0.1.0</version>
   <description>Rviz2 plugins for mapoi</description>
 
   <author email="kimushun1101@gmail.com">Shunsuke Kimura</author>

--- a/mapoi_rviz_plugins/package.xml
+++ b/mapoi_rviz_plugins/package.xml
@@ -1,11 +1,14 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>mapoi_rviz_plugins</name>
   <version>0.1.0</version>
   <description>Rviz2 plugins for mapoi</description>
-
-  <author email="kimushun1101@gmail.com">Shunsuke Kimura</author>
-  <maintainer email="kimushun1101@gmail.com">Shunsuke Kimura</maintainer>
+  <maintainer email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</maintainer>
   <license>MIT</license>
+  <url type="repository">https://github.com/shimz-robotics/mapoi</url>
+  <url type="bugtracker">https://github.com/shimz-robotics/mapoi/issues</url>
+  <author email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</author>
 
   <depend>ament_cmake_auto</depend>
   <depend>std_srvs</depend>

--- a/mapoi_server/package.xml
+++ b/mapoi_server/package.xml
@@ -4,8 +4,11 @@
   <name>mapoi_server</name>
   <version>0.1.0</version>
   <description>map and poi server</description>
-  <maintainer email="kimushun1101@gmail.com">kimura</maintainer>
+  <maintainer email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</maintainer>
   <license>MIT</license>
+  <url type="repository">https://github.com/shimz-robotics/mapoi</url>
+  <url type="bugtracker">https://github.com/shimz-robotics/mapoi/issues</url>
+  <author email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>ament_cmake_auto</depend>

--- a/mapoi_server/package.xml
+++ b/mapoi_server/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mapoi_server</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>map and poi server</description>
   <maintainer email="kimushun1101@gmail.com">kimura</maintainer>
   <license>MIT</license>

--- a/mapoi_turtlebot3_example/package.xml
+++ b/mapoi_turtlebot3_example/package.xml
@@ -4,8 +4,11 @@
   <name>mapoi_turtlebot3_example</name>
   <version>0.1.0</version>
   <description>TurtleBot3 simulation example for mapoi with sample maps and client nodes</description>
-  <maintainer email="kimushun1101@gmail.com">kimura</maintainer>
+  <maintainer email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</maintainer>
   <license>MIT</license>
+  <url type="repository">https://github.com/shimz-robotics/mapoi</url>
+  <url type="bugtracker">https://github.com/shimz-robotics/mapoi/issues</url>
+  <author email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>ament_cmake_auto</depend>

--- a/mapoi_webui/package.xml
+++ b/mapoi_webui/package.xml
@@ -4,8 +4,11 @@
   <name>mapoi_webui</name>
   <version>0.1.0</version>
   <description>Web UI for mapoi - POI editing, navigation, and robot monitoring</description>
-  <maintainer email="kimushun1101@gmail.com">kimura</maintainer>
+  <maintainer email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</maintainer>
   <license>MIT</license>
+  <url type="repository">https://github.com/shimz-robotics/mapoi</url>
+  <url type="bugtracker">https://github.com/shimz-robotics/mapoi/issues</url>
+  <author email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>

--- a/mapoi_webui/package.xml
+++ b/mapoi_webui/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>mapoi_webui</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>Web UI for mapoi - POI editing, navigation, and robot monitoring</description>
   <maintainer email="kimushun1101@gmail.com">kimura</maintainer>
   <license>MIT</license>


### PR DESCRIPTION
## Summary

- 全 5 パッケージの package.xml メタデータを統一・整備
- `v0.1.0` git tag を打つ前の準備

## 変更内訳

### `<version>` を 0.1.0 に統一（3 pkg）

| パッケージ | 変更前 | 変更後 |
|---|---|---|
| mapoi_server | 0.0.0 | 0.1.0 |
| mapoi_webui | 0.0.0 | 0.1.0 |
| mapoi_rviz_plugins | 1.0.0 | 0.1.0 |

### `<maintainer>` / `<author>` の整備（5 pkg）

- 社内活動として、5 pkg 全て `Shunsuke Kimura <kimura.shunsuke@shimz.co.jp>` に統一
- `<author>` を全 pkg に追加（歴史的原作者として記録）

### `<url>` タグ追加（5 pkg）

```xml
<url type="repository">https://github.com/shimz-robotics/mapoi</url>
<url type="bugtracker">https://github.com/shimz-robotics/mapoi/issues</url>
```

### mapoi_rviz_plugins の format="2" → format="3" 昇格

- 他 4 pkg と揃える（挙動影響なし）
- `<?xml version?>` / `<?xml-model?>` ディレクティブも追加

## 背景

- v0.1.0 git tag / ghcr.io image tag と各 package.xml の version を一致させる
- 後続の apt/rosdep 対応（#20）で bloom-release が package.xml の version/属性情報を deb package に反映するため、事前整備で初回実行を素直に通す

## Test plan

- [ ] ローカル `colcon build` で 5 pkg がエラーなく build
- [ ] 全 package.xml で maintainer / author の email が `kimura.shunsuke@shimz.co.jp` に揃っている
- [ ] mapoi_rviz_plugins が format="3" に昇格

Close #21