### PR TITLE
fix(docker): Jazzy base で UID 1000 衝突 (ubuntu user) を解消

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ARG USER_NAME=ros
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN groupadd -f -g ${GROUP_ID} ${USER_NAME} \
+# Ubuntu 24.04 (Jazzy ベース) には UID 1000 の ubuntu ユーザーが pre-created
+# されており、そのまま useradd -u 1000 すると exit 4 (UID in use) で落ちる。
+# 目的の UID を既存ユーザーが占有していたら削除してから作り直す。
+RUN existing_user="$(getent passwd ${USER_ID} | cut -d: -f1)" \
+ && if [ -n "${existing_user}" ] && [ "${existing_user}" != "${USER_NAME}" ]; then \
+      userdel -r "${existing_user}" 2>/dev/null || userdel "${existing_user}" ; \
+    fi \
+ && existing_group="$(getent group ${GROUP_ID} | cut -d: -f1)" \
+ && if [ -n "${existing_group}" ] && [ "${existing_group}" != "${USER_NAME}" ]; then \
+      groupdel "${existing_group}" 2>/dev/null || true ; \
+    fi \
+ && groupadd -f -g ${GROUP_ID} ${USER_NAME} \
  && useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USER_NAME} \
  && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /home/${USER_NAME}/.bashrc \
  && echo "[ -f /ros2_ws/install/setup.bash ] && source /ros2_ws/install/setup.bash" >> /home/${USER_NAME}/.bashrc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,17 +27,26 @@ ARG USER_ID=1000
 ARG GROUP_ID=1000
 # Ubuntu 24.04 (Jazzy ベース) には UID 1000 の ubuntu ユーザーが pre-created
 # されており、そのまま useradd -u 1000 すると exit 4 (UID in use) で落ちる。
-# 目的の UID を既存ユーザーが占有していたら削除してから作り直す。
-RUN existing_user="$(getent passwd ${USER_ID} | cut -d: -f1)" \
- && if [ -n "${existing_user}" ] && [ "${existing_user}" != "${USER_NAME}" ]; then \
-      userdel -r "${existing_user}" 2>/dev/null || userdel "${existing_user}" ; \
+# 衝突する UID/GID を占有する既存ユーザー・グループを先に削除してから作り直す。
+# GID だけが衝突するケース (e.g. USER_ID=1001, GROUP_ID=1000) でも
+# 既存グループを使っているユーザーを userdel しないと groupdel が失敗し、
+# useradd -g が元の競合グループにぶら下がって primary group の GID が
+# ずれる事故が起きるため、両方を明示的にクリアする。
+RUN existing_user_by_uid="$(getent passwd ${USER_ID} | cut -d: -f1)" \
+ && if [ -n "${existing_user_by_uid}" ] && [ "${existing_user_by_uid}" != "${USER_NAME}" ]; then \
+      userdel -r "${existing_user_by_uid}" 2>/dev/null || userdel "${existing_user_by_uid}" ; \
+    fi \
+ && existing_user_by_gid="$(getent passwd | awk -F: -v g=${GROUP_ID} '$4==g {print $1; exit}')" \
+ && if [ -n "${existing_user_by_gid}" ] && [ "${existing_user_by_gid}" != "${USER_NAME}" ]; then \
+      userdel -r "${existing_user_by_gid}" 2>/dev/null || userdel "${existing_user_by_gid}" ; \
     fi \
  && existing_group="$(getent group ${GROUP_ID} | cut -d: -f1)" \
  && if [ -n "${existing_group}" ] && [ "${existing_group}" != "${USER_NAME}" ]; then \
-      groupdel "${existing_group}" 2>/dev/null || true ; \
+      groupdel "${existing_group}" ; \
     fi \
- && groupadd -f -g ${GROUP_ID} ${USER_NAME} \
+ && groupadd -g ${GROUP_ID} ${USER_NAME} \
  && useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USER_NAME} \
+ && [ "$(getent group ${GROUP_ID} | cut -d: -f1)" = "${USER_NAME}" ] \
  && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /home/${USER_NAME}/.bashrc \
  && echo "[ -f /ros2_ws/install/setup.bash ] && source /ros2_ws/install/setup.bash" >> /home/${USER_NAME}/.bashrc \
  && echo "export TURTLEBOT3_MODEL=burger" >> /home/${USER_NAME}/.bashrc


### PR DESCRIPTION
## Summary

PR #27 で workflow を matrix 化した初回 run の Jazzy 側が \`useradd\` で失敗していた問題の hotfix。Ubuntu 24.04 ベース (Jazzy) には UID 1000 の \`ubuntu\` ユーザーが pre-created されており、Dockerfile のデフォルト \`USER_ID=1000\` で \`useradd\` すると \`exit 4\` (UID in use) になる。

## 失敗していた run

[run 24814779888](https://github.com/shimz-robotics/mapoi/actions/runs/24814779888) の \`build-and-push (jazzy)\` ジョブ:

\`\`\`
ERROR: process "useradd -m -u 1000 -g 1000 -s /bin/bash ros" did not complete successfully: exit code: 4
\`\`\`

## 修正内容

\`useradd\` の前に \`getent\` で指定 UID/GID を占有する既存ユーザー/グループを検出し、あれば \`userdel -r\` / \`groupdel\` してから作り直す。

\`\`\`dockerfile
RUN existing_user="\$(getent passwd \${USER_ID} | cut -d: -f1)" \\
 && if [ -n "\${existing_user}" ] && [ "\${existing_user}" != "\${USER_NAME}" ]; then \\
      userdel -r "\${existing_user}" 2>/dev/null || userdel "\${existing_user}" ; \\
    fi \\
 && existing_group="\$(getent group \${GROUP_ID} | cut -d: -f1)" \\
 && if [ -n "\${existing_group}" ] && [ "\${existing_group}" != "\${USER_NAME}" ]; then \\
      groupdel "\${existing_group}" 2>/dev/null || true ; \\
    fi \\
 && groupadd -f -g \${GROUP_ID} \${USER_NAME} \\
 && useradd -m -u \${USER_ID} -g \${GROUP_ID} -s /bin/bash \${USER_NAME} \\
 && ...
\`\`\`

Humble (Ubuntu 22.04) には pre-created ユーザーが無いので条件分岐は no-op として通る。

## 動作確認

ローカルで \`USER_ID=1000\` を明示して両 distro を build:

- \`docker build --build-arg ROS_DISTRO=jazzy --build-arg USER_ID=1000 --target base\` → success、\`docker run --user ros\` で \`uid=1000(ros)\` 確認
- \`docker build --build-arg ROS_DISTRO=humble --build-arg USER_ID=1000 --target base\` → success（回帰なし）

## Test plan

- [ ] PR merge 後、docker-build.yml の matrix run が humble / jazzy 両方 success
- [ ] \`ghcr.io/shimz-robotics/mapoi:jazzy\` が publish される
- [ ] \`docker pull\` + demo 起動で Nav2 active / Web UI 200