### PR TITLE
feat(mapoi_server): mapoi_gz_bridge (gz-sim) で SwitchMap の Jazzy 連動 (#48)

### DIFF
--- a/mapoi_server/CMakeLists.txt
+++ b/mapoi_server/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(mapoi_rviz2_publisher ${_mapoi_yaml_cpp_target})
 
 # mapoi_gazebo_bridge: Gazebo Classic (gazebo_msgs) 用、Humble で build される。
 # Jazzy では gazebo_msgs が存在しないため find_package QUIET で skip。
-# Jazzy 用 (ros_gz_interfaces ベース) は mapoi_gz_bridge として別途 (#42)。
 find_package(gazebo_msgs QUIET)
 if(gazebo_msgs_FOUND)
   ament_auto_add_executable(mapoi_gazebo_bridge
@@ -40,6 +39,20 @@ if(gazebo_msgs_FOUND)
   message(STATUS "Building mapoi_gazebo_bridge (Gazebo Classic)")
 else()
   message(STATUS "Skipping mapoi_gazebo_bridge (gazebo_msgs not found)")
+endif()
+
+# mapoi_gz_bridge: gz-sim (ros_gz_interfaces) 用、Jazzy 以降で build される。
+# Humble では ros_gz_interfaces が存在しないため find_package QUIET で skip。
+find_package(ros_gz_interfaces QUIET)
+if(ros_gz_interfaces_FOUND)
+  ament_auto_add_executable(mapoi_gz_bridge
+    src/mapoi_gz_bridge.cpp
+  )
+  target_link_libraries(mapoi_gz_bridge ${_mapoi_yaml_cpp_target})
+  ament_target_dependencies(mapoi_gz_bridge ros_gz_interfaces)
+  message(STATUS "Building mapoi_gz_bridge (gz-sim)")
+else()
+  message(STATUS "Skipping mapoi_gz_bridge (ros_gz_interfaces not found)")
 endif()
 
 

--- a/mapoi_server/CMakeLists.txt
+++ b/mapoi_server/CMakeLists.txt
@@ -42,17 +42,21 @@ else()
 endif()
 
 # mapoi_gz_bridge: gz-sim (ros_gz_interfaces) 用、Jazzy 以降で build される。
-# Humble では ros_gz_interfaces が存在しないため find_package QUIET で skip。
+# Humble の image にも ros_gz_interfaces が含まれている場合があるが、
+# Humble の rclcpp は create_client(name, rclcpp::QoS, group) シグネチャを持たないため、
+# find_package が成功しても build は skip する必要がある。
+# package.xml の condition と揃え、ROS_DISTRO != humble のときのみ build する。
 find_package(ros_gz_interfaces QUIET)
-if(ros_gz_interfaces_FOUND)
+if(ros_gz_interfaces_FOUND AND NOT "$ENV{ROS_DISTRO}" STREQUAL "humble")
   ament_auto_add_executable(mapoi_gz_bridge
     src/mapoi_gz_bridge.cpp
   )
   target_link_libraries(mapoi_gz_bridge ${_mapoi_yaml_cpp_target})
   ament_target_dependencies(mapoi_gz_bridge ros_gz_interfaces)
-  message(STATUS "Building mapoi_gz_bridge (gz-sim)")
+  message(STATUS "Building mapoi_gz_bridge (gz-sim, ROS_DISTRO=$ENV{ROS_DISTRO})")
 else()
-  message(STATUS "Skipping mapoi_gz_bridge (ros_gz_interfaces not found)")
+  message(STATUS "Skipping mapoi_gz_bridge "
+    "(ros_gz_interfaces_FOUND=${ros_gz_interfaces_FOUND}, ROS_DISTRO=$ENV{ROS_DISTRO})")
 endif()
 
 

--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -18,13 +18,14 @@ mapoi のメインパッケージです。
       - {name: simulator, value: "none"}                   # gazebo|gz|none (default: none)
       - {name: robot_entity_name, value: "burger"}         # simulator=gazebo|gz のとき必要
       - {name: robot_sdf_path, value: "/path/.../model.sdf"} # simulator=gazebo のとき必要
+      - {name: init_world_name, value: "default"}          # simulator=gz のとき必要 (gz_sim 起動時の world 名)
 ```
 
 `maps_path` と `map_name` は **必須** です (未指定だと `mapoi_server` が config ファイルを解決できず起動失敗します)。
 
 `simulator` arg はシミュレータ連動 bridge の起動を制御します:
-- `gazebo` (Gazebo Classic / Humble): `mapoi_gazebo_bridge` を起動。SwitchMap 時に Gazebo 内の `world_model` entity を入れ替え + ロボットを `initial_pose` POI 座標に再生成
-- `gz` (gz-sim / Jazzy): `mapoi_gz_bridge` を起動する想定 (**#42 で実装予定、現状未対応**)。指定しても launch から WARN が出るのみで bridge は起動せず、SwitchMap は gz-sim 側に伝搬しません
+- `gazebo` (Gazebo Classic / Humble): `mapoi_gazebo_bridge` を起動。SwitchMap 時に Gazebo 内の `world_model` entity を入れ替え + ロボットを delete + spawn で `initial_pose` POI 座標に再生成
+- `gz` (gz-sim / Jazzy): `mapoi_gz_bridge` + `parameter_bridge` (`ros_gz_bridge`) を起動。SwitchMap 時に gz-sim 内の `world_model` entity を入れ替え + ロボットを `SetEntityPose` で `initial_pose` POI 座標に teleport (gz-sim では Classic と異なり set_pose service が使えるため delete + spawn は不要)
 - `none` (default): bridge 起動なし (実機運用)
 
 Web UI も使う場合は `mapoi_webui.launch.yaml` も併せて include:

--- a/mapoi_server/include/mapoi_server/mapoi_gz_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_gz_bridge.hpp
@@ -1,0 +1,86 @@
+#ifndef MAPOI_SERVER__MAPOI_GZ_BRIDGE_HPP_
+#define MAPOI_SERVER__MAPOI_GZ_BRIDGE_HPP_
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <ros_gz_interfaces/srv/spawn_entity.hpp>
+#include <ros_gz_interfaces/srv/delete_entity.hpp>
+#include <ros_gz_interfaces/srv/set_entity_pose.hpp>
+
+
+struct GzWorldModelInfo
+{
+  std::string uri;
+  std::string name;
+};
+
+struct MapGzInfo
+{
+  GzWorldModelInfo world_model;
+  double initial_x = 0.0;
+  double initial_y = 0.0;
+  double initial_yaw = 0.0;
+  bool has_gazebo = false;
+  bool has_initial_pose = false;
+};
+
+enum class ConfigLoadStatus
+{
+  Ok,               // parse 成功 + gazebo section あり
+  NoGazeboSection,  // parse 成功 + gazebo section 無し (legitimate)
+  ParseError,       // YAML parse or file I/O 失敗 (transient、retry すべき)
+};
+
+
+class MapoiGzBridge : public rclcpp::Node
+{
+public:
+  MapoiGzBridge();
+  ~MapoiGzBridge() override;
+
+private:
+  void on_config_path(const std_msgs::msg::String::SharedPtr msg);
+  void worker_loop();
+  void process_config_path(const std::string & path);
+  ConfigLoadStatus load_gazebo_info(const std::string & config_path, MapGzInfo & out);
+  bool switch_world(
+    const std::string & prev_map, const std::string & new_map,
+    const MapGzInfo & info);
+  bool delete_model_entity(const std::string & name);
+  bool spawn_model_from_uri(const std::string & name, const std::string & uri);
+  bool teleport_robot(double x, double y, double yaw);
+
+  // parameters
+  std::string robot_name_;
+  std::string init_world_name_;
+
+  // state (worker thread のみ touch)
+  std::string current_map_name_;
+  std::string current_world_model_name_;
+  std::string current_config_path_;
+
+  // service clients (Reentrant callback group で worker thread から wait_for 可能に)
+  rclcpp::CallbackGroup::SharedPtr cb_group_;
+  rclcpp::Client<ros_gz_interfaces::srv::SpawnEntity>::SharedPtr spawn_client_;
+  rclcpp::Client<ros_gz_interfaces::srv::DeleteEntity>::SharedPtr delete_client_;
+  rclcpp::Client<ros_gz_interfaces::srv::SetEntityPose>::SharedPtr set_pose_client_;
+
+  // subscription
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr config_path_sub_;
+
+  // worker thread + queue (subscribe callback は queue.push のみ、worker が直列処理)
+  std::thread worker_;
+  std::atomic<bool> stop_worker_{false};
+  std::queue<std::string> queue_;
+  std::mutex queue_mutex_;
+  std::condition_variable queue_cv_;
+};
+
+#endif  // MAPOI_SERVER__MAPOI_GZ_BRIDGE_HPP_

--- a/mapoi_server/launch/mapoi_bringup.launch.yaml
+++ b/mapoi_server/launch/mapoi_bringup.launch.yaml
@@ -41,7 +41,7 @@ launch:
     description: >
       シミュレータ選択:
         gazebo = Gazebo Classic (Humble 想定、mapoi_gazebo_bridge を起動)
-        gz     = gz-sim (Jazzy 想定、mapoi_gz_bridge を起動。#42 で実装予定)
+        gz     = gz-sim (Jazzy 想定、mapoi_gz_bridge + parameter_bridge を起動)
         none   = シミュレータ連動なし (実機)
 
 - arg:
@@ -55,6 +55,16 @@ launch:
     description: >
       ロボット再生成用 SDF ファイルのフルパス (simulator=gazebo のときのみ使用)。
       空文字なら respawn はスキップ (warn のみ)。
+      simulator=gz では SetEntityPose で teleport するため SDF 不要。
+
+- arg:
+    name: init_world_name
+    default: "default"
+    description: >
+      gz-sim で起動済みの world 名 (起動時固定、bridge ライフタイム中は不変)。
+      mapoi_gz_bridge は /world/<init_world_name>/{create,remove,set_pose} サービスを
+      呼ぶため、gz_sim 起動時の world 名 (SDF の <world name="..."> 値) と一致する必要がある。
+      simulator=gz のときのみ使用。
 
 # core 3 nodes (常時起動)
 - node:
@@ -85,12 +95,21 @@ launch:
       - {name: robot_sdf_path, value: "$(var robot_sdf_path)"}
     if: $(eval "'$(var simulator)' == 'gazebo'")
 
-# gz-sim 連動 (Jazzy): #42 で mapoi_gz_bridge を実装後に有効化する。
-# 現状 simulator=gz を指定しても bridge は起動しない (sim 自体は動くが SwitchMap 連動なし)。
-# 暫定として WARN を出して silent no-op を防ぐ (#42 マージ時に削除)。
-- log:
-    message: >
-      [mapoi_bringup] WARNING: simulator=gz is selected but mapoi_gz_bridge is
-      not yet implemented (see #42). SwitchMap will NOT propagate to gz-sim.
-      To suppress this warning, set simulator=none.
+# gz-sim 連動 (Jazzy): SwitchMap 時に world_model entity を入れ替え +
+# ロボットを SetEntityPose で initial_pose POI 座標に teleport (gz-sim 本体は無停止)。
+# parameter_bridge で gz native service (gz transport) を ROS 2 service として bridge する。
+- node:
+    pkg: mapoi_server
+    exec: mapoi_gz_bridge
+    output: "screen"
+    param:
+      - {name: robot_entity_name, value: "$(var robot_entity_name)"}
+      - {name: init_world_name, value: "$(var init_world_name)"}
+    if: $(eval "'$(var simulator)' == 'gz'")
+
+- node:
+    pkg: ros_gz_bridge
+    exec: parameter_bridge
+    output: "screen"
+    args: "/world/$(var init_world_name)/create@ros_gz_interfaces/srv/SpawnEntity /world/$(var init_world_name)/remove@ros_gz_interfaces/srv/DeleteEntity /world/$(var init_world_name)/set_pose@ros_gz_interfaces/srv/SetEntityPose"
     if: $(eval "'$(var simulator)' == 'gz'")

--- a/mapoi_server/package.xml
+++ b/mapoi_server/package.xml
@@ -32,6 +32,13 @@
        find_package(gazebo_msgs QUIET) を使い build 時に skip する。-->
   <depend condition="$ROS_DISTRO == 'humble'">gazebo_msgs</depend>
 
+  <!-- Jazzy 以降 (gz-sim) で mapoi_gz_bridge を build/run するための依存。
+       Humble では ros_gz_interfaces が存在しないため、CMakeLists 側で
+       find_package(ros_gz_interfaces QUIET) を使い build 時に skip する。
+       ros_gz_bridge は launch から parameter_bridge を起動するために exec_depend。-->
+  <depend condition="$ROS_DISTRO != 'humble'">ros_gz_interfaces</depend>
+  <exec_depend condition="$ROS_DISTRO != 'humble'">ros_gz_bridge</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/mapoi_server/src/mapoi_gz_bridge.cpp
+++ b/mapoi_server/src/mapoi_gz_bridge.cpp
@@ -89,8 +89,14 @@ MapoiGzBridge::~MapoiGzBridge()
 void MapoiGzBridge::on_config_path(const std_msgs::msg::String::SharedPtr msg)
 {
   // 軽量。queue に push して即 return。state 操作と service call は worker。
+  // mapoi_server は config_path を 500ms 周期で re-publish するため、worker が
+  // service 不達などで blocking 中だと queue が際限なく膨らむ。常に latest 1 件のみ
+  // 保持する coalesce 戦略で、stale な path は破棄する。
   {
     std::lock_guard<std::mutex> lock(queue_mutex_);
+    while (!queue_.empty()) {
+      queue_.pop();
+    }
     queue_.push(msg->data);
   }
   queue_cv_.notify_one();
@@ -147,10 +153,24 @@ void MapoiGzBridge::process_config_path(const std::string & path)
     return;
   }
   if (status == ConfigLoadStatus::NoGazeboSection) {
-    // legitimate: gazebo セクションが無い map (例: 実機用)。entity swap は
-    // skip、state のみ進める (次回 same map_name で早期 return するため)。
-    RCLCPP_INFO(this->get_logger(),
-      "No gazebo section in %s; skipping entity swap", path.c_str());
+    // legitimate: gazebo セクション無し map (例: 実機用 map config)。
+    // sim 側に旧 world_model が残っていれば cleanup してから state を進める
+    // (sim 側 state と map state の乖離防止)。delete に失敗したら state を進めず retry。
+    if (!current_world_model_name_.empty()) {
+      RCLCPP_INFO(this->get_logger(),
+        "No gazebo section in %s; cleaning up stale world_model=%s",
+        path.c_str(), current_world_model_name_.c_str());
+      if (!delete_model_entity(current_world_model_name_)) {
+        RCLCPP_WARN(this->get_logger(),
+          "delete world_model failed during NoGazeboSection cleanup; "
+          "keeping state for retry");
+        return;
+      }
+      current_world_model_name_.clear();
+    } else {
+      RCLCPP_INFO(this->get_logger(),
+        "No gazebo section in %s; skipping entity swap", path.c_str());
+    }
     current_map_name_ = map_name;
     current_config_path_ = path;
     return;

--- a/mapoi_server/src/mapoi_gz_bridge.cpp
+++ b/mapoi_server/src/mapoi_gz_bridge.cpp
@@ -1,49 +1,63 @@
-// mapoi_gazebo_bridge: SwitchMap 時に Gazebo Classic (gazebo_msgs) の entity を入れ替える。
+// mapoi_gz_bridge: SwitchMap 時に gz-sim (ros_gz_interfaces) の entity を入れ替える。
 //
 // mapoi_config_path topic を購読し、map_name 変化を検知すると:
-// - 旧マップの world_model entity を /delete_entity で削除
-// - 新マップの world_model entity を /spawn_entity で生成 (model://... URI で)
-// - ロボットも /delete_entity + /spawn_entity で initial_pose POI 座標に再生成
-// Gazebo 本体は無停止で /clock, /tf, /odom, /scan の継続性を保つ。
+// - 旧マップの world_model entity を /world/<init_world>/remove で削除
+// - 新マップの world_model entity を /world/<init_world>/create で生成 (model:// URI で)
+// - ロボットは /world/<init_world>/set_pose で initial_pose POI 座標に teleport
+//   (gz-sim は SetEntityPose が実装されているため delete + spawn は不要)
+// gz-sim 本体は無停止で /clock, /tf, /odom, /scan の継続性を保つ。
 //
 // map 依存情報 (world_model の URI / name) は各 map の mapoi_config.yaml の
 // gazebo: セクションに置き、mapoi_config_path 受信時に本 node が直接 parse する。
-// ロボット依存情報 (entity_name / SDF path) は launch から parameter で渡す。
+// ロボット依存情報 (entity_name) と gz-sim の world 名 (init_world_name) は
+// launch から parameter で渡す。
 //
-// NOTE: Humble (Gazebo Classic) 専用。Jazzy (gz-sim) 用は別 node
-// mapoi_gz_bridge を参照 (#48)。API が異なるため (gazebo_msgs vs ros_gz_interfaces)
+// NOTE: Jazzy 以降 (gz-sim) 専用。Humble (Gazebo Classic) 用は別 node
+// mapoi_gazebo_bridge を参照。API が異なるため (gazebo_msgs vs ros_gz_interfaces)
 // 同一コードでの distro 分岐はせず、別 node に分離している。
+//
+// gz-sim の native service (gz transport) を ROS 2 service として使うために、
+// launch から parameter_bridge を同時起動する想定 (mapoi_bringup.launch.yaml 参照)。
 
-#include "mapoi_server/mapoi_gazebo_bridge.hpp"
+#include "mapoi_server/mapoi_gz_bridge.hpp"
 
 #include <chrono>
 #include <cmath>
 #include <filesystem>
-#include <fstream>
 #include <sstream>
 
 #include <yaml-cpp/yaml.h>
+#include <ros_gz_interfaces/msg/entity.hpp>
 
 using namespace std::chrono_literals;
 using std::placeholders::_1;
 
 
-MapoiGazeboBridge::MapoiGazeboBridge()
-: Node("mapoi_gazebo_bridge")
+MapoiGzBridge::MapoiGzBridge()
+: Node("mapoi_gz_bridge")
 {
   this->declare_parameter<std::string>("robot_entity_name", "burger");
-  this->declare_parameter<std::string>("robot_sdf_path", "");
+  this->declare_parameter<std::string>("init_world_name", "default");
 
   robot_name_ = this->get_parameter("robot_entity_name").as_string();
-  robot_sdf_path_ = this->get_parameter("robot_sdf_path").as_string();
+  init_world_name_ = this->get_parameter("init_world_name").as_string();
+
+  // gz-sim native service 名 (parameter_bridge で同名 ROS 2 service として bridge される想定)
+  const std::string spawn_srv = "/world/" + init_world_name_ + "/create";
+  const std::string remove_srv = "/world/" + init_world_name_ + "/remove";
+  const std::string set_pose_srv = "/world/" + init_world_name_ + "/set_pose";
 
   // Reentrant callback group + MultiThreadedExecutor で worker thread から
   // async_send_request().future.wait_for() が executor の別 thread で resolve される。
   cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
-  spawn_client_ = this->create_client<gazebo_msgs::srv::SpawnEntity>(
-    "spawn_entity", rmw_qos_profile_services_default, cb_group_);
-  delete_client_ = this->create_client<gazebo_msgs::srv::DeleteEntity>(
-    "delete_entity", rmw_qos_profile_services_default, cb_group_);
+  // Jazzy: create_client(name, rmw_qos_profile_t, group) は deprecated、
+  // rclcpp::ServicesQoS() を使う。
+  spawn_client_ = this->create_client<ros_gz_interfaces::srv::SpawnEntity>(
+    spawn_srv, rclcpp::ServicesQoS(), cb_group_);
+  delete_client_ = this->create_client<ros_gz_interfaces::srv::DeleteEntity>(
+    remove_srv, rclcpp::ServicesQoS(), cb_group_);
+  set_pose_client_ = this->create_client<ros_gz_interfaces::srv::SetEntityPose>(
+    set_pose_srv, rclcpp::ServicesQoS(), cb_group_);
 
   auto sub_opts = rclcpp::SubscriptionOptions();
   sub_opts.callback_group = cb_group_;
@@ -53,18 +67,17 @@ MapoiGazeboBridge::MapoiGazeboBridge()
   auto sub_qos = rclcpp::QoS(rclcpp::KeepLast(10)).transient_local().reliable();
   config_path_sub_ = this->create_subscription<std_msgs::msg::String>(
     "mapoi_config_path", sub_qos,
-    std::bind(&MapoiGazeboBridge::on_config_path, this, _1),
+    std::bind(&MapoiGzBridge::on_config_path, this, _1),
     sub_opts);
 
-  worker_ = std::thread(&MapoiGazeboBridge::worker_loop, this);
+  worker_ = std::thread(&MapoiGzBridge::worker_loop, this);
 
   RCLCPP_INFO(this->get_logger(),
-    "mapoi_gazebo_bridge initialized: robot=%s, sdf=%s",
-    robot_name_.c_str(),
-    robot_sdf_path_.empty() ? "(not set)" : robot_sdf_path_.c_str());
+    "mapoi_gz_bridge initialized: robot=%s, init_world_name=%s",
+    robot_name_.c_str(), init_world_name_.c_str());
 }
 
-MapoiGazeboBridge::~MapoiGazeboBridge()
+MapoiGzBridge::~MapoiGzBridge()
 {
   stop_worker_ = true;
   queue_cv_.notify_all();
@@ -73,7 +86,7 @@ MapoiGazeboBridge::~MapoiGazeboBridge()
   }
 }
 
-void MapoiGazeboBridge::on_config_path(const std_msgs::msg::String::SharedPtr msg)
+void MapoiGzBridge::on_config_path(const std_msgs::msg::String::SharedPtr msg)
 {
   // 軽量。queue に push して即 return。state 操作と service call は worker。
   {
@@ -83,7 +96,7 @@ void MapoiGazeboBridge::on_config_path(const std_msgs::msg::String::SharedPtr ms
   queue_cv_.notify_one();
 }
 
-void MapoiGazeboBridge::worker_loop()
+void MapoiGzBridge::worker_loop()
 {
   while (!stop_worker_) {
     std::string path;
@@ -104,7 +117,7 @@ void MapoiGazeboBridge::worker_loop()
   }
 }
 
-void MapoiGazeboBridge::process_config_path(const std::string & path)
+void MapoiGzBridge::process_config_path(const std::string & path)
 {
   if (path == current_config_path_) {
     return;
@@ -123,7 +136,7 @@ void MapoiGazeboBridge::process_config_path(const std::string & path)
 
   std::string prev_map_name = current_map_name_;
 
-  MapGazeboInfo info;
+  MapGzInfo info;
   const auto status = load_gazebo_info(path, info);
   if (status == ConfigLoadStatus::ParseError) {
     // transient な失敗 (YAML parse / I/O)。state 進めず、mapoi_server の
@@ -151,7 +164,7 @@ void MapoiGazeboBridge::process_config_path(const std::string & path)
     current_map_name_ = map_name;
     current_config_path_ = path;
     RCLCPP_INFO(this->get_logger(),
-      "Initial map=%s; assuming Gazebo already loaded matching world",
+      "Initial map=%s; assuming gz-sim already loaded matching world model",
       map_name.c_str());
     return;
   }
@@ -166,8 +179,8 @@ void MapoiGazeboBridge::process_config_path(const std::string & path)
   }
 }
 
-ConfigLoadStatus MapoiGazeboBridge::load_gazebo_info(
-  const std::string & config_path, MapGazeboInfo & out)
+ConfigLoadStatus MapoiGzBridge::load_gazebo_info(
+  const std::string & config_path, MapGzInfo & out)
 {
   try {
     YAML::Node cfg = YAML::LoadFile(config_path);
@@ -210,16 +223,16 @@ ConfigLoadStatus MapoiGazeboBridge::load_gazebo_info(
   return out.has_gazebo ? ConfigLoadStatus::Ok : ConfigLoadStatus::NoGazeboSection;
 }
 
-bool MapoiGazeboBridge::switch_world(
+bool MapoiGzBridge::switch_world(
   const std::string & prev_map, const std::string & new_map,
-  const MapGazeboInfo & info)
+  const MapGzInfo & info)
 {
   (void)prev_map;
   (void)new_map;
 
   // 旧 world_model delete
   if (!current_world_model_name_.empty()) {
-    if (!delete_entity(current_world_model_name_)) {
+    if (!delete_model_entity(current_world_model_name_)) {
       RCLCPP_WARN(this->get_logger(),
         "delete world_model failed; aborting world switch (旧 world_model stays)");
       return false;
@@ -231,145 +244,120 @@ bool MapoiGazeboBridge::switch_world(
 
   // 新 world_model spawn
   if (!info.world_model.uri.empty()) {
-    if (spawn_entity_from_uri(info.world_model.name, info.world_model.uri)) {
+    if (spawn_model_from_uri(info.world_model.name, info.world_model.uri)) {
       current_world_model_name_ = info.world_model.name;
     } else {
       all_ok = false;
     }
   }
 
-  // robot respawn (initial_pose POI がある場合のみ)
+  // robot teleport (gz-sim は SetEntityPose で 1 回。delete+spawn は不要)
   if (info.has_initial_pose) {
-    if (!respawn_robot(info.initial_x, info.initial_y, info.initial_yaw)) {
+    if (!teleport_robot(info.initial_x, info.initial_y, info.initial_yaw)) {
       all_ok = false;
     }
   } else {
     RCLCPP_WARN(this->get_logger(),
-      "No initial_pose POI for %s; skipping robot respawn", new_map.c_str());
+      "No initial_pose POI for %s; skipping robot teleport", new_map.c_str());
   }
 
   return all_ok;
 }
 
-bool MapoiGazeboBridge::delete_entity(const std::string & name)
+bool MapoiGzBridge::delete_model_entity(const std::string & name)
 {
   if (!delete_client_->wait_for_service(10s)) {
-    RCLCPP_WARN(this->get_logger(), "delete_entity service not available");
+    RCLCPP_WARN(this->get_logger(),
+      "delete service not available (/world/%s/remove)",
+      init_world_name_.c_str());
     return false;
   }
-  auto req = std::make_shared<gazebo_msgs::srv::DeleteEntity::Request>();
-  req->name = name;
+  auto req = std::make_shared<ros_gz_interfaces::srv::DeleteEntity::Request>();
+  req->entity.name = name;
+  req->entity.type = ros_gz_interfaces::msg::Entity::MODEL;
   auto future = delete_client_->async_send_request(req);
   if (future.wait_for(5s) != std::future_status::ready) {
     RCLCPP_WARN(this->get_logger(),
-      "delete_entity(%s) timed out", name.c_str());
+      "delete_model_entity(%s) timed out", name.c_str());
     return false;
   }
   auto res = future.get();
   if (!res->success) {
     RCLCPP_WARN(this->get_logger(),
-      "delete_entity(%s) failed: %s",
-      name.c_str(), res->status_message.c_str());
+      "delete_model_entity(%s) failed (gz returned success=false)", name.c_str());
     return false;
   }
-  RCLCPP_INFO(this->get_logger(), "delete_entity(%s): success", name.c_str());
+  RCLCPP_INFO(this->get_logger(), "delete_model_entity(%s): success", name.c_str());
   return true;
 }
 
-bool MapoiGazeboBridge::spawn_entity_from_uri(
+bool MapoiGzBridge::spawn_model_from_uri(
   const std::string & name, const std::string & uri)
 {
   if (!spawn_client_->wait_for_service(10s)) {
-    RCLCPP_WARN(this->get_logger(), "spawn_entity service not available");
+    RCLCPP_WARN(this->get_logger(),
+      "spawn service not available (/world/%s/create)",
+      init_world_name_.c_str());
     return false;
   }
+  // gz-sim の EntityFactory.sdf に inline SDF を渡す。
+  // model:// URI は gz-sim 側 (gz_sim プロセス) の GZ_SIM_RESOURCE_PATH で解決される。
   std::ostringstream sdf;
   sdf << "<?xml version=\"1.0\"?>"
-      << "<sdf version=\"1.6\"><world name=\"default\">"
+      << "<sdf version=\"1.9\">"
       << "<include><uri>" << uri << "</uri></include>"
-      << "</world></sdf>";
-  auto req = std::make_shared<gazebo_msgs::srv::SpawnEntity::Request>();
-  req->name = name;
-  req->xml = sdf.str();
+      << "</sdf>";
+  auto req = std::make_shared<ros_gz_interfaces::srv::SpawnEntity::Request>();
+  req->entity_factory.name = name;
+  req->entity_factory.sdf = sdf.str();
   auto future = spawn_client_->async_send_request(req);
   if (future.wait_for(10s) != std::future_status::ready) {
     RCLCPP_WARN(this->get_logger(),
-      "spawn_entity(%s) timed out", name.c_str());
+      "spawn_model_from_uri(%s) timed out", name.c_str());
     return false;
   }
   auto res = future.get();
   if (!res->success) {
     RCLCPP_WARN(this->get_logger(),
-      "spawn_entity(%s) failed: %s",
-      name.c_str(), res->status_message.c_str());
+      "spawn_model_from_uri(%s, %s) failed (gz returned success=false)",
+      name.c_str(), uri.c_str());
     return false;
   }
   RCLCPP_INFO(this->get_logger(),
-    "spawn_entity(%s, %s): success", name.c_str(), uri.c_str());
+    "spawn_model_from_uri(%s, %s): success", name.c_str(), uri.c_str());
   return true;
 }
 
-bool MapoiGazeboBridge::respawn_robot(double x, double y, double yaw)
+bool MapoiGzBridge::teleport_robot(double x, double y, double yaw)
 {
-  // preflight: 失敗するなら delete もしない
-  if (robot_sdf_path_.empty()) {
+  if (!set_pose_client_->wait_for_service(10s)) {
     RCLCPP_WARN(this->get_logger(),
-      "robot_sdf_path is empty; skipping respawn (robot stays at old pose)");
+      "set_pose service not available (/world/%s/set_pose)",
+      init_world_name_.c_str());
     return false;
   }
-  if (!std::filesystem::exists(robot_sdf_path_)) {
-    RCLCPP_ERROR(this->get_logger(),
-      "robot_sdf_path not found: %s", robot_sdf_path_.c_str());
-    return false;
-  }
-  if (!spawn_client_->wait_for_service(10s)) {
-    RCLCPP_WARN(this->get_logger(),
-      "spawn_entity service not available; skipping robot respawn");
-    return false;
-  }
-  std::ifstream f(robot_sdf_path_);
-  if (!f.is_open()) {
-    RCLCPP_ERROR(this->get_logger(),
-      "Failed to open robot SDF: %s", robot_sdf_path_.c_str());
-    return false;
-  }
-  std::stringstream buf;
-  buf << f.rdbuf();
-  const std::string sdf = buf.str();
-
-  // delete は失敗しても spawn を試みる
-  // (前回 delete 成功 + spawn 失敗で robot 不在の状態からの retry 対応。
-  // 重複があれば spawn 側が success=false で検知)
-  if (!delete_entity(robot_name_)) {
-    RCLCPP_INFO(this->get_logger(),
-      "delete robot returned not-success; entity may already be gone. "
-      "will still attempt spawn at new pose");
-  }
-
-  auto req = std::make_shared<gazebo_msgs::srv::SpawnEntity::Request>();
-  req->name = robot_name_;
-  req->xml = sdf;
-  req->initial_pose.position.x = x;
-  req->initial_pose.position.y = y;
-  req->initial_pose.position.z = 0.01;
-  req->initial_pose.orientation.z = std::sin(yaw / 2.0);
-  req->initial_pose.orientation.w = std::cos(yaw / 2.0);
-  auto future = spawn_client_->async_send_request(req);
+  auto req = std::make_shared<ros_gz_interfaces::srv::SetEntityPose::Request>();
+  req->entity.name = robot_name_;
+  req->entity.type = ros_gz_interfaces::msg::Entity::MODEL;
+  req->pose.position.x = x;
+  req->pose.position.y = y;
+  req->pose.position.z = 0.01;
+  req->pose.orientation.z = std::sin(yaw / 2.0);
+  req->pose.orientation.w = std::cos(yaw / 2.0);
+  auto future = set_pose_client_->async_send_request(req);
   if (future.wait_for(10s) != std::future_status::ready) {
     RCLCPP_WARN(this->get_logger(),
-      "respawn_robot(%s) timed out (robot may be deleted)",
-      robot_name_.c_str());
+      "teleport_robot(%s) timed out", robot_name_.c_str());
     return false;
   }
   auto res = future.get();
   if (!res->success) {
     RCLCPP_WARN(this->get_logger(),
-      "respawn_robot(%s) failed: %s",
-      robot_name_.c_str(), res->status_message.c_str());
+      "teleport_robot(%s) failed (gz returned success=false)", robot_name_.c_str());
     return false;
   }
   RCLCPP_INFO(this->get_logger(),
-    "respawn_robot(%s, %.2f, %.2f, yaw=%.2f): success",
+    "teleport_robot(%s, %.2f, %.2f, yaw=%.2f): success",
     robot_name_.c_str(), x, y, yaw);
   return true;
 }
@@ -378,7 +366,7 @@ bool MapoiGazeboBridge::respawn_robot(double x, double y, double yaw)
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<MapoiGazeboBridge>();
+  auto node = std::make_shared<MapoiGzBridge>();
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(node);
   executor.spin();


### PR DESCRIPTION
## 概要

Close #48

#46 (Humble + Gazebo Classic 用 `mapoi_gazebo_bridge`) の対となる Jazzy + gz-sim 用 bridge を追加する。SwitchMap 時に gz-sim 内の `world_model` entity を入れ替え + ロボットを `initial_pose` POI に teleport する。

## Classic 版 (#46) との API 比較

| 項目 | Classic (`gazebo_msgs`) | gz-sim (`ros_gz_interfaces`) |
|---|---|---|
| Spawn req | `name` + `xml` (SDF文字列) + `initial_pose` (Pose) | `EntityFactory entity_factory` (中に `name`, `sdf`, `sdf_filename`, `pose`) |
| Delete req | `name` のみ | `Entity entity` = `id (uint64) + name + type (uint8)` |
| Pose 変更 | **不可** (`set_entity_state` plugin が upstream archive 済み) | **`SetEntityPose`** で 1 回 |
| Service 名 | `/spawn_entity`, `/delete_entity` (gazebo_ros が ROS service として直接 expose) | `/world/<world_name>/{create,remove,set_pose}` (gz transport native、`parameter_bridge` で ROS 2 service として bridge) |
| Service client template | `Client<gazebo_msgs::srv::SpawnEntity>` | `Client<ros_gz_interfaces::srv::SpawnEntity>` |

## 設計

設計の骨格は `mapoi_gazebo_bridge` を踏襲:
- worker thread + queue + condition_variable で `mapoi_config_path` を直列処理
- ReentrantCallbackGroup + MultiThreadedExecutor で worker thread から `async_send_request().future.wait_for()`
- `mapoi_config_path` subscriber を `transient_local + reliable` (publisher の latched 値を後起動でも受信)
- `ConfigLoadStatus` enum (Ok / NoGazeboSection / ParseError) で transient エラーを retry 可能に分離

### Classic との差異

- **構造体は別定義** (`GazeboWorldModelInfo` / `GzWorldModelInfo` 等)。実質同じ構造ですが、振る舞い (出力 API) が異なるため共通化のメリットが薄く、依存複雑化を避けるため YAGNI で別定義
- **Robot teleport は `SetEntityPose`** (Classic の delete + spawn 不要、SDF path も不要)
- **`init_world_name` parameter 追加** (default `"default"`)。bridge 内で `/world/<init_world_name>/{create,remove,set_pose}` のサービス名を構築。「起動時固定、bridge ライフタイム中は不変」の意味で `init_*` プレフィックス
- **`parameter_bridge` を bringup で同時起動**。`ros_gz_bridge`/`parameter_bridge` が gz transport の native service を ROS 2 service として bridge する設定:
  ```
  parameter_bridge \
    /world/default/create@ros_gz_interfaces/srv/SpawnEntity \
    /world/default/remove@ros_gz_interfaces/srv/DeleteEntity \
    /world/default/set_pose@ros_gz_interfaces/srv/SetEntityPose
  ```

## 変更点

### 新規ファイル

- `mapoi_server/src/mapoi_gz_bridge.cpp` (+ `.hpp`): `MapoiGzBridge` クラス、約 320 行 (Classic 版より短い ← teleport 簡素化)

### 修正

- `mapoi_server/CMakeLists.txt`: `find_package(ros_gz_interfaces QUIET)` で Jazzy 以降のみ build (Humble では skip)
- `mapoi_server/package.xml`:
  - `<depend condition="$ROS_DISTRO != 'humble'">ros_gz_interfaces</depend>`
  - `<exec_depend condition="$ROS_DISTRO != 'humble'">ros_gz_bridge</exec_depend>`
- `mapoi_server/launch/mapoi_bringup.launch.yaml`:
  - `simulator=gz` の WARN ブロック削除
  - `mapoi_gz_bridge` node + `parameter_bridge` node を inline で追加 (両方 `if: simulator==gz`)
  - `init_world_name` arg 追加
- `mapoi_server/README.md`: `simulator=gz` の説明を「実装済み」に更新、`init_world_name` arg 追加
- `mapoi_server/src/mapoi_gazebo_bridge.cpp`: 既存コメント中の "#42 と統合した別 PR" を `#48` 参照に修正

## 動作確認

Jazzy image (`ghcr.io/shimz-robotics/mapoi:jazzy`) で:

### Build
```bash
colcon build --packages-up-to mapoi_server   # 警告なし
```
※ 当初 `rmw_qos_profile_services_default` 経由の deprecation warning が出たので `rclcpp::ServicesQoS()` に書き換え済み

### Launch
```bash
TURTLEBOT3_MODEL=burger ros2 launch mapoi_turtlebot3_example \
  turtlebot3_navigation.launch.yaml rviz:=false gazebo_gui:=false
```
- `mapoi_gz_bridge` 起動: `mapoi_gz_bridge initialized: robot=burger, init_world_name=default`
- `parameter_bridge`:
  ```
  Creating ROS->GZ service bridge [/world/default/create  -> ...]
  Creating ROS->GZ service bridge [/world/default/remove  -> ...]
  Creating ROS->GZ service bridge [/world/default/set_pose -> ...]
  ```
- `ros2 service list` に `/world/default/{create,remove,set_pose}` が現れる

### E2E SwitchMap test
```bash
ros2 service call /switch_map mapoi_interfaces/srv/SwitchMap "{map_name: turtlebot3_dqn_stage1}"
```
→ `success=True`、bridge log:
```
config_path changed → map_name=turtlebot3_dqn_stage1
delete_model_entity(turtlebot3_world): success
spawn_model_from_uri(turtlebot3_dqn_world, model://turtlebot3_dqn_world): success
teleport_robot(burger, -2.00, -0.50, yaw=0.00): success
```

## Test plan

- [x] Jazzy image で colcon build 成功 (deprecation warning なし)
- [x] launch で `mapoi_gz_bridge` + `parameter_bridge` 起動確認
- [x] `/world/default/{create,remove,set_pose}` の ROS 2 service bridge 確認
- [x] E2E SwitchMap で entity swap + robot teleport が success
- [ ] Codex review (round 1〜)
- [ ] Humble image で `mapoi_server` の build が CMake skip で正常通過 (regression なし)

## 関連

- #46 (PR): Humble + Gazebo Classic 用 `mapoi_gazebo_bridge` (本 PR の対)
- #42 (PR #49): Jazzy headless wrapper
- #20: apt/rosdep 配布 (distro 横断対応の前提)
