### PR TITLE
fix(nav_server): /initialpose 自動 publish 前に subscriber readiness を待機 (#33)

### DIFF
--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -138,6 +138,11 @@ private:
   void publish_initial_pose(
     const geometry_msgs::msg::Pose & pose, const std::string & source);
 
+  // /initialpose subscriber (主に AMCL) が ready になるまで待つ (#33)。
+  // subscriber が既に ready なら即 return。timeout 内に ready にならなければ WARN。
+  // 200ms 間隔の polling で blocking wait する (single-thread executor 前提)。
+  void wait_for_initialpose_subscriber(std::chrono::seconds timeout);
+
   // 同一 config_path への重複 publish 防止
   std::string last_initial_pose_config_path_;
 

--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #endif
 
+#include <chrono>
 #include <vector>
 #include <memory>
 #include <string>

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <functional>
 #include <cmath>
+#include <thread>
 
 using namespace std::chrono_literals;
 using std::placeholders::_1;
@@ -253,6 +254,11 @@ void MapoiNavServer::auto_publish_initial_pose()
     return;
   }
 
+  // AMCL より早く起動した場合の subscription readiness race を回避するため、
+  // /initialpose subscriber を一定時間 wait してから publish する (#33)。
+  // SwitchMap 等で AMCL が既に起動している経路では即時 return するので overhead なし。
+  wait_for_initialpose_subscriber(std::chrono::seconds(10));
+
   publish_initial_pose(matched[0].pose, "auto from POI '" + matched[0].name + "'");
   last_initial_pose_config_path_ = last_config_path_;
 }
@@ -269,6 +275,30 @@ void MapoiNavServer::publish_initial_pose(
   msg.pose.covariance[35] = 0.06853891945200942;
   nav2_initialpose_pub_->publish(msg);
   RCLCPP_INFO(this->get_logger(), "Published initial pose (%s).", source.c_str());
+}
+
+void MapoiNavServer::wait_for_initialpose_subscriber(std::chrono::seconds timeout)
+{
+  // 既に subscriber がいれば即 return (SwitchMap 等の AMCL 起動済み経路)
+  if (nav2_initialpose_pub_->get_subscription_count() > 0) {
+    return;
+  }
+  RCLCPP_INFO(this->get_logger(),
+    "Waiting for /initialpose subscriber (e.g. AMCL) up to %lds...",
+    static_cast<long>(timeout.count()));
+
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+    if (nav2_initialpose_pub_->get_subscription_count() > 0) {
+      RCLCPP_INFO(this->get_logger(), "/initialpose subscriber detected; proceeding to publish.");
+      return;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+  RCLCPP_WARN(this->get_logger(),
+    "/initialpose subscriber not detected within %lds; publishing anyway "
+    "(AMCL may miss the message; user can re-publish via WebUI/RViz/mapoi_initialpose_poi).",
+    static_cast<long>(timeout.count()));
 }
 
 void MapoiNavServer::on_route_received(rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture future)


### PR DESCRIPTION
## 概要

Close #33

`mapoi_nav_server` から `/initialpose` を自動 publish する経路 (#32 で追加) は、`mapoi_nav_server` が AMCL より早く起動したケースで、初回 publish が AMCL の subscription 確立前に行われて取りこぼされる race を持っていた。

## 背景: 案 A → 案 B への変更

issue #33 の本文では **案 A (publisher を transient_local 化)** を第一推奨としていたが、PR #55 で案 A を実装後、Codex round 1 で公式 ROS 2 QoS docs (https://docs.ros.org/en/humble/Concepts/Intermediate/About-Quality-of-Service-Settings.html) を確認した結果:

> `transient_local` publisher + `volatile` subscriber は接続互換性はあるが、**late-joiner に過去 sample を届けない** (`New messages only`)

Nav2 humble AMCL の `/initialpose` subscription は volatile (`SystemDefaultsQoS`) のため、**案 A 単独では race を構造的に解消できない** ことが判明した。

→ PR #55 を close し、本 PR で **案 B (subscriber readiness 待ちロジック)** を実装する。

## 変更内容

`MapoiNavServer::wait_for_initialpose_subscriber(std::chrono::seconds timeout)` を追加:

```cpp
void MapoiNavServer::wait_for_initialpose_subscriber(std::chrono::seconds timeout)
{
  if (nav2_initialpose_pub_->get_subscription_count() > 0) return;  // 既に ready なら即 return

  RCLCPP_INFO(...);
  const auto deadline = std::chrono::steady_clock::now() + timeout;
  while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
    if (nav2_initialpose_pub_->get_subscription_count() > 0) {
      RCLCPP_INFO(..., "subscriber detected; proceeding to publish.");
      return;
    }
    std::this_thread::sleep_for(std::chrono::milliseconds(200));
  }
  RCLCPP_WARN(..., "subscriber not detected within %lds; publishing anyway", ...);
}
```

`auto_publish_initial_pose()` 内の `publish_initial_pose()` 直前で `wait_for_initialpose_subscriber(10s)` を呼ぶ。

### 設計判断

- **wait の配置**: `auto_publish_initial_pose` のみ (`publish_initial_pose` 全体ではない)。手動 publish 経路 (`mapoi_initialpose_poi`) は user 操作のため AMCL 起動済み前提で OK
- **timeout 10s**: AMCL の典型的な起動時間 (1-3s) より十分長く、CI 環境の遅延も吸収
- **timeout 後の挙動**: skip ではなく **publish anyway** (best effort)。WARN log でユーザーに WebUI/RViz 経由の手動 publish を案内
- **blocking sleep**: single-thread executor 前提。startup 1 回のみで他 callback への影響は限定的 (10s 上限)
- **publisher QoS は変更しない**: 案 A 由来の transient_local 変更は (副次効果として有意でも) 案 B fix のスコープを超えるため revert

## 動作確認

```bash
colcon build --packages-up-to mapoi_server   # clean
colcon test --packages-select mapoi_server   # 全件 pass
```

## Test plan

- [x] Humble image でビルド + test 通過
- [x] Codex review (round 1〜)
- [ ] (実機検証推奨) AMCL 起動より早く mapoi_nav_server が起動する設定で、`Waiting for /initialpose subscriber` ログ → `subscriber detected; proceeding to publish` → AMCL particle が initial_pose POI に collapse、を確認

## 関連

- #9: `initial_pose` タグ仕様
- #32 (PR): 自動 publish 機能の実装 (本 PR が race 解消対象)
- #55: 案 A の試行 PR (close 済み、Codex 指摘で premise 誤りが判明)
