### PR TITLE
feat(nav_server): localization-agnostic Tier 1 — initial_pose topic/timeout を param 化、AMCL set_initial_pose 重複を解消 (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,17 +247,28 @@ maps/
 
 ### 3. AMCL パラメータの設定
 
-初期位置の自動設定や地図切り替え機能を利用する場合は、AMCL のパラメータに以下を追加します。
+初期位置は `mapoi_config.yaml` の `initial_pose` タグ付き POI を **single source of truth** として `mapoi_nav_server` が `/initialpose` topic に自動配信します。AMCL の `set_initial_pose` (Nav2 native の self-init) と二重管理にならないよう、AMCL 側はそれを無効化し、地図切り替えは `first_map_only_` を `False` にしてください。
 
 ```yaml
 amcl:
   ros__parameters:
-    # 初期位置の自動設定
-    set_initial_pose: True
-    initial_pose: {x: -2.0, y: -0.5, yaw: 0.0}
+    # 初期位置は mapoi_nav_server から /initialpose topic 経由で配信される
+    # POI single source of truth 化のため AMCL native の self-init は使わない
+    set_initial_pose: False
     # 地図切り替えの有効化
     first_map_only_: False
 ```
+
+initial_pose は `mapoi_config.yaml` 側で:
+
+```yaml
+poi:
+  - name: elevator_hall
+    pose: {x: -2.0, y: -0.5, yaw: 0.0}
+    tags: [goal, initial_pose]
+```
+
+別 topic 名・別 message 型を使う localization パッケージへの対応については [`mapoi_server/README.md`](./mapoi_server/README.md) の「対応 localization パッケージの要件」節を参照してください。
 
 ### 4. POI 半径イベントの利用（オプション）
 

--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -87,6 +87,8 @@ POI 名を指定した自律走行と、POI 半径イベント検知を行うノ
 | `hysteresis_exit_multiplier` | `double` | `1.15` | EXIT 判定の閾値倍率（チャタリング防止） |
 | `map_frame` | `string` | `map` | TF の親フレーム |
 | `base_frame` | `string` | `base_link` | TF の子フレーム |
+| `initial_pose_topic` | `string` | `/initialpose` | initial_pose の配信先 topic 名 (非 AMCL の localization に対応する場合に変更) |
+| `initial_pose_subscriber_wait_timeout_sec` | `double` | `10.0` | 自動 publish 前に subscriber readiness を待つ秒数 (起動の遅い localization は延長) |
 
 #### サブスクライバー
 
@@ -104,7 +106,7 @@ POI 名を指定した自律走行と、POI 半径イベント検知を行うノ
 
 | トピック名 | 型 | 説明 |
 | --- | --- | --- |
-| `initialpose` | `geometry_msgs/PoseWithCovarianceStamped` | 初期位置の配信。`mapoi_initialpose_poi` で明示指定された場合に加え、地図ロード/切替時に `initial_pose` タグ付き POI から自動配信 |
+| `initialpose` | `geometry_msgs/PoseWithCovarianceStamped` | 初期位置の配信 (topic 名は `initial_pose_topic` parameter で変更可)。`mapoi_initialpose_poi` で明示指定された場合に加え、地図ロード/切替時に `initial_pose` タグ付き POI から自動配信。自動 publish 前は subscriber readiness を最大 `initial_pose_subscriber_wait_timeout_sec` 秒待つ |
 | `goal_pose` | `geometry_msgs/PoseStamped` | ゴール位置の配信 |
 | `mapoi_nav_status` | `std_msgs/String` | ナビゲーション状態（`navigating`, `succeeded`, `aborted`, `canceled`, `paused`） |
 | `mapoi_poi_events` | `mapoi_interfaces/PoiEvent` | POI 侵入・退出イベント |
@@ -115,6 +117,19 @@ POI 名を指定した自律走行と、POI 半径イベント検知を行うノ
 | --- | --- | --- |
 | `follow_waypoints` | `nav2_msgs/FollowWaypoints` | ウェイポイント追従 |
 | `navigate_to_pose` | `nav2_msgs/NavigateToPose` | 単一ゴールナビゲーション |
+
+#### 対応 localization パッケージの要件
+
+mapoi_nav_server の自動 initial_pose 配信は、以下を満たす localization パッケージで動作します:
+
+- `geometry_msgs/PoseWithCovarianceStamped` を topic で受信できる (default `/initialpose`)
+- 動的 (起動後の SwitchMap) でも上記 topic 経由で初期位置を受け付ける
+
+**動作確認済み**: Nav2 AMCL (Humble / Jazzy)。
+
+**別 topic を使うパッケージ** (例: 自社実装) は、`initial_pose_topic` parameter で配信先を変更できます。受信 message 型が `PoseWithCovarianceStamped` でない場合は、launch 構成で adapter ノードを介する必要があります (将来的な adapter pattern は別 issue で検討予定)。
+
+**注意**: SwitchMap 経由の map 入替は現状 Nav2 `LoadMap` action 経由のため、Nav2 lifecycle に乗らない localization では map 入替動作の整合は別途検証・対応が必要です。
 
 #### POI 半径イベント検知
 

--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -139,10 +139,11 @@ private:
   void publish_initial_pose(
     const geometry_msgs::msg::Pose & pose, const std::string & source);
 
-  // /initialpose subscriber (主に AMCL) が ready になるまで待つ (#33)。
+  // initialpose subscriber (主に AMCL) が ready になるまで待つ (#33)。
   // subscriber が既に ready なら即 return。timeout 内に ready にならなければ WARN。
   // 200ms 間隔の polling で blocking wait する (single-thread executor 前提)。
-  void wait_for_initialpose_subscriber(std::chrono::seconds timeout);
+  // timeout_sec は parameter `initial_pose_subscriber_wait_timeout_sec` で調整可能 (#57)。
+  void wait_for_initialpose_subscriber(double timeout_sec);
 
   // 同一 config_path への重複 publish 防止
   std::string last_initial_pose_config_path_;

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -14,10 +14,17 @@ MapoiNavServer::MapoiNavServer(const rclcpp::NodeOptions & options)
 {
   this->get_logger().set_level(rclcpp::Logger::Level::Info);
 
+  // localization-agnostic 化のための parameter (#57):
+  // - initial_pose_topic: 配信先 topic 名 (default `/initialpose`、AMCL/slam_toolbox 等の de-facto standard)
+  // - initial_pose_subscriber_wait_timeout_sec: subscriber readiness 待ちの上限秒数 (起動の遅い localization 対応)
+  this->declare_parameter<std::string>("initial_pose_topic", "/initialpose");
+  this->declare_parameter<double>("initial_pose_subscriber_wait_timeout_sec", 10.0);
+
   // initialpose subscriber and publisher
   mapoi_initialpose_poi_sub_ = this->create_subscription<std_msgs::msg::String>(
     "mapoi_initialpose_poi", 1, std::bind(&MapoiNavServer::mapoi_initialpose_poi_cb, this, std::placeholders::_1));
-  nav2_initialpose_pub_ = this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("initialpose", 1);
+  nav2_initialpose_pub_ = this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    this->get_parameter("initial_pose_topic").as_string(), 1);
 
   // goal_pose subscriber and publisher
   mapoi_goal_pose_poi_sub_ = this->create_subscription<std_msgs::msg::String>(
@@ -254,10 +261,13 @@ void MapoiNavServer::auto_publish_initial_pose()
     return;
   }
 
-  // AMCL より早く起動した場合の subscription readiness race を回避するため、
-  // /initialpose subscriber を一定時間 wait してから publish する (#33)。
-  // SwitchMap 等で AMCL が既に起動している経路では即時 return するので overhead なし。
-  wait_for_initialpose_subscriber(std::chrono::seconds(10));
+  // localization (主に AMCL) より早く起動した場合の subscription readiness race を
+  // 回避するため、/initialpose subscriber を一定時間 wait してから publish する (#33)。
+  // SwitchMap 等で localization が既に起動している経路では即時 return するので overhead なし。
+  // timeout は parameter 化 (#57)、起動の遅い localization にも調整可能。
+  const double timeout_sec =
+    this->get_parameter("initial_pose_subscriber_wait_timeout_sec").as_double();
+  wait_for_initialpose_subscriber(timeout_sec);
 
   publish_initial_pose(matched[0].pose, "auto from POI '" + matched[0].name + "'");
   last_initial_pose_config_path_ = last_config_path_;
@@ -277,28 +287,28 @@ void MapoiNavServer::publish_initial_pose(
   RCLCPP_INFO(this->get_logger(), "Published initial pose (%s).", source.c_str());
 }
 
-void MapoiNavServer::wait_for_initialpose_subscriber(std::chrono::seconds timeout)
+void MapoiNavServer::wait_for_initialpose_subscriber(double timeout_sec)
 {
-  // 既に subscriber がいれば即 return (SwitchMap 等の AMCL 起動済み経路)
+  // 既に subscriber がいれば即 return (SwitchMap 等の localization 起動済み経路)
   if (nav2_initialpose_pub_->get_subscription_count() > 0) {
     return;
   }
   RCLCPP_INFO(this->get_logger(),
-    "Waiting for /initialpose subscriber (e.g. AMCL) up to %lds...",
-    static_cast<long>(timeout.count()));
+    "Waiting for initialpose subscriber (e.g. AMCL) up to %.1fs...", timeout_sec);
 
-  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  const auto deadline = std::chrono::steady_clock::now() +
+    std::chrono::milliseconds(static_cast<int>(timeout_sec * 1000));
   while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
     if (nav2_initialpose_pub_->get_subscription_count() > 0) {
-      RCLCPP_INFO(this->get_logger(), "/initialpose subscriber detected; proceeding to publish.");
+      RCLCPP_INFO(this->get_logger(), "initialpose subscriber detected; proceeding to publish.");
       return;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
   }
   RCLCPP_WARN(this->get_logger(),
-    "/initialpose subscriber not detected within %lds; publishing anyway "
-    "(AMCL may miss the message; user can re-publish via WebUI/RViz/mapoi_initialpose_poi).",
-    static_cast<long>(timeout.count()));
+    "initialpose subscriber not detected within %.1fs; publishing anyway "
+    "(localization may miss the message; user can re-publish via WebUI/RViz/mapoi_initialpose_poi).",
+    timeout_sec);
 }
 
 void MapoiNavServer::on_route_received(rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture future)

