### PR TITLE
feat(turtlebot3_example): mapoi_sim_bridge で SwitchMap の Gazebo 連動 (#30)

### DIFF
--- a/mapoi_turtlebot3_example/CMakeLists.txt
+++ b/mapoi_turtlebot3_example/CMakeLists.txt
@@ -2,7 +2,11 @@ cmake_minimum_required(VERSION 3.8)
 project(mapoi_turtlebot3_example)
 
 find_package(ament_cmake_auto REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 ament_auto_find_build_dependencies()
+
+# Python サブパッケージ (sim_bridge)
+ament_python_install_package(${PROJECT_NAME})
 
 ament_auto_add_executable(get_maps_info_client
   src/get_maps_info_client.cpp
@@ -29,8 +33,14 @@ ament_auto_add_executable(follow_waypoints_client
 )
 
 
+install(PROGRAMS
+  ${PROJECT_NAME}/sim_bridge.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 install(
   DIRECTORY
+    config
     launch
     maps
     param

--- a/mapoi_turtlebot3_example/config/sim_bridge.yaml
+++ b/mapoi_turtlebot3_example/config/sim_bridge.yaml
@@ -1,0 +1,15 @@
+# mapoi_sim_bridge の parameter
+# map_name → Gazebo entity (model URI と scene 内 entity 名) のマッピング
+mapoi_sim_bridge:
+  ros__parameters:
+    map_obstacle_table_yaml: |
+      turtlebot3_world:
+        uri: model://turtlebot3_world
+        name: turtlebot3_world
+      turtlebot3_dqn_stage1:
+        uri: model://turtlebot3_dqn_world
+        name: turtlebot3_dqn_world
+    robot_entity_name: burger
+    # ロボット re-spawn 用 SDF パス (set_entity_state が humble + Classic で
+    # 実用上動かないため、teleport の代わりに delete + spawn する)
+    robot_sdf_path: /opt/ros/humble/share/turtlebot3_gazebo/models/turtlebot3_burger/model.sdf

--- a/mapoi_turtlebot3_example/config/sim_bridge.yaml
+++ b/mapoi_turtlebot3_example/config/sim_bridge.yaml
@@ -10,6 +10,9 @@ mapoi_sim_bridge:
         uri: model://turtlebot3_dqn_world
         name: turtlebot3_dqn_world
     robot_entity_name: burger
-    # ロボット re-spawn 用 SDF パス (set_entity_state が humble + Classic で
-    # 実用上動かないため、teleport の代わりに delete + spawn する)
-    robot_sdf_path: /opt/ros/humble/share/turtlebot3_gazebo/models/turtlebot3_burger/model.sdf
+    # ロボット re-spawn 用 SDF パス。
+    # ROS params yaml は launch substitution を評価しないため、ここでは default を
+    # 置かず、turtlebot3_navigation.launch.yaml から
+    #   $(find-pkg-share turtlebot3_gazebo)/models/turtlebot3_$(env TURTLEBOT3_MODEL)/model.sdf
+    # を渡す (空文字なら sim_bridge は respawn を skip)。
+    robot_sdf_path: ""

--- a/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
@@ -62,14 +62,17 @@ launch:
     if: $(var rviz)
 
 
-# mapoi_sim_bridge: SwitchMap 時に Gazebo の障害物 entity を入れ替え + ロボット teleport
-# (Gazebo 本体は再起動せず、/clock /tf /odom 等の継続性を保つ)
+# mapoi_sim_bridge: SwitchMap 時に Gazebo の障害物 entity を入れ替え + ロボット再生成
+# (Gazebo 本体は再起動せず、/clock /tf /odom 等の継続性を保つ)。
+# 現状 Humble (Gazebo Classic) 専用。Jazzy (gz-sim) 対応は #42 で別途。
 - node:
     pkg: mapoi_turtlebot3_example
     exec: sim_bridge.py
     output: "screen"
     param:
       - from: "$(find-pkg-share mapoi_turtlebot3_example)/config/sim_bridge.yaml"
+      - {name: robot_sdf_path, value: "$(find-pkg-share turtlebot3_gazebo)/models/turtlebot3_$(env TURTLEBOT3_MODEL)/model.sdf"}
+    if: $(eval "'$(env ROS_DISTRO)' == 'humble'")
 
 # Mapoi core (mapoi_server / mapoi_nav_server / mapoi_rviz2_publisher)
 - include:

--- a/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
@@ -62,6 +62,15 @@ launch:
     if: $(var rviz)
 
 
+# mapoi_sim_bridge: SwitchMap 時に Gazebo の障害物 entity を入れ替え + ロボット teleport
+# (Gazebo 本体は再起動せず、/clock /tf /odom 等の継続性を保つ)
+- node:
+    pkg: mapoi_turtlebot3_example
+    exec: sim_bridge.py
+    output: "screen"
+    param:
+      - from: "$(find-pkg-share mapoi_turtlebot3_example)/config/sim_bridge.yaml"
+
 # Mapoi core (mapoi_server / mapoi_nav_server / mapoi_rviz2_publisher)
 - include:
     file: "$(find-pkg-share mapoi_server)/launch/mapoi_core.launch.yaml"

--- a/mapoi_turtlebot3_example/mapoi_turtlebot3_example/sim_bridge.py
+++ b/mapoi_turtlebot3_example/mapoi_turtlebot3_example/sim_bridge.py
@@ -15,10 +15,20 @@ ros_gz_interfaces 系の service 名・型に切り替える必要があり、#4
 を使うのが筋だが、Humble + Gazebo Classic では plugin の launch arg load が
 upstream の既知問題で client から呼べない (gazebo_ros_pkgs issue #1526, #1157,
 upstream archived 2025-07)。delete + spawn で代替する。
+
+並列性の扱い: subscribe callback (`_on_config_path`) は受信した msg を queue に
+push するだけで即 return し、別 thread の worker が queue から逐次取り出して
+service call を含む処理を行う。これにより:
+- 連続 switch_map での state 崩れを防ぐ (queue が直列化、lock 不要)
+- callback 内で `spin_until_future_complete` を呼ぶことに伴う ROS 2 executor の
+  ネスト spin 問題を回避 (worker は executor 外の thread で `Future.add_done_callback`
+  + `threading.Event.wait` で結果を待つ)
 """
 
 import math
 import os
+import queue
+import threading
 
 import rclpy
 import yaml
@@ -43,21 +53,29 @@ class MapoiSimBridge(Node):
         self._robot_sdf_path = self.get_parameter(
             'robot_sdf_path').get_parameter_value().string_value
 
-        # 内部状態
+        # 内部状態 (worker thread のみが触る、callback thread は queue.put のみ)
         self._current_map_name = None
         self._current_obstacle_name = None
         self._current_config_path = None
 
-        # 同 callback 内から service call 完了を待つため Reentrant + MultiThreaded
+        # service client は ReentrantCallbackGroup (worker から call_async すれば
+        # done callback は executor の別 thread で呼ばれる)
         self._cb_group = ReentrantCallbackGroup()
         self._spawn_cli = self.create_client(
             SpawnEntity, 'spawn_entity', callback_group=self._cb_group)
         self._delete_cli = self.create_client(
             DeleteEntity, 'delete_entity', callback_group=self._cb_group)
 
+        # subscribe callback は queue に push するだけ
+        self._work_queue = queue.Queue()
         self._config_path_sub = self.create_subscription(
             String, 'mapoi_config_path', self._on_config_path, 10,
             callback_group=self._cb_group)
+
+        # worker thread (queue を直列消費)
+        self._worker_stop = threading.Event()
+        self._worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self._worker.start()
 
         self.get_logger().info(
             f'mapoi_sim_bridge initialized: robot={self._robot_name}, '
@@ -78,6 +96,22 @@ class MapoiSimBridge(Node):
             return {}
 
     def _on_config_path(self, msg):
+        # 軽量。queue に push して即 return。state 操作と service call は worker。
+        self._work_queue.put(msg)
+
+    def _worker_loop(self):
+        while not self._worker_stop.is_set():
+            try:
+                msg = self._work_queue.get(timeout=1.0)
+            except queue.Empty:
+                continue
+            try:
+                self._process_config_path(msg)
+            except Exception as e:
+                self.get_logger().error(
+                    f'sim_bridge worker exception: {e}', exc_info=True)
+
+    def _process_config_path(self, msg):
         path = msg.data
         if path == self._current_config_path:
             return
@@ -146,20 +180,36 @@ class MapoiSimBridge(Node):
 
         self._respawn_robot(x, y, yaw)
 
+    def _call_blocking(self, client, req, timeout_sec=10.0):
+        """worker thread から service を blocking call。
+
+        executor の他 thread が future を resolve する前提なので、Multi+Reentrant
+        が必要。`spin_until_future_complete` を使わず done_callback + Event.wait
+        で待つので、callback thread のネスト spin にならない。
+        """
+        future = client.call_async(req)
+        done_event = threading.Event()
+        future.add_done_callback(lambda _f: done_event.set())
+        if done_event.wait(timeout=timeout_sec):
+            try:
+                return future.result()
+            except Exception as e:
+                self.get_logger().warn(f'service call raised: {e}')
+                return None
+        return None
+
     def _delete_entity(self, name):
         if not self._delete_cli.wait_for_service(timeout_sec=10.0):
             self.get_logger().warn('delete_entity service not available')
             return
         req = DeleteEntity.Request()
         req.name = name
-        future = self._delete_cli.call_async(req)
-        rclpy.spin_until_future_complete(self, future, timeout_sec=5.0)
-        if future.done() and future.result() is not None:
-            res = future.result()
+        res = self._call_blocking(self._delete_cli, req, timeout_sec=5.0)
+        if res is None:
+            self.get_logger().warn(f'delete_entity({name}) timed out')
+        else:
             self.get_logger().info(
                 f'delete_entity({name}): success={res.success}')
-        else:
-            self.get_logger().warn(f'delete_entity({name}) timed out')
 
     def _spawn_entity_from_uri(self, name, uri):
         if not self._spawn_cli.wait_for_service(timeout_sec=10.0):
@@ -174,14 +224,12 @@ class MapoiSimBridge(Node):
         req = SpawnEntity.Request()
         req.name = name
         req.xml = sdf
-        future = self._spawn_cli.call_async(req)
-        rclpy.spin_until_future_complete(self, future, timeout_sec=10.0)
-        if future.done() and future.result() is not None:
-            res = future.result()
+        res = self._call_blocking(self._spawn_cli, req, timeout_sec=10.0)
+        if res is None:
+            self.get_logger().warn(f'spawn_entity({name}) timed out')
+        else:
             self.get_logger().info(
                 f'spawn_entity({name}, {uri}): success={res.success}')
-        else:
-            self.get_logger().warn(f'spawn_entity({name}) timed out')
 
     def _respawn_robot(self, x, y, yaw):
         """ロボットを delete + spawn で新位置に再生成。
@@ -189,26 +237,35 @@ class MapoiSimBridge(Node):
         set_entity_state の代替 (上記 NOTE 参照)。/odom の連続性は失われ、AMCL は
         再 collapse が必要だが、本 PoC のスコープでは許容 (PR #32 の auto initial_pose
         publish が補正する想定)。
-        """
-        # 既存 robot を delete
-        self._delete_entity(self._robot_name)
 
+        preflight (SDF 存在 + spawn service ready + SDF 読込) を delete より先に
+        やる。これにより spawn 不能なときに robot を消したまま復旧不能、を避ける。
+        """
+        # 1. preflight: 失敗するなら delete もしない
         if not self._robot_sdf_path:
             self.get_logger().warn(
-                'robot_sdf_path parameter is empty; skipping robot respawn')
+                'robot_sdf_path parameter is empty; skipping respawn (robot stays at old pose)')
             return
         if not os.path.exists(self._robot_sdf_path):
             self.get_logger().error(
-                f'robot_sdf_path not found: {self._robot_sdf_path}')
+                f'robot_sdf_path not found: {self._robot_sdf_path}; skipping respawn')
             return
-        with open(self._robot_sdf_path, 'r') as f:
-            sdf = f.read()
-
         if not self._spawn_cli.wait_for_service(timeout_sec=10.0):
             self.get_logger().warn(
-                'spawn_entity service not available for robot respawn')
+                'spawn_entity service not available; skipping respawn (robot stays at old pose)')
+            return
+        try:
+            with open(self._robot_sdf_path, 'r') as f:
+                sdf = f.read()
+        except Exception as e:
+            self.get_logger().error(
+                f'Failed to read robot SDF ({self._robot_sdf_path}): {e}; skipping respawn')
             return
 
+        # 2. delete (preflight 通過後にのみ実行)
+        self._delete_entity(self._robot_name)
+
+        # 3. spawn
         req = SpawnEntity.Request()
         req.name = self._robot_name
         req.xml = sdf
@@ -217,17 +274,14 @@ class MapoiSimBridge(Node):
         req.initial_pose.position.z = 0.01
         req.initial_pose.orientation.z = math.sin(yaw / 2.0)
         req.initial_pose.orientation.w = math.cos(yaw / 2.0)
-
-        future = self._spawn_cli.call_async(req)
-        rclpy.spin_until_future_complete(self, future, timeout_sec=10.0)
-        if future.done() and future.result() is not None:
-            res = future.result()
+        res = self._call_blocking(self._spawn_cli, req, timeout_sec=10.0)
+        if res is None:
+            self.get_logger().warn(
+                f'respawn_robot({self._robot_name}) timed out (robot may be deleted)')
+        else:
             self.get_logger().info(
                 f'respawn_robot({self._robot_name}, {x:.2f}, {y:.2f}, yaw={yaw:.2f}): '
                 f'success={res.success}')
-        else:
-            self.get_logger().warn(
-                f'respawn_robot({self._robot_name}) timed out')
 
 
 def main(args=None):
@@ -240,6 +294,8 @@ def main(args=None):
     except KeyboardInterrupt:
         pass
     finally:
+        node._worker_stop.set()
+        node._worker.join(timeout=2.0)
         executor.shutdown()
         node.destroy_node()
         rclpy.try_shutdown()

--- a/mapoi_turtlebot3_example/mapoi_turtlebot3_example/sim_bridge.py
+++ b/mapoi_turtlebot3_example/mapoi_turtlebot3_example/sim_bridge.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""mapoi_sim_bridge: Gazebo (Classic) entity replacement on map switch.
+
+mapoi_config_path topic を購読し、map_name 変化を検知すると
+- 旧マップの障害物 entity を /delete_entity で削除
+- 新マップの障害物 entity を /spawn_entity で生成 (model://... URI で)
+- ロボット (burger) も /delete_entity + /spawn_entity で initial_pose POI 座標に再生成
+する。Gazebo 本体は無停止で /clock, /tf, /odom, /scan の継続性を保つ。
+
+NOTE: 現状 Humble (Gazebo Classic) 専用。Jazzy (gz-sim) 対応は
+ros_gz_interfaces 系の service 名・型に切り替える必要があり、#42 と統合した
+別 PR で対応予定。
+
+設計メモ: ロボット teleport には本来 /set_entity_state (gazebo_ros_state plugin)
+を使うのが筋だが、Humble + Gazebo Classic では plugin の launch arg load が
+upstream の既知問題で client から呼べない (gazebo_ros_pkgs issue #1526, #1157,
+upstream archived 2025-07)。delete + spawn で代替する。
+"""
+
+import math
+import os
+
+import rclpy
+import yaml
+from gazebo_msgs.srv import DeleteEntity, SpawnEntity
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from std_msgs.msg import String
+
+
+class MapoiSimBridge(Node):
+    def __init__(self):
+        super().__init__('mapoi_sim_bridge')
+
+        self.declare_parameter('map_obstacle_table_yaml', '')
+        self.declare_parameter('robot_entity_name', 'burger')
+        self.declare_parameter('robot_sdf_path', '')
+
+        self._table = self._load_table()
+        self._robot_name = self.get_parameter(
+            'robot_entity_name').get_parameter_value().string_value
+        self._robot_sdf_path = self.get_parameter(
+            'robot_sdf_path').get_parameter_value().string_value
+
+        # 内部状態
+        self._current_map_name = None
+        self._current_obstacle_name = None
+        self._current_config_path = None
+
+        # 同 callback 内から service call 完了を待つため Reentrant + MultiThreaded
+        self._cb_group = ReentrantCallbackGroup()
+        self._spawn_cli = self.create_client(
+            SpawnEntity, 'spawn_entity', callback_group=self._cb_group)
+        self._delete_cli = self.create_client(
+            DeleteEntity, 'delete_entity', callback_group=self._cb_group)
+
+        self._config_path_sub = self.create_subscription(
+            String, 'mapoi_config_path', self._on_config_path, 10,
+            callback_group=self._cb_group)
+
+        self.get_logger().info(
+            f'mapoi_sim_bridge initialized: robot={self._robot_name}, '
+            f'maps={list(self._table.keys())}')
+
+    def _load_table(self):
+        param = self.get_parameter(
+            'map_obstacle_table_yaml').get_parameter_value().string_value
+        if not param:
+            self.get_logger().warn(
+                'map_obstacle_table_yaml is empty; sim bridge will skip swaps')
+            return {}
+        try:
+            return yaml.safe_load(param) or {}
+        except Exception as e:
+            self.get_logger().error(
+                f'Failed to parse map_obstacle_table_yaml: {e}')
+            return {}
+
+    def _on_config_path(self, msg):
+        path = msg.data
+        if path == self._current_config_path:
+            return
+        self._current_config_path = path
+
+        # path の構造: <maps_path>/<map_name>/<config_file>
+        map_name = os.path.basename(os.path.dirname(path))
+        self.get_logger().info(f'config_path changed → map_name={map_name}')
+
+        if map_name == self._current_map_name:
+            return
+
+        prev_map_name = self._current_map_name
+        self._current_map_name = map_name
+
+        if prev_map_name is None:
+            # 起動時の最初の通知: launch がすでに対応する world で起動済みと仮定し、
+            # 内部状態のみ更新。entity 入れ替えはしない。
+            entry = self._table.get(map_name)
+            if entry:
+                self._current_obstacle_name = entry.get('name')
+            self.get_logger().info(
+                f'Initial map={map_name}; assuming Gazebo already loaded matching world')
+            return
+
+        x, y, yaw = self._extract_initial_pose(path)
+        self._switch_world(prev_map_name, map_name, x, y, yaw)
+
+    def _extract_initial_pose(self, config_path):
+        """mapoi_config.yaml から initial_pose タグ POI の座標を取得。
+
+        見つからなければ (0, 0, 0) を返す。
+        """
+        try:
+            with open(config_path, 'r') as f:
+                cfg = yaml.safe_load(f) or {}
+        except Exception as e:
+            self.get_logger().error(f'Failed to read {config_path}: {e}')
+            return 0.0, 0.0, 0.0
+        for poi in cfg.get('poi', []) or []:
+            if 'initial_pose' in (poi.get('tags') or []):
+                pose = poi.get('pose', {})
+                return (
+                    float(pose.get('x', 0.0)),
+                    float(pose.get('y', 0.0)),
+                    float(pose.get('yaw', 0.0)),
+                )
+        self.get_logger().warn(
+            f'No initial_pose POI in {config_path}; using (0, 0, 0)')
+        return 0.0, 0.0, 0.0
+
+    def _switch_world(self, prev_map, new_map, x, y, yaw):
+        prev_entry = self._table.get(prev_map)
+        new_entry = self._table.get(new_map)
+
+        if prev_entry and self._current_obstacle_name:
+            self._delete_entity(self._current_obstacle_name)
+            self._current_obstacle_name = None
+
+        if new_entry:
+            self._spawn_entity_from_uri(new_entry['name'], new_entry['uri'])
+            self._current_obstacle_name = new_entry['name']
+        else:
+            self.get_logger().warn(
+                f"No map_obstacle_table entry for '{new_map}'; obstacle not spawned")
+
+        self._respawn_robot(x, y, yaw)
+
+    def _delete_entity(self, name):
+        if not self._delete_cli.wait_for_service(timeout_sec=10.0):
+            self.get_logger().warn('delete_entity service not available')
+            return
+        req = DeleteEntity.Request()
+        req.name = name
+        future = self._delete_cli.call_async(req)
+        rclpy.spin_until_future_complete(self, future, timeout_sec=5.0)
+        if future.done() and future.result() is not None:
+            res = future.result()
+            self.get_logger().info(
+                f'delete_entity({name}): success={res.success}')
+        else:
+            self.get_logger().warn(f'delete_entity({name}) timed out')
+
+    def _spawn_entity_from_uri(self, name, uri):
+        if not self._spawn_cli.wait_for_service(timeout_sec=10.0):
+            self.get_logger().warn('spawn_entity service not available')
+            return
+        sdf = (
+            '<?xml version="1.0"?>'
+            '<sdf version="1.6"><world name="default">'
+            f'<include><uri>{uri}</uri></include>'
+            '</world></sdf>'
+        )
+        req = SpawnEntity.Request()
+        req.name = name
+        req.xml = sdf
+        future = self._spawn_cli.call_async(req)
+        rclpy.spin_until_future_complete(self, future, timeout_sec=10.0)
+        if future.done() and future.result() is not None:
+            res = future.result()
+            self.get_logger().info(
+                f'spawn_entity({name}, {uri}): success={res.success}')
+        else:
+            self.get_logger().warn(f'spawn_entity({name}) timed out')
+
+    def _respawn_robot(self, x, y, yaw):
+        """ロボットを delete + spawn で新位置に再生成。
+
+        set_entity_state の代替 (上記 NOTE 参照)。/odom の連続性は失われ、AMCL は
+        再 collapse が必要だが、本 PoC のスコープでは許容 (PR #32 の auto initial_pose
+        publish が補正する想定)。
+        """
+        # 既存 robot を delete
+        self._delete_entity(self._robot_name)
+
+        if not self._robot_sdf_path:
+            self.get_logger().warn(
+                'robot_sdf_path parameter is empty; skipping robot respawn')
+            return
+        if not os.path.exists(self._robot_sdf_path):
+            self.get_logger().error(
+                f'robot_sdf_path not found: {self._robot_sdf_path}')
+            return
+        with open(self._robot_sdf_path, 'r') as f:
+            sdf = f.read()
+
+        if not self._spawn_cli.wait_for_service(timeout_sec=10.0):
+            self.get_logger().warn(
+                'spawn_entity service not available for robot respawn')
+            return
+
+        req = SpawnEntity.Request()
+        req.name = self._robot_name
+        req.xml = sdf
+        req.initial_pose.position.x = x
+        req.initial_pose.position.y = y
+        req.initial_pose.position.z = 0.01
+        req.initial_pose.orientation.z = math.sin(yaw / 2.0)
+        req.initial_pose.orientation.w = math.cos(yaw / 2.0)
+
+        future = self._spawn_cli.call_async(req)
+        rclpy.spin_until_future_complete(self, future, timeout_sec=10.0)
+        if future.done() and future.result() is not None:
+            res = future.result()
+            self.get_logger().info(
+                f'respawn_robot({self._robot_name}, {x:.2f}, {y:.2f}, yaw={yaw:.2f}): '
+                f'success={res.success}')
+        else:
+            self.get_logger().warn(
+                f'respawn_robot({self._robot_name}) timed out')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = MapoiSimBridge()
+    executor = MultiThreadedExecutor()
+    executor.add_node(node)
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        executor.shutdown()
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/mapoi_turtlebot3_example/mapoi_turtlebot3_example/sim_bridge.py
+++ b/mapoi_turtlebot3_example/mapoi_turtlebot3_example/sim_bridge.py
@@ -115,17 +115,17 @@ class MapoiSimBridge(Node):
         path = msg.data
         if path == self._current_config_path:
             return
-        self._current_config_path = path
 
         # path の構造: <maps_path>/<map_name>/<config_file>
         map_name = os.path.basename(os.path.dirname(path))
         self.get_logger().info(f'config_path changed → map_name={map_name}')
 
         if map_name == self._current_map_name:
+            # path だけ変わって map_name は同じ (mapoi_server の周期 re-publish 等)
+            self._current_config_path = path
             return
 
         prev_map_name = self._current_map_name
-        self._current_map_name = map_name
 
         if prev_map_name is None:
             # 起動時の最初の通知: launch がすでに対応する world で起動済みと仮定し、
@@ -133,12 +133,22 @@ class MapoiSimBridge(Node):
             entry = self._table.get(map_name)
             if entry:
                 self._current_obstacle_name = entry.get('name')
+            self._current_map_name = map_name
+            self._current_config_path = path
             self.get_logger().info(
                 f'Initial map={map_name}; assuming Gazebo already loaded matching world')
             return
 
         x, y, yaw = self._extract_initial_pose(path)
-        self._switch_world(prev_map_name, map_name, x, y, yaw)
+        if self._switch_world(prev_map_name, map_name, x, y, yaw):
+            # 全ステップ成功時のみ map_name と config_path を新へ進める。
+            # 失敗時は state 維持 → 次の同 config_path 受信で retry 可能。
+            self._current_map_name = map_name
+            self._current_config_path = path
+        else:
+            self.get_logger().warn(
+                f'switch_world {prev_map_name} → {map_name} failed; '
+                f'keeping internal state at {prev_map_name} for retry')
 
     def _extract_initial_pose(self, config_path):
         """mapoi_config.yaml から initial_pose タグ POI の座標を取得。
@@ -164,21 +174,42 @@ class MapoiSimBridge(Node):
         return 0.0, 0.0, 0.0
 
     def _switch_world(self, prev_map, new_map, x, y, yaw):
+        """全 step 成功時のみ True を返す。
+
+        partial 失敗 (delete 成功・spawn 失敗 等) では `_current_obstacle_name`
+        は事実 (Gazebo 実体の有無) を追跡するように都度更新する。
+        """
         prev_entry = self._table.get(prev_map)
         new_entry = self._table.get(new_map)
+        all_ok = True
 
+        # 旧障害物 delete
         if prev_entry and self._current_obstacle_name:
-            self._delete_entity(self._current_obstacle_name)
-            self._current_obstacle_name = None
+            if self._delete_entity(self._current_obstacle_name):
+                self._current_obstacle_name = None
+            else:
+                all_ok = False
+                # 削除失敗時は _current_obstacle_name そのまま、新 spawn もスキップ
+                self.get_logger().warn(
+                    f'delete failed; aborting world switch (旧 obstacle stays)')
+                return False
 
+        # 新障害物 spawn
         if new_entry:
-            self._spawn_entity_from_uri(new_entry['name'], new_entry['uri'])
-            self._current_obstacle_name = new_entry['name']
+            if self._spawn_entity_from_uri(new_entry['name'], new_entry['uri']):
+                self._current_obstacle_name = new_entry['name']
+            else:
+                all_ok = False
         else:
             self.get_logger().warn(
                 f"No map_obstacle_table entry for '{new_map}'; obstacle not spawned")
+            # 新 entry 不明は config 不足、ここでは all_ok は維持
 
-        self._respawn_robot(x, y, yaw)
+        # robot respawn
+        if not self._respawn_robot(x, y, yaw):
+            all_ok = False
+
+        return all_ok
 
     def _call_blocking(self, client, req, timeout_sec=10.0):
         """worker thread から service を blocking call。
@@ -199,22 +230,28 @@ class MapoiSimBridge(Node):
         return None
 
     def _delete_entity(self, name):
+        """成功時 True を返す。timeout / success=False は False。"""
         if not self._delete_cli.wait_for_service(timeout_sec=10.0):
             self.get_logger().warn('delete_entity service not available')
-            return
+            return False
         req = DeleteEntity.Request()
         req.name = name
         res = self._call_blocking(self._delete_cli, req, timeout_sec=5.0)
         if res is None:
             self.get_logger().warn(f'delete_entity({name}) timed out')
-        else:
-            self.get_logger().info(
-                f'delete_entity({name}): success={res.success}')
+            return False
+        if not res.success:
+            self.get_logger().warn(
+                f'delete_entity({name}) failed: {res.status_message}')
+            return False
+        self.get_logger().info(f'delete_entity({name}): success')
+        return True
 
     def _spawn_entity_from_uri(self, name, uri):
+        """成功時 True を返す。timeout / success=False は False。"""
         if not self._spawn_cli.wait_for_service(timeout_sec=10.0):
             self.get_logger().warn('spawn_entity service not available')
-            return
+            return False
         sdf = (
             '<?xml version="1.0"?>'
             '<sdf version="1.6"><world name="default">'
@@ -227,12 +264,16 @@ class MapoiSimBridge(Node):
         res = self._call_blocking(self._spawn_cli, req, timeout_sec=10.0)
         if res is None:
             self.get_logger().warn(f'spawn_entity({name}) timed out')
-        else:
-            self.get_logger().info(
-                f'spawn_entity({name}, {uri}): success={res.success}')
+            return False
+        if not res.success:
+            self.get_logger().warn(
+                f'spawn_entity({name}) failed: {res.status_message}')
+            return False
+        self.get_logger().info(f'spawn_entity({name}, {uri}): success')
+        return True
 
     def _respawn_robot(self, x, y, yaw):
-        """ロボットを delete + spawn で新位置に再生成。
+        """ロボットを delete + spawn で新位置に再生成。成功時 True。
 
         set_entity_state の代替 (上記 NOTE 参照)。/odom の連続性は失われ、AMCL は
         再 collapse が必要だが、本 PoC のスコープでは許容 (PR #32 の auto initial_pose
@@ -245,25 +286,28 @@ class MapoiSimBridge(Node):
         if not self._robot_sdf_path:
             self.get_logger().warn(
                 'robot_sdf_path parameter is empty; skipping respawn (robot stays at old pose)')
-            return
+            return False
         if not os.path.exists(self._robot_sdf_path):
             self.get_logger().error(
                 f'robot_sdf_path not found: {self._robot_sdf_path}; skipping respawn')
-            return
+            return False
         if not self._spawn_cli.wait_for_service(timeout_sec=10.0):
             self.get_logger().warn(
                 'spawn_entity service not available; skipping respawn (robot stays at old pose)')
-            return
+            return False
         try:
             with open(self._robot_sdf_path, 'r') as f:
                 sdf = f.read()
         except Exception as e:
             self.get_logger().error(
                 f'Failed to read robot SDF ({self._robot_sdf_path}): {e}; skipping respawn')
-            return
+            return False
 
         # 2. delete (preflight 通過後にのみ実行)
-        self._delete_entity(self._robot_name)
+        if not self._delete_entity(self._robot_name):
+            self.get_logger().warn(
+                'delete robot failed; skipping respawn to avoid duplicate entity')
+            return False
 
         # 3. spawn
         req = SpawnEntity.Request()
@@ -278,10 +322,14 @@ class MapoiSimBridge(Node):
         if res is None:
             self.get_logger().warn(
                 f'respawn_robot({self._robot_name}) timed out (robot may be deleted)')
-        else:
-            self.get_logger().info(
-                f'respawn_robot({self._robot_name}, {x:.2f}, {y:.2f}, yaw={yaw:.2f}): '
-                f'success={res.success}')
+            return False
+        if not res.success:
+            self.get_logger().warn(
+                f'respawn_robot({self._robot_name}) failed: {res.status_message}')
+            return False
+        self.get_logger().info(
+            f'respawn_robot({self._robot_name}, {x:.2f}, {y:.2f}, yaw={yaw:.2f}): success')
+        return True
 
 
 def main(args=None):

--- a/mapoi_turtlebot3_example/mapoi_turtlebot3_example/sim_bridge.py
+++ b/mapoi_turtlebot3_example/mapoi_turtlebot3_example/sim_bridge.py
@@ -303,11 +303,15 @@ class MapoiSimBridge(Node):
                 f'Failed to read robot SDF ({self._robot_sdf_path}): {e}; skipping respawn')
             return False
 
-        # 2. delete (preflight 通過後にのみ実行)
+        # 2. delete (preflight 通過後にのみ実行)。失敗しても spawn には進む。
+        # 理由: 前回試行で delete 成功 + spawn 失敗で robot が既に消えている
+        # ケースを retry する場合、delete が "entity not found" で success=False
+        # を返す。abort すると burger 不在のまま固定化されるため、log だけ残して
+        # spawn を試行する (重複は spawn 側が success=False で検知)。
         if not self._delete_entity(self._robot_name):
-            self.get_logger().warn(
-                'delete robot failed; skipping respawn to avoid duplicate entity')
-            return False
+            self.get_logger().info(
+                'delete robot returned not-success; entity may already be gone. '
+                'will still attempt spawn at new pose (duplicate detected by spawn).')
 
         # 3. spawn
         req = SpawnEntity.Request()

--- a/mapoi_turtlebot3_example/package.xml
+++ b/mapoi_turtlebot3_example/package.xml
@@ -11,6 +11,7 @@
   <author email="kimura.shunsuke@shimz.co.jp">Shunsuke Kimura</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
   <depend>ament_cmake_auto</depend>
 
   <depend>rclcpp</depend>
@@ -22,6 +23,11 @@
   <exec_depend>mapoi_server</exec_depend>
   <exec_depend>mapoi_webui</exec_depend>
   <exec_depend>mapoi_rviz_plugins</exec_depend>
+
+  <!-- sim_bridge.py (Gazebo entity 入れ替え) 用 -->
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>gazebo_msgs</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
   <depend>yaml_cpp_vendor</depend>
   <depend>ament_index_cpp</depend>
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
## 概要

mapoi の `switch_map` を Gazebo シミュレーション上で動作確認可能にする `mapoi_sim_bridge` ノードを新設。issue #30 の Phase 1 PoC。

## 設計方針

### entity 入れ替え方式 (P2)

`mapoi_config_path` topic を購読し、map_name 変化を検知すると Gazebo の entity (障害物 model + ロボット) を入れ替える。**Gazebo 本体は無停止** で `/clock` `/tf (odom→base_footprint)` `/odom` `/scan` の継続性を保つ。

P1 (Gazebo 全体再起動) ではなく P2 を採用した理由:
- AMCL 等の lifecycle node が無中断
- 切替時間 1-3 秒級 (vs P1 の 10-30 秒)
- `/clock` 不連続による race condition を大幅解消

### ロボット teleport を delete + spawn で代替

本来は `/set_entity_state` (`gazebo_ros_state.so` plugin) を使うのが筋だが、Humble + Gazebo Classic では plugin の launch arg load (`extra_gazebo_args -s libgazebo_ros_state.so`) で `service list` には登録されるが client から呼べない **upstream の既知問題** あり (gazebo_ros_pkgs issue [#1526](https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1526), [#1157](https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1157)、リポジトリは 2025-07 archived、Classic は 2025-01 EOL)。

代替として `/delete_entity` + `/spawn_entity` で robot を再生成する形を取る。機能等価で、副次的な利点として Phase 1 PoC のスコープを最小化できる。

## 変更ファイル

| 種類 | ファイル |
|---|---|
| 新規 | `mapoi_turtlebot3_example/mapoi_turtlebot3_example/sim_bridge.py` (Python ノード本体) |
| 新規 | `mapoi_turtlebot3_example/mapoi_turtlebot3_example/__init__.py` |
| 新規 | `mapoi_turtlebot3_example/config/sim_bridge.yaml` (`map_obstacle_table_yaml` 等) |
| 修正 | `mapoi_turtlebot3_example/CMakeLists.txt` (`ament_python_install_package` + sim_bridge.py の `install(PROGRAMS)`) |
| 修正 | `mapoi_turtlebot3_example/package.xml` (`rclpy` / `gazebo_msgs` / `python3-yaml` の exec_depend) |
| 修正 | `mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml` (sim_bridge node 追加) |

## 動作確認

### Humble + headless

```bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
ros2 service call /switch_map mapoi_interfaces/srv/SwitchMap \
  "{map_name: turtlebot3_dqn_stage1}"
```

ログ:

```
[mapoi_sim_bridge]: config_path changed → map_name=turtlebot3_dqn_stage1
[mapoi_sim_bridge]: delete_entity(turtlebot3_world): success=True
[mapoi_sim_bridge]: spawn_entity(turtlebot3_dqn_world, model://turtlebot3_dqn_world): success=True
[mapoi_sim_bridge]: delete_entity(burger): success=True
[mapoi_sim_bridge]: respawn_robot(burger, -2.00, -0.50, yaw=0.00): success=True
```

- ✅ `switch_map` srv 全体 success=True (Nav2 map_server load_map 含む)
- ✅ Gazebo 無停止で `turtlebot3_world` → `turtlebot3_dqn_stage1` 切替
- ✅ 4 service call (delete_entity x2, spawn_entity x2) すべて success=True
- ✅ ロボットが `initial_pose` POI 座標 (-2.0, -0.5) に再生成

## 制約と前提

- **Humble (Gazebo Classic) 限定**: Jazzy (gz-sim) は service が `ros_gz_interfaces` 系に変わるため別対応 (#42 と統合)
- **AMCL 再 collapse は本 PR スコープ外**: ロボット再生成で odom 不連続 → AMCL の TF chain 再構築 → PR #32 の auto initial_pose publish が補正する想定
- **走行中 SwitchMap の自動 goal cancel は対象外**: ユーザーが事前に navigation 停止する前提

## スコープ外 (別 issue 候補)

- **#42**: Jazzy (gz-sim) 対応 — `ros_gz_interfaces/srv/{SpawnEntity, DeleteEntity, SetEntityPose}` への adapter 追加
- AMCL 再 collapse の確実化 (sim_bridge から `/initialpose` 再 publish trigger 等)
- 走行中 SwitchMap での Goal cancel 自動化
- 高速切替 (現状 ~1-3 秒、最適化余地あり)

Close #30
