### PR TITLE
fix(nav_server): /initialpose publisher を transient_local 化して subscriber readiness race を解消 (#33)

### DIFF
--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -16,7 +16,12 @@ MapoiNavServer::MapoiNavServer(const rclcpp::NodeOptions & options)
   // initialpose subscriber and publisher
   mapoi_initialpose_poi_sub_ = this->create_subscription<std_msgs::msg::String>(
     "mapoi_initialpose_poi", 1, std::bind(&MapoiNavServer::mapoi_initialpose_poi_cb, this, std::placeholders::_1));
-  nav2_initialpose_pub_ = this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("initialpose", 1);
+  // /initialpose は transient_local + KeepLast(1) で publish する。
+  // mapoi_nav_server が AMCL より先に起動するケースで、初回の自動 publish が
+  // AMCL subscription readiness 前に行われて取りこぼされる race を回避する
+  // (#33)。AMCL 側 subscriber は volatile + reliable で互換性あり。
+  nav2_initialpose_pub_ = this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    "initialpose", rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
 
   // goal_pose subscriber and publisher
   mapoi_goal_pose_poi_sub_ = this->create_subscription<std_msgs::msg::String>(


### PR DESCRIPTION
## 概要

Close #33

#32 (PR for #9) で `mapoi_nav_server` から `/initialpose` を自動 publish する経路を追加した際、`nav2_initialpose_pub_` の QoS が default の volatile だったため、AMCL より早く `mapoi_nav_server` が起動するケースで初回 publish が AMCL の subscription 確立前に行われて取りこぼされる race が残っていた。

症状:
- 起動直後の particle が `initial_pose` POI 座標に collapse しない
- WebUI / RViz / `mapoi_initialpose_poi` 経由で手動 publish するか、SwitchMap で別 map に切替→元に戻すと初めて反映される

## 対応 (issue 推奨の案 A を採用)

`nav2_initialpose_pub_` の QoS を `rclcpp::QoS(KeepLast(1)).transient_local().reliable()` に変更。

```cpp
nav2_initialpose_pub_ = this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
  "initialpose", rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
```

### QoS 互換性

| 側 | Reliability | Durability |
|---|---|---|
| publisher (mapoi_nav_server) | reliable | transient_local |
| subscriber (Nav2 AMCL) | reliable | volatile |

→ DDS の互換性ルール上 OK (publisher が transient_local、subscriber が volatile は許容、subscriber は latched 値を受信できる)。

### なぜ案 A を選択したか

- 案 B (subscriber count 待ちロジック) は実装複雑、起動ログが煩雑
- 案 C (fixed delay) は distro / HW 依存で fragile
- 案 A は publisher 側 QoS 変更のみ、構造的に race を消せる

## 動作確認 (Humble)

```bash
colcon build --packages-up-to mapoi_server   # clean
colcon test --packages-select mapoi_server   # 全件 pass
```

## Test plan

- [x] Humble image でビルド + test 通過
- [x] DDS QoS 互換性確認 (publisher transient_local + subscriber volatile)
- [ ] Codex review

## 関連

- #9: `initial_pose` タグ仕様
- #32 (PR): 自動 publish 機能の実装 (本 PR の対象)
