### PR TITLE
fix(rviz): humble に存在しない nav2_rviz_plugins/Selector,Docking panel を除去 (#37)

### DIFF
--- a/mapoi_turtlebot3_example/rviz/tb3_navigation2.rviz
+++ b/mapoi_turtlebot3_example/rviz/tb3_navigation2.rviz
@@ -23,10 +23,6 @@ Panels:
     Splitter Ratio: 0.3333333432674408
   - Class: nav2_rviz_plugins/Navigation 2
     Name: Navigation 2
-  - Class: nav2_rviz_plugins/Selector
-    Name: Selector
-  - Class: nav2_rviz_plugins/Docking
-    Name: Docking
   - Class: mapoi_rviz_plugins/MapoiPanel
     Name: MapoiPanel
   - Class: rviz_common/Help
@@ -608,8 +604,6 @@ Visualization Manager:
 Window Geometry:
   Displays:
     collapsed: false
-  Docking:
-    collapsed: false
   Height: 836
   Help:
     collapsed: false
@@ -625,8 +619,6 @@ Window Geometry:
   RealsenseCamera:
     collapsed: false
   Selection:
-    collapsed: false
-  Selector:
     collapsed: false
   Tool Properties:
     collapsed: false


### PR DESCRIPTION
## 概要

Close #37

`mapoi_turtlebot3_example/rviz/tb3_navigation2.rviz` を Humble 環境の RViz で開くと下記エラーが出ていた:

```
[rviz2]: PluginlibFactory: The plugin for class 'nav2_rviz_plugins/Selector' failed to load.
[rviz2]: PluginlibFactory: The plugin for class 'nav2_rviz_plugins/Docking' failed to load.
```

`Selector` / `Docking` は Nav2 jazzy 以降で追加された RViz panel で、Humble の `nav2_rviz_plugins` には存在しない。`tb3_navigation2.rviz` は jazzy 環境で生成された設定が混入していたのが原因。

## 対応

issue の **対応案 (a)「rviz config から該当 Panel エントリを削除 (Humble サポート優先)」** を採用。

- `Panels:` セクションから `nav2_rviz_plugins/Selector` / `nav2_rviz_plugins/Docking` の 2 エントリを削除
- `Window Geometry:` セクションから関連の `Selector:` / `Docking:` collapsed state を削除
- `QMainWindow State` の binary blob には panel 状態がエンコードされているが、RViz は存在しない panel は無視するため再生成は不要 (RViz 起動時に自動更新される)

## 検証

- YAML parse OK、残った Panels リストに Selector / Docking なし:
  ```
  ['rviz_common/Displays', 'rviz_common/Selection', 'rviz_common/Tool Properties',
   'rviz_common/Views', 'nav2_rviz_plugins/Navigation 2',
   'mapoi_rviz_plugins/MapoiPanel', 'rviz_common/Help', 'mapoi_rviz_plugins/PoiEditor']
  ```

## トレードオフ

Jazzy users はこれらの panel が初期 UI に表示されなくなる。再表示したい場合は RViz の **Panels メニュー → Add New Panel** から手動追加可能。

将来的に Jazzy 用に separate config を持ちたければ別 issue で対応する想定。

## Test plan

- [x] YAML parse 確認
- [x] Panels リストから Selector / Docking 消失確認
- [ ] Codex review