--- a/mapoi_turtlebot3_example/param/humble/burger.yaml
+++ b/mapoi_turtlebot3_example/param/humble/burger.yaml
@@ -38,9 +38,9 @@ amcl:
     z_rand: 0.5
     z_short: 0.05
     scan_topic: scan
-    # Added parameters for initial pose
-    set_initial_pose: True
-    initial_pose: {x: -2.0, y: -0.5, yaw: 0.0}
+    # initial_pose は mapoi_nav_server から /initialpose topic で配信される (#57)
+    # POI single source of truth 化のため AMCL native の self-init は使わない
+    set_initial_pose: False
     # Added parameter to switch maps
     first_map_only_: False
 

--- a/mapoi_turtlebot3_example/param/jazzy/burger.yaml
+++ b/mapoi_turtlebot3_example/param/jazzy/burger.yaml
@@ -38,16 +38,12 @@ amcl:
     z_short: 0.05
     scan_topic: scan
     map_topic: map
-    # Enabled for mapoi initial pose auto-setting
-    set_initial_pose: true
+    # initial_pose は mapoi_nav_server から /initialpose topic で配信される (#57)
+    # POI single source of truth 化のため AMCL native の self-init は使わない
+    set_initial_pose: false
     always_reset_initial_pose: false
     # Enabled for mapoi map switching
     first_map_only: false
