### PR TITLE
fix(webui): shutdown 時の二重 rclpy.shutdown() で RCLError を吐く問題を解消 (#36)

### DIFF
--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -392,7 +392,12 @@ def main(args=None):
         pass
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+        # launch 経由 SIGINT の場合、rclpy context は既に shutdown 済みで
+        # 二重呼び出しになると RCLError を吐くため吸収する。
+        try:
+            rclpy.shutdown()
+        except Exception:
+            pass
 
 
 if __name__ == '__main__':

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -392,12 +392,10 @@ def main(args=None):
         pass
     finally:
         node.destroy_node()
-        # launch 経由 SIGINT の場合、rclpy context は既に shutdown 済みで
-        # 二重呼び出しになると RCLError を吐くため吸収する。
-        try:
-            rclpy.shutdown()
-        except Exception:
-            pass
+        # launch 経由 SIGINT では rclpy context が既に shutdown 済みの場合があり、
+        # rclpy.shutdown() を直接呼ぶと RCLError になる。try_shutdown() は
+        # 状態確認と shutdown を 1 つの API に閉じ込めてある。
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 概要

`mapoi_webui_node.py` の `main()` 終了時に二重 `rclpy.shutdown()` で `RCLError` (exit code 1) になる問題を修正。issue #36。

## 原因

launch 経由で SIGINT を受けた場合、`rclpy` の context は launch ライフサイクル側で既に shutdown されている。その状態で `main()` の `finally` 節の `rclpy.shutdown()` を呼ぶと:

```
rclpy._rclpy_pybind11.RCLError: failed to shutdown:
  rcl_shutdown already called on the given context, at ./src/rcl/init.c:241
```

で exit code 1 になり、launch ログに `process has died [exit code 1]` として残る (CI で誤検知のノイズ源)。

## 変更

`mapoi_webui/mapoi_webui/mapoi_webui_node.py:395` の `rclpy.shutdown()` を try/except でラップし、既に shutdown 済みの場合は無視する。

## 動作確認

既存の launch 動作 (PR #41 の動作確認時) で必ず observable なので、マージ後の次回 launch 終了時に `RCLError` のトレースバックが出なくなることで確認できます。

Close #36
