### PR TITLE
fix(test): test_nav_server_unit.cpp で UNIT_TEST redefined 警告を解消 (#47)

### DIFF
--- a/mapoi_server/test/test_nav_server_unit.cpp
+++ b/mapoi_server/test/test_nav_server_unit.cpp
@@ -1,4 +1,4 @@
-#define UNIT_TEST
+// UNIT_TEST マクロは CMakeLists.txt の target_compile_definitions で定義する
 #include <gtest/gtest.h>
 #include <rclcpp/rclcpp.hpp>
 #include "mapoi_server/mapoi_nav_server.hpp"


### PR DESCRIPTION
## 概要

Close #47

`mapoi_server/test/test_nav_server_unit.cpp` の冒頭の `#define UNIT_TEST` と、CMakeLists.txt の `target_compile_definitions(test_nav_server_unit PRIVATE UNIT_TEST)` で渡している同名マクロが衝突し、ビルド毎に下記警告が出ていた:

```
--- stderr: mapoi_server
src/mapoi_server/test/test_nav_server_unit.cpp:1: warning: "UNIT_TEST" redefined
    1 | #define UNIT_TEST
      |
<command-line>: note: this is the location of the previous definition
---
```

CMake 側で常に定義しているのでソース側の `#define` は冗長。削除する。

## 変更点

- `mapoi_server/test/test_nav_server_unit.cpp:1`: `#define UNIT_TEST` → コメント (UNIT_TEST マクロは CMake で定義) に置換

## 動作確認

- `colcon build --packages-up-to mapoi_server`: stderr なし (警告消滅)
- `colcon test --packages-select mapoi_server`: 4 tests passed (gtest 4 / launch_test 0、既存と同等)

## Test plan

- [x] Humble image でビルド時の警告消滅
- [x] colcon test 全件 pass
- [x] Codex review