-    initial_pose:
-      x: -2.0
-      y: -0.5
-      z: 0.0
-      yaw: 0.0
 
 bt_navigator:
   ros__parameters:


### PR DESCRIPTION
## 概要

Close #57

将来 AMCL 以外の自己位置推定パッケージ (slam_toolbox localization mode、FAST-LIO、自社実装等) を mapoi 経由で動かすケースに備えた最小コスト改修 (Tier 1)。あわせて `burger.yaml` の `set_initial_pose` と mapoi POI の `initial_pose` の重複も解消する。

## 変更内容

### 1. mapoi_nav_server の parameter 化

| パラメータ名 | default | 用途 |
|---|---|---|
| `initial_pose_topic` | `/initialpose` | 配信先 topic 名 (非 AMCL の localization に対応する場合に変更) |
| `initial_pose_subscriber_wait_timeout_sec` | `10.0` | 自動 publish 前に subscriber readiness を待つ秒数 |

### 2. `wait_for_initialpose_subscriber` の signature 変更

`std::chrono::seconds` → `double timeout_sec` に変更し、parameter の `double` 値を直接渡せるように。出力ログも fractional 対応 (`%.1fs`)。

### 3. AMCL params の重複解消

`mapoi_turtlebot3_example/param/{humble,jazzy}/burger.yaml`:
- `set_initial_pose` を `True/true` → `False/false` に変更
- `initial_pose: {x: -2.0, y: -0.5, yaw: 0.0}` の hardcoded 値を **削除**
- 効果: first map の初期化も `mapoi_nav_server` の自動 publish 経路 (POI ベース) に統一される
- race 問題は PR #56 (#33) の subscriber wait で構造的に解消済みのため発生しない

