### PR TITLE
feat(turtlebot3_example): Jazzy (gz-sim) 用 headless wrapper を追加 (#42)

### DIFF
--- a/mapoi_turtlebot3_example/README.md
+++ b/mapoi_turtlebot3_example/README.md
@@ -49,9 +49,9 @@ ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
 | arg | default | 効果 |
 |---|---|---|
 | `rviz` | `true` | RViz2 の起動有無 |
-| `gazebo_gui` | `true` | Gazebo GUI (`gzclient`) の起動有無。`false` でも `gzserver` は起動し物理シミュレーションは動作 |
+| `gazebo_gui` | `true` | シミュレータ GUI の起動有無。`false` でも server (Humble: `gzserver` / Jazzy: `gz sim -s`) は起動し物理シミュレーションは動作 |
 
-> **⚠️ Distro の制約**: headless モード (`gazebo_gui:=false`) は現状 **Humble (Gazebo Classic) のみ対応**。Jazzy 以降は `turtlebot3_gazebo` 側の launch が `ros_gz_sim` (Harmonic) ベースに変わるため、`gazebo_gui` arg は無視され常に GUI 付きで起動する。Jazzy 対応は別 issue で追加予定。`rviz:=false` は distro によらず動作。
+`gazebo_gui` は Humble (Gazebo Classic) と Jazzy (gz-sim) のどちらでも有効です。distro 別の wrapper (`gazebo_headless_aware.launch.yaml` / `gz_sim_headless_aware.launch.yaml`) を `turtlebot3_navigation.launch.yaml` から `ROS_DISTRO` で使い分けています。`rviz:=false` は distro によらず動作。
 
 ## 地図の作成（SLAM）
 

--- a/mapoi_turtlebot3_example/launch/gazebo_headless_aware.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/gazebo_headless_aware.launch.yaml
@@ -1,12 +1,9 @@
-# Headless-aware wrapper of turtlebot3_gazebo/launch/turtlebot3_world.launch.py.
+# Headless-aware wrapper of turtlebot3_gazebo/launch/turtlebot3_world.launch.py (Humble / Gazebo Classic 版).
 # 上流の turtlebot3_world.launch.py は gzserver と gzclient を無条件 include するため、
 # gazebo_gui arg で gzclient を条件化したラッパーを用意する。
 #
-# NOTE: この wrapper は Humble (Gazebo Classic) 専用。
-# Jazzy 以降は turtlebot3_gazebo 側の launch が ros_gz_sim (Harmonic) ベースに
-# 変わるため、この wrapper をそのまま流用できない。Jazzy 対応は別 issue で
-# 対応する。turtlebot3_navigation.launch.yaml は ROS_DISTRO で分岐して、
-# Jazzy ではこの wrapper を使わず上流 launch を直接 include する。
+# Jazzy (gz-sim) 用は gz_sim_headless_aware.launch.yaml を参照。
+# turtlebot3_navigation.launch.yaml は ROS_DISTRO で分岐して使い分ける。
 
 launch:
 

--- a/mapoi_turtlebot3_example/launch/gz_sim_headless_aware.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/gz_sim_headless_aware.launch.yaml
@@ -1,0 +1,53 @@
+# Headless-aware wrapper of turtlebot3_gazebo/launch/turtlebot3_world.launch.py (Jazzy / gz-sim 版).
+# 上流の turtlebot3_world.launch.py は gz_sim を server (-s) と GUI (-g) の 2 つの
+# IncludeLaunchDescription として無条件に起動するため、gazebo_gui arg で GUI 側を
+# 条件化したラッパーを用意する。
+#
+# Humble (Gazebo Classic) 用は gazebo_headless_aware.launch.yaml を参照。
+# turtlebot3_navigation.launch.yaml は ROS_DISTRO で分岐して使い分ける。
+
+launch:
+
+- arg: {name: use_sim_time, default: "true"}
+- arg: {name: x_pose, default: "-2.0"}
+- arg: {name: y_pose, default: "-0.5"}
+- arg:
+    name: world
+    default: "$(find-pkg-share turtlebot3_gazebo)/worlds/turtlebot3_world.world"
+- arg:
+    name: gazebo_gui
+    default: "true"
+    description: "Launch gz GUI client (-g). Set false for headless."
+
+# turtlebot3_gazebo の models を GZ_SIM_RESOURCE_PATH に追加 (上流 launch と同等)
+- append_env:
+    name: GZ_SIM_RESOURCE_PATH
+    value: "$(find-pkg-share turtlebot3_gazebo)/models"
+
+# gz server (-r run, -s server only)
+- include:
+    file: "$(find-pkg-share ros_gz_sim)/launch/gz_sim.launch.py"
+    arg:
+      - {name: gz_args, value: "-r -s -v2 $(var world)"}
+      - {name: on_exit_shutdown, value: "true"}
+
+# gz GUI (-g GUI only). gazebo_gui:=false で headless
+- include:
+    file: "$(find-pkg-share ros_gz_sim)/launch/gz_sim.launch.py"
+    arg:
+      - {name: gz_args, value: "-g -v2"}
+      - {name: on_exit_shutdown, value: "true"}
+    if: $(var gazebo_gui)
+
+# robot_state_publisher
+- include:
+    file: "$(find-pkg-share turtlebot3_gazebo)/launch/robot_state_publisher.launch.py"
+    arg:
+      - {name: use_sim_time, value: "$(var use_sim_time)"}
+
+# spawn turtlebot (parameter_bridge / image_bridge も内部で起動)
+- include:
+    file: "$(find-pkg-share turtlebot3_gazebo)/launch/spawn_turtlebot3.launch.py"
+    arg:
+      - {name: x_pose, value: "$(var x_pose)"}
+      - {name: y_pose, value: "$(var y_pose)"}

--- a/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
@@ -25,7 +25,7 @@ launch:
 - arg:
     name: gazebo_gui
     default: "true"
-    description: "Launch Gazebo GUI (gzclient; set false for headless). gzserver は常時起動"
+    description: "Launch シミュレータ GUI (Humble: gzclient / Jazzy: gz sim -g). false で headless. server は常時起動"
 
 # Gazebo launch (distro 別の headless-aware wrapper を使い分け)
 # - Humble: Gazebo Classic 用 (gazebo_ros gzserver/gzclient を条件化)

--- a/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
@@ -27,9 +27,10 @@ launch:
     default: "true"
     description: "Launch Gazebo GUI (gzclient; set false for headless). gzserver は常時起動"
 
-# Gazebo launch
-# - Humble: headless-aware wrapper (gazebo_gui arg で gzclient を条件化可能)
-# - Jazzy: 上流 launch を直接 include (headless 未対応、gazebo_gui arg は無視)
+# Gazebo launch (distro 別の headless-aware wrapper を使い分け)
+# - Humble: Gazebo Classic 用 (gazebo_ros gzserver/gzclient を条件化)
+# - Jazzy 以降: gz-sim 用 (ros_gz_sim gz_sim を server/GUI で条件化)
+# 両 wrapper とも gazebo_gui arg を受け、false で headless 起動
 - include:
     file: "$(find-pkg-share mapoi_turtlebot3_example)/launch/gazebo_headless_aware.launch.yaml"
     arg:
@@ -38,7 +39,10 @@ launch:
     if: $(eval "'$(env ROS_DISTRO)' == 'humble'")
 
 - include:
-    file: "$(find-pkg-share turtlebot3_gazebo)/launch/turtlebot3_world.launch.py"
+    file: "$(find-pkg-share mapoi_turtlebot3_example)/launch/gz_sim_headless_aware.launch.yaml"
+    arg:
+      - {name: gazebo_gui, value: "$(var gazebo_gui)"}
+      - {name: use_sim_time, value: "$(var use_sim_time)"}
     unless: $(eval "'$(env ROS_DISTRO)' == 'humble'")
 
 

--- a/mapoi_turtlebot3_example/package.xml
+++ b/mapoi_turtlebot3_example/package.xml
@@ -19,6 +19,9 @@
   <exec_depend>turtlebot3</exec_depend>
   <exec_depend>turtlebot3_gazebo</exec_depend>
   <exec_depend>turtlebot3_navigation2</exec_depend>
+  <!-- gz_sim_headless_aware.launch.yaml が ros_gz_sim/launch/gz_sim.launch.py を直接 include するため、
+       Jazzy 以降では明示的に exec_depend を持たせる。Humble (Gazebo Classic) では不要 -->
+  <exec_depend condition="$ROS_DISTRO != 'humble'">ros_gz_sim</exec_depend>
   <exec_depend>mapoi_server</exec_depend>
   <exec_depend>mapoi_webui</exec_depend>
   <exec_depend>mapoi_rviz_plugins</exec_depend>


### PR DESCRIPTION
## 概要

Close #42

#31 で追加した `gazebo_headless_aware.launch.yaml` は Humble (Gazebo Classic) 専用で、Jazzy 以降では `turtlebot3_world.launch.py` を直接 include していたため `gazebo_gui:=false` が無視されていた。

Jazzy (gz-sim / Harmonic) 用の wrapper を新設し、`turtlebot3_navigation.launch.yaml` から `ROS_DISTRO` で使い分ける。

## 変更点

### 新規 `gz_sim_headless_aware.launch.yaml` (Jazzy 用)

`ros_gz_sim/launch/gz_sim.launch.py` を 2 回 include する upstream パターンを踏襲しつつ、GUI 側を `gazebo_gui` arg で条件化:

- gz server: `-r -s -v2 <world>` (常時起動)
- gz GUI:    `-g -v2` (`gazebo_gui:=true` のときのみ起動)
- `GZ_SIM_RESOURCE_PATH` に `turtlebot3_gazebo/models` を append
- `robot_state_publisher.launch.py` / `spawn_turtlebot3.launch.py` は上流をそのまま include

### `turtlebot3_navigation.launch.yaml` 更新

```yaml
- include:
    file: ".../gazebo_headless_aware.launch.yaml"     # Humble (Classic)
    if: $(eval "'$(env ROS_DISTRO)' == 'humble'")

- include:
    file: ".../gz_sim_headless_aware.launch.yaml"     # Jazzy (gz-sim)
    unless: $(eval "'$(env ROS_DISTRO)' == 'humble'")
```

両 wrapper とも `gazebo_gui` / `use_sim_time` arg を受け取る。

### `package.xml` 更新

新 wrapper が `ros_gz_sim/launch/gz_sim.launch.py` を直接 include するため、Jazzy 以降のみ明示的に exec_depend:

```xml
<exec_depend condition="$ROS_DISTRO != 'humble'">ros_gz_sim</exec_depend>
```

## 動作確認

### Jazzy (`ghcr.io/shimz-robotics/mapoi:jazzy`)

```bash
colcon build --packages-up-to mapoi_turtlebot3_example   # 成功
TURTLEBOT3_MODEL=burger ros2 launch mapoi_turtlebot3_example \
  turtlebot3_navigation.launch.yaml rviz:=false gazebo_gui:=false
```

確認内容:
- `gz sim -r -s -v2 ...` (server only) のみ起動
- `gz sim -g -v2` (GUI) は **起動しない**
- Nav2 stack が全 lifecycle node activate
- `mapoi_server` / `mapoi_nav_server` も起動

### Humble regression

`ros2 launch -p` で launch tree 正常 parse、構造変化なし。

## Test plan

- [x] Jazzy image で colcon build 成功
- [x] Jazzy headless 起動確認 (gz GUI なし、server のみ)
- [x] Humble image で launch parse 正常 (regression なし)
- [x] Codex review (round 1〜)

## 関連

- #31: Humble headless モード (元実装)
- #40, #41, #43: launch 周辺の rename / 整理
- #48: mapoi_gz_bridge (gz-sim 用 SwitchMap 連動 bridge、本 PR とは独立、後続予定)
