### PR TITLE
feat(mapoi_webui): tag_definitions 取得を get_tag_definitions service 経由に切替 (#39)

### DIFF
--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -38,7 +38,7 @@ Web UI も使う場合は `mapoi_webui.launch.yaml` も併せて include:
       - {name: map_name, value: "initial_map_name"}
 ```
 
-> **NOTE**: `mapoi_webui` は現状 `mapoi_server` の share 配下 `maps/tag_definitions.yaml` を runtime 参照します (システムタグの表示に使用)。そのため `mapoi_webui` 単体を起動する場合も `mapoi_server` パッケージがインストール済みである必要があります。将来的に service 化する予定 (#39)。
+> **NOTE**: `mapoi_webui` はシステムタグを `mapoi_server` の `get_tag_definitions` service 経由で取得します。`mapoi_webui` 単体を起動しても system tags の表示は service 通信になるため、`mapoi_server` の package install 自体は不要 (ただし service responder として `mapoi_server` ノードが起動している必要あり)。
 
 TurtleBot3 を使った動作例は `mapoi_turtlebot3_example` パッケージを参照してください。
 

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -160,6 +160,10 @@ class MapoiWebNode(Node):
         Flask thread はここで future.done() を polling する。spin_until_future_complete を
         Flask thread から呼ぶと main thread の spin と executor を競合させるので避ける。
 
+        実効最長待ち時間 ≒ wait_for_service_sec + timeout_sec (default 5s)。
+        timeout 時は future.cancel() で pending request を解放する (helper の
+        繰り返し呼び出しで cancel 忘れ future が蓄積しないように)。
+
         Args:
             client: rclpy service client
             request: service request message
@@ -177,6 +181,7 @@ class MapoiWebNode(Node):
         deadline = time.monotonic() + timeout_sec
         while not future.done():
             if time.monotonic() > deadline:
+                future.cancel()
                 self.get_logger().warn(f'{service_name} call timed out after {timeout_sec}s')
                 return None
             time.sleep(0.05)

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -5,17 +5,18 @@ import math
 import os
 import logging
 import threading
+import time
 
 import rclpy
 from rclpy.node import Node
 from std_msgs.msg import String
 from std_srvs.srv import Trigger
-from mapoi_interfaces.srv import GetMapsInfo
+from mapoi_interfaces.srv import GetMapsInfo, GetTagDefinitions
 import tf2_ros
 
 from flask import Flask, jsonify, request, send_from_directory, Response
 
-from mapoi_webui.yaml_handler import load_config, save_pois, save_routes, save_custom_tags, get_pois, get_routes, get_tag_definitions
+from mapoi_webui.yaml_handler import load_config, save_pois, save_routes, save_custom_tags, get_pois, get_routes
 from mapoi_webui.map_image import get_map_metadata, get_map_png
 
 
@@ -43,6 +44,7 @@ class MapoiWebNode(Node):
         # ROS2 service clients
         self.reload_client_ = self.create_client(Trigger, 'reload_map_info')
         self.get_maps_client_ = self.create_client(GetMapsInfo, 'get_maps_info')
+        self.tag_defs_client_ = self.create_client(GetTagDefinitions, 'get_tag_definitions')
 
         # Navigation publishers
         self.goal_poi_pub_ = self.create_publisher(String, 'mapoi_goal_pose_poi', 10)
@@ -68,18 +70,8 @@ class MapoiWebNode(Node):
         self.config_path_sub_ = self.create_subscription(
             String, 'mapoi_config_path', self.config_path_callback, 10)
 
-        # Resolve system tag_definitions.yaml from mapoi_server package
-        self.system_tags_path_ = ''
-        try:
-            from ament_index_python.packages import get_package_share_directory
-            self.system_tags_path_ = os.path.join(
-                get_package_share_directory('mapoi_server'), 'maps', 'tag_definitions.yaml')
-        except Exception:
-            # Fallback: try sibling directory
-            pkg_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            fallback = os.path.join(os.path.dirname(pkg_dir), 'mapoi_server', 'maps', 'tag_definitions.yaml')
-            if os.path.exists(fallback):
-                self.system_tags_path_ = fallback
+        # tag_definitions は mapoi_server の get_tag_definitions service から取得 (#39)。
+        # share/ ファイル直読みを廃止し、ROS 2 service 経由で結合度を下げた。
 
         # If maps_path not set, try to get it from get_maps_info service or use default
         if not self.maps_path_:
@@ -159,6 +151,40 @@ class MapoiWebNode(Node):
         # We don't block here since we're in Flask thread; fire and forget
         self.get_logger().info('Called reload_map_info')
         return True
+
+    def _call_service_sync(self, client, request, service_name, timeout_sec=3.0,
+                           wait_for_service_sec=2.0):
+        """Call ROS 2 service from Flask thread and wait for the response.
+
+        SingleThreadedExecutor で main thread の rclpy.spin が future を resolve するため、
+        Flask thread はここで future.done() を polling する。spin_until_future_complete を
+        Flask thread から呼ぶと main thread の spin と executor を競合させるので避ける。
+
+        Args:
+            client: rclpy service client
+            request: service request message
+            service_name: service name for logging
+            timeout_sec: 全体の wait timeout (default 3.0s)
+            wait_for_service_sec: service discovery の wait timeout (default 2.0s)
+
+        Returns:
+            response object on success, None on timeout / unavailability / exception.
+        """
+        if not client.wait_for_service(timeout_sec=wait_for_service_sec):
+            self.get_logger().warn(f'{service_name} service not available')
+            return None
+        future = client.call_async(request)
+        deadline = time.monotonic() + timeout_sec
+        while not future.done():
+            if time.monotonic() > deadline:
+                self.get_logger().warn(f'{service_name} call timed out after {timeout_sec}s')
+                return None
+            time.sleep(0.05)
+        try:
+            return future.result()
+        except Exception as e:
+            self.get_logger().error(f'{service_name} call exception: {e}')
+            return None
 
     def get_maps_list(self):
         """Get list of available maps from maps_path directory."""
@@ -266,8 +292,15 @@ class MapoiWebNode(Node):
 
         @app.route('/api/tag_definitions')
         def api_tag_definitions():
-            config_path = node.get_config_path()
-            tags = get_tag_definitions(node.system_tags_path_, config_path)
+            # mapoi_server の get_tag_definitions service 経由で system + custom 両方を取得 (#39)
+            response = node._call_service_sync(
+                node.tag_defs_client_, GetTagDefinitions.Request(), 'get_tag_definitions')
+            if response is None:
+                return jsonify({'error': 'get_tag_definitions service unavailable or timed out'}), 503
+            tags = [
+                {'name': d.name, 'description': d.description, 'is_system': d.is_system}
+                for d in response.definitions
+            ]
             return jsonify({'tags': tags})
 
         @app.route('/api/custom_tags', methods=['POST'])

--- a/mapoi_webui/mapoi_webui/yaml_handler.py
+++ b/mapoi_webui/mapoi_webui/yaml_handler.py
@@ -4,7 +4,6 @@ Reads/writes mapoi_config.yaml, replacing only the 'poi' section
 while preserving 'map' and 'route' sections and unknown fields.
 """
 
-import os
 import yaml
 
 
@@ -50,42 +49,6 @@ def get_routes(config_path):
     """Read route list from config file."""
     config = load_config(config_path)
     return config.get('route', [])
-
-
-def get_tag_definitions(system_tags_path, config_path):
-    """Read tag definitions from system tag_definitions.yaml and per-map custom_tags.
-
-    Args:
-        system_tags_path: Path to mapoi_server's maps/tag_definitions.yaml
-        config_path: Path to current map's mapoi_config.yaml
-
-    Returns:
-        List of dicts: [{'name': str, 'description': str, 'is_system': bool}, ...]
-    """
-    tags = []
-
-    # System tags
-    if os.path.exists(system_tags_path):
-        with open(system_tags_path, 'r') as f:
-            data = yaml.safe_load(f)
-        for tag in (data or {}).get('tags', []):
-            tags.append({
-                'name': tag.get('name', ''),
-                'description': tag.get('description', ''),
-                'is_system': True,
-            })
-
-    # User tags from per-map config
-    if os.path.exists(config_path):
-        config = load_config(config_path)
-        for tag in config.get('custom_tags', []):
-            tags.append({
-                'name': tag.get('name', ''),
-                'description': tag.get('description', ''),
-                'is_system': False,
-            })
-
-    return tags
 
 
 def save_custom_tags(config_path, custom_tags):

--- a/mapoi_webui/package.xml
+++ b/mapoi_webui/package.xml
@@ -22,11 +22,8 @@
   <exec_depend>python3-flask</exec_depend>
   <exec_depend>python3-pil</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
-
-  <!-- mapoi_webui_node.py が get_package_share_directory('mapoi_server') で
-       maps/tag_definitions.yaml を runtime 参照するため。
-       #40 で mapoi_server → mapoi_webui の依存が消えたため、循環しない。 -->
-  <exec_depend>mapoi_server</exec_depend>
+  <!-- mapoi_server への依存は #39 で解消 (tag_definitions を service 経由に変更)。
+       runtime には mapoi_server ノードが起動している必要があるが、package install 依存は不要。 -->
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## 概要

Close #39

`mapoi_webui` が `mapoi_server` の `share/maps/tag_definitions.yaml` を直読み (private 領域踏み込み = ROS 2 anti-pattern) していた pattern を解消し、ROS 2 service (`mapoi_interfaces/srv/GetTagDefinitions`) 経由に切替。webui → mapoi_server の package install 依存を runtime service 通信に置換し、結合度を下げる。

## 変更内容

### 1. `mapoi_webui_node.py`
- `GetTagDefinitions` service client を追加
- `system_tags_path_` 解決ブロック (`get_package_share_directory('mapoi_server')` + fallback) を削除
- helper `_call_service_sync(client, request, service_name, timeout_sec, wait_for_service_sec)` を追加
- `/api/tag_definitions` endpoint を service 呼び出しに置換、service 不可時は `503 Service Unavailable` を返す
- import から `get_tag_definitions` (yaml_handler) を削除

### 2. `yaml_handler.py`
- `get_tag_definitions()` 関数を削除 (mapoi_webui 全体で他から未使用)
- `import os` を削除 (関数削除に伴い未使用化)

### 3. `mapoi_webui/package.xml`
- `<exec_depend>mapoi_server</exec_depend>` を削除
- 注記コメントも新方針に更新

### 4. `mapoi_server/README.md`
- webui の依存に関する NOTE を「service 経由に解消済み」に更新

## 設計判断: Flask thread から rclpy service を呼ぶ thread safety

`/api/tag_definitions` は **response が必要** な endpoint なので、既存 `reload_client_` の fire-and-forget pattern は使えない。検討した選択肢:

| 案 | 内容 | 採否 |
|---|---|---|
| **A: call_async + future.done() polling** | Flask thread で `time.sleep(0.05)` polling、main thread の `rclpy.spin` が future を resolve | **採用** |
| B: Flask thread から `spin_until_future_complete` | 直接 spin | ✕ main thread の spin と executor 競合、undefined behavior |
| C: MultiThreadedExecutor + ReentrantCallbackGroup に全面切替 | 構造変更 | ✕ scope 過大 |
| D: 起動時 1 回 cache | static 仮定 | ✕ tag_definitions.yaml 編集や custom_tags 変更に追従できない |

→ **案 A**: `_call_service_sync` helper として実装。SingleThreadedExecutor のままで安全、timeout 入れて mapoi_server 未起動時も hang しない。将来 response 必要な service 呼び出しが増えれば同 helper を再利用可能。

## 動作確認 (Humble)

```bash
colcon build --packages-up-to mapoi_webui   # clean
```

実機 launch + curl:
```bash
ros2 launch mapoi_server mapoi_bringup.launch.yaml maps_path:=... map_name:=turtlebot3_world &
ros2 launch mapoi_webui mapoi_webui.launch.yaml maps_path:=... map_name:=turtlebot3_world &
sleep 12
curl -sS http://localhost:8765/api/tag_definitions
```

レスポンス:
```json
{"tags":[
  {"name":"goal","description":"Navigation goal destination","is_system":true},
  {"name":"origin","description":"Map origin reference point","is_system":true},
  {"name":"pause","description":"Automatically pause navigation when robot enters the POI radius","is_system":true},
  {"name":"initial_pose","description":"Initial pose for localization (e.g. AMCL); auto-published on map load/switch","is_system":true},
  {"name":"event","description":"Event trigger area","is_system":false},
  {"name":"destination","description":"General destination point","is_system":false},
  {"name":"landmark","description":"Landmark for guidance","is_system":false},
  {"name":"audio_info","description":"Audio guide trigger","is_system":false}
]}
```

system 4 件 + custom 4 件 = 計 8 タグが service 経由で正しく取得できることを確認。

## Test plan

- [x] Humble で colcon build clean
- [x] launch 後 `/api/tag_definitions` が system + custom タグを正しく返す
- [x] `ros2 service list` で `/get_tag_definitions` が現れる (mapoi_server 提供)
- [x] Codex review

## 関連
- #40 (PR #43): 循環依存の片側 (mapoi_server → mapoi_webui) を解消した先行 PR