これで mapoi POI が **真の single source of truth** になる (AMCL params との手動同期が不要)。

### 4. README 整備

`mapoi_server/README.md`:
- パラメータ表に上記 2 件追加
- **「対応 localization パッケージの要件」節を新設**:
  - `PoseWithCovarianceStamped` を topic で受信できれば動作 (動作確認済み: Nav2 AMCL Humble/Jazzy)
  - 別 topic 名のパッケージは `initial_pose_topic` parameter で対応
  - 別 message 型のパッケージは adapter ノード経由が必要 (将来 Tier 2 で検討)
  - SwitchMap は現状 Nav2 `LoadMap` 経由のため、Nav2 lifecycle 非対応 localization では別途検証が必要

## スコープ外 (将来の別 issue で検討)

- **Tier 2**: 中間 topic (`/mapoi_set_initial_pose`) + adapter pattern (`mapoi_amcl_adapter` 等)
- **Tier 2**: SwitchMap の map 入替 strategy 化 (Nav2 LoadMap 以外の対応)
- **Tier 3**: pluginlib 化

→ いずれも **実需が出てから検討** (YAGNI)。本 PR は最小コストで「将来の選択肢を残す」ことに focus。

## 動作確認

- Humble image: colcon build + colcon test 全件 pass
- regression check: 既存 launch_test (4 件) 全 pass、initial_pose 関連の既存挙動は維持

## Test plan

- [x] Humble image でビルド + test 通過
- [x] AMCL params の hardcoded initial_pose 削除後も既存テストが pass
- [ ] (実機検証推奨) `set_initial_pose: False` 状態で起動 → mapoi_nav_server の自動 publish (subscriber wait 経由) で AMCL particle が初回から initial_pose POI に集約することを確認
- [ ] Codex review

## 関連

- #33 (PR #56): subscriber readiness wait の実装 (本 PR の前提)
- #20: rosdep 配布 (distro/環境横断対応の前提として localization-agnostic 化が望ましい)
