### PR TITLE
feat(docker): NVIDIA GPU 対応を opt-in で追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,35 @@ bind mount 時の所有者ずれを避けるため、ホストの UID/GID に合
 USER_ID=$(id -u) GROUP_ID=$(id -g) docker compose build dev
 ```
 
+### GPU (NVIDIA) で加速する
+
+デフォルトは CPU レンダリング (Mesa llvmpipe) で GPU 非依存ですが、NVIDIA GPU で RViz2 / Gazebo の描画を加速できます。
+
+ホスト要件:
+- NVIDIA ドライバがインストールされている Linux ホスト
+- [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) が設定済み
+
+pull 済みイメージから起動する場合（`--gpus all` を追加）:
+
+```sh
+xhost +local:docker
+docker run --rm -it --network host --ipc host --gpus all \
+  -e DISPLAY=$DISPLAY \
+  -e NVIDIA_DRIVER_CAPABILITIES=all \
+  -e QT_X11_NO_MITSHM=1 \
+  -e GAZEBO_MODEL_DATABASE_URI= \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  ghcr.io/shimz-robotics/mapoi:humble
+```
+
+compose から起動する場合（`docker-compose.gpu.yml` を override で重ねる）:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml up demo
+```
+
+GPU を使わない通常起動は `docker-compose.yml` 単体、`--gpus all` 無しの `docker run` を使ってください（既存手順そのまま）。
+
 ### Jazzy で compose から試す
 
 Dockerfile / docker-compose は `ARG ROS_DISTRO` でディストリを切替可能です。Jazzy (Gazebo Harmonic) でソースビルドする場合:

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -17,7 +17,7 @@ services:
           devices:
             - driver: nvidia
               count: all
-              capabilities: [gpu, graphics, display]
+              capabilities: [gpu]
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
@@ -29,7 +29,7 @@ services:
           devices:
             - driver: nvidia
               count: all
-              capabilities: [gpu, graphics, display]
+              capabilities: [gpu]
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,35 @@
+# NVIDIA GPU 対応 override
+#
+# ホスト要件:
+#   - NVIDIA ドライバがインストールされている Linux ホスト
+#   - nvidia-container-toolkit が設定済み (https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+#
+# 利用方法:
+#   xhost +local:docker
+#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up demo
+#
+# GPU なしで使う場合は docker-compose.yml 単体で起動してください (CPU 経路、デフォルト挙動)
+services:
+  dev:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu, graphics, display]
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all
+
+  demo:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu, graphics, display]
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all


### PR DESCRIPTION
## Summary

RViz2 / Gazebo のレンダリングを NVIDIA GPU で加速できるようにする。デフォルトは CPU レンダリング (Mesa llvmpipe) のまま、GPU 非依存要件 (#10) は維持。既存の docker-compose.yml / Dockerfile / ghcr.io 配布 image はすべて変更なし。GPU を使いたいユーザーだけが明示 opt-in する設計。

## 追加ファイル

**\`docker-compose.gpu.yml\`** (override 専用):

- \`deploy.resources.reservations.devices\` で NVIDIA GPU を reserve
- \`NVIDIA_VISIBLE_DEVICES=all\` / \`NVIDIA_DRIVER_CAPABILITIES=all\` を env に追加
- dev / demo の両 service に同じ設定を適用

使い方:
\`\`\`sh
docker compose -f docker-compose.yml -f docker-compose.gpu.yml up demo
\`\`\`

## README 追記

Docker 節に「GPU (NVIDIA) で加速する」セクションを追加:
- ホスト要件 (NVIDIA ドライバ + nvidia-container-toolkit のリンク)
- pull 済みイメージからの \`docker run --gpus all\` パターン
- compose override パターン
- 「GPU を使わない通常起動は既存手順そのまま」と明記

## 利用方式（A: 明示 opt-in）

業界標準の明示 opt-in 方式を採用。自動検知 (entrypoint / wrapper script) は以下の理由で見送り:
- エントリポイント自動検知は \`--gpus all\` を事前に渡す必要があり実質「自動」にならない
- wrapper script は docker コマンドを隠して失敗時の切り分けを難しくし、他プロジェクトで身につけた知識 (\`--gpus all\`) を活かせない

## 動作確認

- \`docker run --gpus all -e NVIDIA_DRIVER_CAPABILITIES=all ghcr.io/shimz-robotics/mapoi:humble nvidia-smi\` → container 内で GPU (NVIDIA driver 580) を認識確認
- \`docker compose -f docker-compose.yml -f docker-compose.gpu.yml config\` → \`deploy.resources.reservations.devices\` が demo service に正しくマージされることを確認
- GPU 無し手順 (既存): ghcr.io 配布 image / Dockerfile / 既存 docker-compose.yml はすべて変更なし、既存の pull & run 手順に regression なし

## Test plan

- [ ] docker compose -f docker-compose.yml -f docker-compose.gpu.yml up demo で Gazebo / RViz2 が起動し GPU 加速が効く
- [ ] docker compose up demo (既存手順) で CPU 経路のまま動作 (回帰なし)
- [ ] docker run ghcr.io/shimz-robotics/mapoi:humble (GPU フラグなし) が CPU 経路で動作 (回帰なし)

Close #13