### PR TITLE
fix(mapoi_gazebo_bridge): NoGazeboSection cleanup と queue coalesce を gz_bridge と対称化 (#53)

### DIFF
--- a/mapoi_server/src/mapoi_gazebo_bridge.cpp
+++ b/mapoi_server/src/mapoi_gazebo_bridge.cpp
@@ -76,8 +76,14 @@ MapoiGazeboBridge::~MapoiGazeboBridge()
 void MapoiGazeboBridge::on_config_path(const std_msgs::msg::String::SharedPtr msg)
 {
   // 軽量。queue に push して即 return。state 操作と service call は worker。
+  // mapoi_server は config_path を 500ms 周期で re-publish するため、worker が
+  // service 不達などで blocking 中だと queue が際限なく膨らむ。常に latest 1 件のみ
+  // 保持する coalesce 戦略で、stale な path は破棄する。
   {
     std::lock_guard<std::mutex> lock(queue_mutex_);
+    while (!queue_.empty()) {
+      queue_.pop();
+    }
     queue_.push(msg->data);
   }
   queue_cv_.notify_one();
@@ -134,10 +140,24 @@ void MapoiGazeboBridge::process_config_path(const std::string & path)
     return;
   }
   if (status == ConfigLoadStatus::NoGazeboSection) {
-    // legitimate: gazebo セクションが無い map (例: 実機用)。entity swap は
-    // skip、state のみ進める (次回 same map_name で早期 return するため)。
-    RCLCPP_INFO(this->get_logger(),
-      "No gazebo section in %s; skipping entity swap", path.c_str());
+    // legitimate: gazebo セクション無し map (例: 実機用 map config)。
+    // sim 側に旧 world_model が残っていれば cleanup してから state を進める
+    // (sim 側 state と map state の乖離防止)。delete に失敗したら state を進めず retry。
+    if (!current_world_model_name_.empty()) {
+      RCLCPP_INFO(this->get_logger(),
+        "No gazebo section in %s; cleaning up stale world_model=%s",
+        path.c_str(), current_world_model_name_.c_str());
+      if (!delete_entity(current_world_model_name_)) {
+        RCLCPP_WARN(this->get_logger(),
+          "delete world_model failed during NoGazeboSection cleanup; "
+          "keeping state for retry");
+        return;
+      }
+      current_world_model_name_.clear();
+    } else {
+      RCLCPP_INFO(this->get_logger(),
+        "No gazebo section in %s; skipping entity swap", path.c_str());
+    }
     current_map_name_ = map_name;
     current_config_path_ = path;
     return;


### PR DESCRIPTION
## 概要

Close #53

#48 (PR #52) で `mapoi_gz_bridge` を実装した際、Codex round 1 で指摘された 2 件の medium バグは Classic 版 `mapoi_gazebo_bridge` にも同じく存在していた。本 PR は対称な fix を Classic 版に適用する。

## 変更内容

### bug 1: `NoGazeboSection` 時の旧 entity 残留

`gazebo` セクション無し map に切り替わった時、`current_world_model_name_` を残したまま state を進めていたため、Gazebo 側に旧 entity が残ったまま map state だけ進む不整合が発生していた。次回 same `map_name` 通知で早期 return するためズレが固定化。

→ delete を試みてから state を進める。失敗時は state 進めず retry。

### bug 2: queue 無制限蓄積

`mapoi_config_path` は 500ms 周期 publish。worker が `delete_entity` / `spawn_entity` の `wait_for_service(10s)` などで blocking 中だと、queue に同じ path が積み上がり続ける。

→ `on_config_path` で queue クリアしてから push する **latest-only coalesce** に変更。

文言・コメントは PR #52 の gz_bridge 側と対称になるよう統一。

## 動作確認 (Humble)

```bash
colcon build --packages-up-to mapoi_server   # clean
colcon test --packages-select mapoi_server   # 4 tests passed (gtest 4 / launch_test 0)
```

## Test plan

- [x] Humble image でビルド clean
- [x] colcon test 全件 pass (既存 launch_test に regression なし)
- [ ] Codex review (round 1〜)

## 関連

- #46 (PR): Classic 版 `mapoi_gazebo_bridge` 元実装
- #48 (PR #52): gz 版 `mapoi_gz_bridge` (本 PR の fix の元になる Codex 指摘あり)
