### PR TITLE
feat(mapoi_webui): editor 用 launch + service/publisher graceful handling (#60)

### DIFF
--- a/mapoi_server/launch/mapoi_bringup.launch.yaml
+++ b/mapoi_server/launch/mapoi_bringup.launch.yaml
@@ -70,15 +70,13 @@ launch:
     name: with_nav_server
     default: "true"
     description: >
-      mapoi_nav_server の起動制御 (#60)。default true で従来通り起動。
-      editor 用途 (POI/Route 編集のみ) など、Nav2 連携が不要な場合は false で起動を抑止。
+      mapoi_nav_server を起動するか。Nav2 連携が不要な構成 (POI/Route 編集のみの editor 用途等) で false。
 
 - arg:
     name: with_rviz_publisher
     default: "true"
     description: >
-      mapoi_rviz2_publisher の起動制御 (#60)。default true で従来通り起動。
-      RViz を使わない (例: WebUI のみ、headless 編集) 場合は false で marker publish を抑止。
+      mapoi_rviz2_publisher を起動するか。RViz を使わない構成 (WebUI のみ、headless 編集等) で false。
 
 # core 3 nodes (常時起動)
 - node:

--- a/mapoi_server/launch/mapoi_bringup.launch.yaml
+++ b/mapoi_server/launch/mapoi_bringup.launch.yaml
@@ -66,6 +66,20 @@ launch:
       呼ぶため、gz_sim 起動時の world 名 (SDF の <world name="..."> 値) と一致する必要がある。
       simulator=gz のときのみ使用。
 
+- arg:
+    name: with_nav_server
+    default: "true"
+    description: >
+      mapoi_nav_server の起動制御 (#60)。default true で従来通り起動。
+      editor 用途 (POI/Route 編集のみ) など、Nav2 連携が不要な場合は false で起動を抑止。
+
+- arg:
+    name: with_rviz_publisher
+    default: "true"
+    description: >
+      mapoi_rviz2_publisher の起動制御 (#60)。default true で従来通り起動。
+      RViz を使わない (例: WebUI のみ、headless 編集) 場合は false で marker publish を抑止。
+
 # core 3 nodes (常時起動)
 - node:
     pkg: mapoi_server
@@ -79,10 +93,12 @@ launch:
 - node:
     pkg: mapoi_server
     exec: mapoi_nav_server
+    if: $(var with_nav_server)
 
 - node:
     pkg: mapoi_server
     exec: mapoi_rviz2_publisher
+    if: $(var with_rviz_publisher)
 
 # Gazebo Classic 連動 (Humble): SwitchMap 時に world_model entity を入れ替え +
 # ロボットを initial_pose POI 座標に再生成 (Gazebo 本体は無停止)。

--- a/mapoi_webui/README.md
+++ b/mapoi_webui/README.md
@@ -75,13 +75,69 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 | POST | `/api/nav/cancel` | ナビゲーションの停止 |
 | POST | `/api/nav/initialpose` | 自己位置推定のリセット |
 
-## 起動方法
+## 起動方法 (3 つのシナリオ)
+
+利用目的に応じて 3 つの起動方法を使い分けてください。いずれもブラウザで `http://<ホスト>:8765` にアクセスします。
+
+### A. webui のみ起動 (オペレーター用、`mapoi_server` を別プロセスで起動済み)
+
+ロボットが既に動いている (`mapoi_server` / `mapoi_nav_server` 等が別プロセスで稼働) 状態で、RViz の代替 UI として webui を後付けする用途。
 
 ```bash
 ros2 launch mapoi_webui mapoi_webui.launch.yaml maps_path:=/path/to/maps map_name:=your_map
 ```
 
-ブラウザで `http://<ホスト>:8765` にアクセスしてください。
+### B. webui + mapoi_server を一緒に起動 (エディター用)
+
+PC でデスクトップ上の POI/Route/CustomTags 編集だけ行いたい用途 (ロボット動作 / Nav2 / RViz は不要)。`mapoi_bringup` を minimal config (`with_nav_server=false`, `with_rviz_publisher=false`, `simulator=none`) で include する。
+
+```bash
+ros2 launch mapoi_webui mapoi_editor.launch.yaml maps_path:=/path/to/maps map_name:=your_map
+```
+
+### C. 統合運用 / デモ (Nav2 + sim + webui を全部)
+
+`mapoi_turtlebot3_example` の `turtlebot3_navigation.launch.yaml` のような bringup + webui 統合 launch を使う。詳細はそのパッケージの README を参照。
+
+## REST API と server 依存
+
+各 endpoint が `mapoi_server` (or `mapoi_nav_server`) の起動を必要とするかの早見表:
+
+| endpoint | server 必要 | 理由 |
+|---|---|---|
+| `GET /api/maps` `/maps/<name>/image\|metadata` | 不要 | `maps_path` を直 ls / YAML/PNG 直読み |
+| `GET /api/pois` `/api/routes` | 不要 | YAML 直読み |
+| `POST /api/pois` `/api/routes` `/api/custom_tags` | **必要** | YAML 書き込み後に `reload_map_info` service を呼ぶ |
+| `GET /api/tag_definitions` | **必要** | `get_tag_definitions` service 経由 |
+| `POST /api/nav/{goal,route,cancel,pause,resume,initialpose}` | **必要 (mapoi_nav_server)** | publisher → nav_server が listener、subscriber 0 件なら warning を返す |
+| `GET /api/nav/status` | 不要 (subscriber 経由で受信値返却) | nav_server がいなければ default 値 |
+
+server / nav_server 不在時の挙動:
+- service 必須 endpoint: `503 Service Unavailable` を返す (timeout)
+- publisher 系 endpoint: `200 OK` だが `warning` フィールドに「subscriber 不在」を含める
+
+## 開発者規約
+
+### Flask thread から ROS 2 service を呼ぶ場合
+
+**必ず `MapoiWebNode._call_service_sync()` 経由で呼ぶ**。直接 `client.call_async()` を fire-and-forget したり、`spin_until_future_complete()` を Flask thread から呼ぶのは禁止 (前者は silent failure、後者は main thread の `rclpy.spin` と executor 競合)。
+
+```python
+response = node._call_service_sync(
+    node.some_client_, SomeReq(), 'some_service', timeout_sec=3.0)
+if response is None:
+    return jsonify({'error': 'service unavailable'}), 503
+```
+
+### Flask thread から ROS 2 publish する場合
+
+**必ず `MapoiWebNode.publish_with_subscriber_check()` 経由で publish する**。subscriber 0 件 (例: `mapoi_nav_server` 未起動) の silent failure を避けるため。
+
+```python
+_, warning = node.publish_with_subscriber_check(
+    node.some_pub_, msg, 'some_topic')
+return jsonify({'success': True, 'warning': warning} if warning else {'success': True})
+```
 
 ## 依存パッケージ
 

--- a/mapoi_webui/README.md
+++ b/mapoi_webui/README.md
@@ -112,9 +112,10 @@ ros2 launch mapoi_webui mapoi_editor.launch.yaml maps_path:=/path/to/maps map_na
 | `POST /api/nav/{goal,route,cancel,pause,resume,initialpose}` | **必要 (mapoi_nav_server)** | publisher → nav_server が listener、subscriber 0 件なら warning を返す |
 | `GET /api/nav/status` | 不要 (subscriber 経由で受信値返却) | nav_server がいなければ default 値 |
 
-server / nav_server 不在時の挙動:
-- service 必須 endpoint: `503 Service Unavailable` を返す (timeout)
-- publisher 系 endpoint: `200 OK` だが `warning` フィールドに「subscriber 不在」を含める
+server / nav_server 不在時の挙動 (endpoint カテゴリ別):
+- `GET /api/tag_definitions`: `503 Service Unavailable` (service 必須、unavailable / timeout 時)
+- `POST /api/pois` / `/api/routes` / `/api/custom_tags`: `200 OK` + `warning` フィールド (YAML 書き込み自体は成功するため、`reload_map_info` の unavailable / timeout / failure は warning として通知)
+- `POST /api/nav/{goal,route,cancel,pause,resume,initialpose}`: `200 OK` + `warning` フィールド (publish 自体は成功扱い、subscriber 不在を best-effort で検出して通知)
 
 ## 開発者規約
 

--- a/mapoi_webui/launch/mapoi_editor.launch.yaml
+++ b/mapoi_webui/launch/mapoi_editor.launch.yaml
@@ -48,12 +48,10 @@ launch:
       - {name: with_nav_server, value: "false"}
       - {name: with_rviz_publisher, value: "false"}
 
-# WebUI (POI/Route 編集 UI)
-- node:
-    pkg: mapoi_webui
-    exec: mapoi_webui_node.py
-    output: "screen"
-    param:
+# WebUI (POI/Route 編集 UI) — 既存 mapoi_webui.launch.yaml を include して DRY 化
+- include:
+    file: "$(find-pkg-share mapoi_webui)/launch/mapoi_webui.launch.yaml"
+    arg:
       - {name: maps_path, value: "$(var maps_path)"}
       - {name: map_name, value: "$(var map_name)"}
       - {name: config_file, value: "$(var config_file)"}

--- a/mapoi_webui/launch/mapoi_editor.launch.yaml
+++ b/mapoi_webui/launch/mapoi_editor.launch.yaml
@@ -1,0 +1,61 @@
+# mapoi editor: デスクトップで POI / Route / CustomTags を編集する用途の standalone launch (#60)。
+# mapoi_bringup を minimal config (nav_server / rviz_publisher / sim 全て off) で include +
+# mapoi_webui を起動する。ロボット動作 / ナビゲーション系は起動しない。
+#
+# 用途:
+# - PC で POI 一覧を編集してリポジトリにコミット
+# - 現場 / 実機を立ち上げずに mapoi_config.yaml を整備
+#
+# robot を制御したい / ナビ操作も含む統合 UI が欲しい場合は、example の
+# turtlebot3_navigation.launch.yaml のような bringup + webui 統合 launch を使うこと。
+# webui だけを起動 (mapoi_server 別プロセス) したい場合は mapoi_webui.launch.yaml。
+
+launch:
+
+- arg:
+    name: maps_path
+    description: "Full path to maps directory (REQUIRED)"
+
+- arg:
+    name: map_name
+    default: "turtlebot3_world"
+    description: "Initial map name"
+
+- arg:
+    name: config_file
+    default: "mapoi_config.yaml"
+    description: "Config file name inside each map directory"
+
+- arg:
+    name: web_port
+    default: "8765"
+    description: "HTTP server port"
+
+- arg:
+    name: web_host
+    default: "0.0.0.0"
+    description: "HTTP server bind address"
+
+# mapoi_server を minimal で起動 (nav_server / rviz_publisher / sim bridge は起動しない)。
+# graceful service handling は mapoi_webui 側 (#60) で実装済み。
+- include:
+    file: "$(find-pkg-share mapoi_server)/launch/mapoi_bringup.launch.yaml"
+    arg:
+      - {name: maps_path, value: "$(var maps_path)"}
+      - {name: map_name, value: "$(var map_name)"}
+      - {name: config_file, value: "$(var config_file)"}
+      - {name: simulator, value: "none"}
+      - {name: with_nav_server, value: "false"}
+      - {name: with_rviz_publisher, value: "false"}
+
+# WebUI (POI/Route 編集 UI)
+- node:
+    pkg: mapoi_webui
+    exec: mapoi_webui_node.py
+    output: "screen"
+    param:
+      - {name: maps_path, value: "$(var maps_path)"}
+      - {name: map_name, value: "$(var map_name)"}
+      - {name: config_file, value: "$(var config_file)"}
+      - {name: web_port, value: "$(var web_port)"}
+      - {name: web_host, value: "$(var web_host)"}

--- a/mapoi_webui/launch/mapoi_editor.launch.yaml
+++ b/mapoi_webui/launch/mapoi_editor.launch.yaml
@@ -1,4 +1,4 @@
-# mapoi editor: デスクトップで POI / Route / CustomTags を編集する用途の standalone launch (#60)。
+# mapoi editor: デスクトップで POI / Route / CustomTags を編集する用途の standalone launch。
 # mapoi_bringup を minimal config (nav_server / rviz_publisher / sim 全て off) で include +
 # mapoi_webui を起動する。ロボット動作 / ナビゲーション系は起動しない。
 #
@@ -37,7 +37,6 @@ launch:
     description: "HTTP server bind address"
 
 # mapoi_server を minimal で起動 (nav_server / rviz_publisher / sim bridge は起動しない)。
-# graceful service handling は mapoi_webui 側 (#60) で実装済み。
 - include:
     file: "$(find-pkg-share mapoi_server)/launch/mapoi_bringup.launch.yaml"
     arg:
@@ -48,7 +47,7 @@ launch:
       - {name: with_nav_server, value: "false"}
       - {name: with_rviz_publisher, value: "false"}
 
-# WebUI (POI/Route 編集 UI) — 既存 mapoi_webui.launch.yaml を include して DRY 化
+# WebUI (POI/Route 編集 UI)
 - include:
     file: "$(find-pkg-share mapoi_webui)/launch/mapoi_webui.launch.yaml"
     arg:

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -168,6 +168,12 @@ class MapoiWebNode(Node):
         subscriber 不在 (mapoi_nav_server 未起動等) を silent failure させずに
         warning として返したい。
 
+        **best-effort**: `get_subscription_count()` と `publish()` の間で
+        subscriber 状態が変わる可能性 (race) があり、check 通過後に subscriber が
+        消える / check 失敗後に publish 直前に subscriber が現れる、を完全に
+        排除はできない。「明らかな未起動」を検出する目的のみで、厳密な到達
+        確認が必要な場合は service / action / ack 設計に切り替えること。
+
         Args:
             pub: rclpy publisher
             msg: message to publish
@@ -323,7 +329,13 @@ class MapoiWebNode(Node):
                 return jsonify({'error': 'Config not found'}), 404
             try:
                 save_pois(config_path, data['pois'])
-                node.call_reload_map_info()
+                reloaded = node.call_reload_map_info()
+                if not reloaded:
+                    return jsonify({
+                        'success': True,
+                        'warning': 'YAML は保存しましたが、mapoi_server の reload_map_info '
+                                   'service が応答しなかったか失敗しました。詳細はログを確認してください'
+                    })
                 return jsonify({'success': True})
             except Exception as e:
                 node.get_logger().error(f'Failed to save POIs: {e}')
@@ -352,7 +364,13 @@ class MapoiWebNode(Node):
                 return jsonify({'error': 'Config not found'}), 404
             try:
                 save_custom_tags(config_path, data['custom_tags'])
-                node.call_reload_map_info()
+                reloaded = node.call_reload_map_info()
+                if not reloaded:
+                    return jsonify({
+                        'success': True,
+                        'warning': 'YAML は保存しましたが、mapoi_server の reload_map_info '
+                                   'service が応答しなかったか失敗しました。詳細はログを確認してください'
+                    })
                 return jsonify({'success': True})
             except Exception as e:
                 node.get_logger().error(f'Failed to save custom tags: {e}')
@@ -376,7 +394,13 @@ class MapoiWebNode(Node):
                 return jsonify({'error': 'Config not found'}), 404
             try:
                 save_routes(config_path, data['routes'])
-                node.call_reload_map_info()
+                reloaded = node.call_reload_map_info()
+                if not reloaded:
+                    return jsonify({
+                        'success': True,
+                        'warning': 'YAML は保存しましたが、mapoi_server の reload_map_info '
+                                   'service が応答しなかったか失敗しました。詳細はログを確認してください'
+                    })
                 return jsonify({'success': True})
             except Exception as e:
                 node.get_logger().error(f'Failed to save routes: {e}')

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -70,9 +70,6 @@ class MapoiWebNode(Node):
         self.config_path_sub_ = self.create_subscription(
             String, 'mapoi_config_path', self.config_path_callback, 10)
 
-        # tag_definitions は mapoi_server の get_tag_definitions service から取得 (#39)。
-        # share/ ファイル直読みを廃止し、ROS 2 service 経由で結合度を下げた。
-
         # If maps_path not set, try to get it from get_maps_info service or use default
         if not self.maps_path_:
             self.get_logger().warn('maps_path parameter not set. Set it to use the web editor.')
@@ -142,13 +139,10 @@ class MapoiWebNode(Node):
         return os.path.join(self.maps_path_, name)
 
     def call_reload_map_info(self):
-        """Call reload_map_info service on mapoi_server, awaiting response.
+        """Call reload_map_info service and await response.success.
 
-        #60: 旧実装は call_async fire-and-forget で response を見ていなかったため、
-        server reload 失敗 (YAML 破損等) が silent failure になっていた。
-        _call_service_sync で response.success を確認するように改修。
-
-        Returns: True on server-side success, False on unavailable/timeout/server failure.
+        Returns True only when server reports success; False on
+        unavailable / timeout / server-side failure.
         """
         response = self._call_service_sync(
             self.reload_client_, Trigger.Request(), 'reload_map_info', timeout_sec=3.0)
@@ -161,18 +155,16 @@ class MapoiWebNode(Node):
         return True
 
     def publish_with_subscriber_check(self, pub, msg, topic_name):
-        """Publish a message with subscriber-count check (#60).
+        """Publish with best-effort subscriber-count check.
 
-        ROS 2 publisher.publish() は subscriber がいなくても成功扱い。
-        webui のような UI から「ボタン押した結果」を user に返すケースでは、
-        subscriber 不在 (mapoi_nav_server 未起動等) を silent failure させずに
-        warning として返したい。
+        ROS 2 `publisher.publish()` は subscriber がいなくても成功扱いになる。
+        UI ボタン経由の publish では subscriber 不在 (相手 node 未起動等) を
+        silent failure にせず warning として user に返したい場面がある。
 
         **best-effort**: `get_subscription_count()` と `publish()` の間で
-        subscriber 状態が変わる可能性 (race) があり、check 通過後に subscriber が
-        消える / check 失敗後に publish 直前に subscriber が現れる、を完全に
-        排除はできない。「明らかな未起動」を検出する目的のみで、厳密な到達
-        確認が必要な場合は service / action / ack 設計に切り替えること。
+        subscriber 状態が変わる race を排除できない (check 通過後に消える /
+        check 失敗後に直前に現れる)。「明らかな未起動」検出が目的で、厳密な
+        到達確認が必要なら service / action / ack 設計に切り替える。
 
         Args:
             pub: rclpy publisher
@@ -343,7 +335,6 @@ class MapoiWebNode(Node):
 
         @app.route('/api/tag_definitions')
         def api_tag_definitions():
-            # mapoi_server の get_tag_definitions service 経由で system + custom 両方を取得 (#39)
             response = node._call_service_sync(
                 node.tag_defs_client_, GetTagDefinitions.Request(), 'get_tag_definitions')
             if response is None:

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -142,15 +142,49 @@ class MapoiWebNode(Node):
         return os.path.join(self.maps_path_, name)
 
     def call_reload_map_info(self):
-        """Call reload_map_info service on mapoi_server."""
-        if not self.reload_client_.wait_for_service(timeout_sec=2.0):
-            self.get_logger().warn('reload_map_info service not available')
+        """Call reload_map_info service on mapoi_server, awaiting response.
+
+        #60: 旧実装は call_async fire-and-forget で response を見ていなかったため、
+        server reload 失敗 (YAML 破損等) が silent failure になっていた。
+        _call_service_sync で response.success を確認するように改修。
+
+        Returns: True on server-side success, False on unavailable/timeout/server failure.
+        """
+        response = self._call_service_sync(
+            self.reload_client_, Trigger.Request(), 'reload_map_info', timeout_sec=3.0)
+        if response is None:
+            return False  # service unavailable / timeout (logged in helper)
+        if not response.success:
+            self.get_logger().warn(f'reload_map_info returned failure: {response.message}')
             return False
-        req = Trigger.Request()
-        future = self.reload_client_.call_async(req)
-        # We don't block here since we're in Flask thread; fire and forget
-        self.get_logger().info('Called reload_map_info')
+        self.get_logger().info('reload_map_info succeeded')
         return True
+
+    def publish_with_subscriber_check(self, pub, msg, topic_name):
+        """Publish a message with subscriber-count check (#60).
+
+        ROS 2 publisher.publish() は subscriber がいなくても成功扱い。
+        webui のような UI から「ボタン押した結果」を user に返すケースでは、
+        subscriber 不在 (mapoi_nav_server 未起動等) を silent failure させずに
+        warning として返したい。
+
+        Args:
+            pub: rclpy publisher
+            msg: message to publish
+            topic_name: topic name for warning message
+
+        Returns:
+            (published, warning) where warning is None or human-readable string.
+            published is always True since publish itself doesn't fail locally.
+        """
+        sub_count = pub.get_subscription_count()
+        pub.publish(msg)
+        if sub_count == 0:
+            warning = (f"{topic_name} に subscriber が見つかりません "
+                       "(mapoi_nav_server などの listener が起動していない可能性)")
+            self.get_logger().warn(warning)
+            return True, warning
+        return True, None
 
     def _call_service_sync(self, client, request, service_name, timeout_sec=3.0,
                            wait_for_service_sec=2.0):
@@ -355,11 +389,12 @@ class MapoiWebNode(Node):
                 return jsonify({'error': 'poi_name required'}), 400
             msg = String()
             msg.data = data['poi_name']
-            node.goal_poi_pub_.publish(msg)
+            _, warning = node.publish_with_subscriber_check(
+                node.goal_poi_pub_, msg, 'mapoi_goal_pose_poi')
             node.nav_status_ = 'navigating'
             node.nav_status_target_ = data['poi_name']
             node.get_logger().info(f'Nav goal: {data["poi_name"]}')
-            return jsonify({'success': True})
+            return jsonify({'success': True, 'warning': warning} if warning else {'success': True})
 
         @app.route('/api/nav/route', methods=['POST'])
         def api_nav_route():
@@ -368,36 +403,40 @@ class MapoiWebNode(Node):
                 return jsonify({'error': 'route_name required'}), 400
             msg = String()
             msg.data = data['route_name']
-            node.route_pub_.publish(msg)
+            _, warning = node.publish_with_subscriber_check(
+                node.route_pub_, msg, 'mapoi_route')
             node.nav_status_ = 'navigating'
             node.nav_status_target_ = data['route_name']
             node.get_logger().info(f'Nav route: {data["route_name"]}')
-            return jsonify({'success': True})
+            return jsonify({'success': True, 'warning': warning} if warning else {'success': True})
 
         @app.route('/api/nav/cancel', methods=['POST'])
         def api_nav_cancel():
             msg = String()
             msg.data = 'cancel'
-            node.cancel_pub_.publish(msg)
+            _, warning = node.publish_with_subscriber_check(
+                node.cancel_pub_, msg, 'mapoi_cancel')
             node.nav_status_ = 'canceled'
             node.get_logger().info('Nav canceled')
-            return jsonify({'success': True})
+            return jsonify({'success': True, 'warning': warning} if warning else {'success': True})
 
         @app.route('/api/nav/pause', methods=['POST'])
         def api_nav_pause():
             msg = String()
             msg.data = 'webui'
-            node.pause_pub_.publish(msg)
+            _, warning = node.publish_with_subscriber_check(
+                node.pause_pub_, msg, 'mapoi_pause')
             node.get_logger().info('Nav pause requested')
-            return jsonify({'success': True})
+            return jsonify({'success': True, 'warning': warning} if warning else {'success': True})
 
         @app.route('/api/nav/resume', methods=['POST'])
         def api_nav_resume():
             msg = String()
             msg.data = 'webui'
-            node.resume_pub_.publish(msg)
+            _, warning = node.publish_with_subscriber_check(
+                node.resume_pub_, msg, 'mapoi_resume')
             node.get_logger().info('Nav resume requested')
-            return jsonify({'success': True})
+            return jsonify({'success': True, 'warning': warning} if warning else {'success': True})
 
         @app.route('/api/nav/status')
         def api_nav_status():
@@ -414,9 +453,10 @@ class MapoiWebNode(Node):
                 return jsonify({'error': 'poi_name required'}), 400
             msg = String()
             msg.data = data['poi_name']
-            node.initialpose_poi_pub_.publish(msg)
+            _, warning = node.publish_with_subscriber_check(
+                node.initialpose_poi_pub_, msg, 'mapoi_initialpose_poi')
             node.get_logger().info(f'Initial pose: {data["poi_name"]}')
-            return jsonify({'success': True})
+            return jsonify({'success': True, 'warning': warning} if warning else {'success': True})
 
         return app
 

--- a/mapoi_webui/package.xml
+++ b/mapoi_webui/package.xml
@@ -22,12 +22,9 @@
   <exec_depend>python3-flask</exec_depend>
   <exec_depend>python3-pil</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
-  <!-- mapoi_server への依存:
-       - #39 (PR #59) で share/maps/tag_definitions.yaml の直読み依存は service 経由化により解消
-       - #60 で mapoi_editor.launch.yaml が mapoi_server の launch を include するため、
-         exec_depend として再追加 (ament_index で share dir を解決するため)
-       - 加えて runtime には mapoi_server ノードが起動している必要あり
-         (tag_definitions / reload_map_info service の responder として) -->
+  <!-- mapoi_editor.launch.yaml が mapoi_server の launch を include する (ament_index で
+       share dir 解決) + runtime に mapoi_server ノードが起動している必要あり
+       (tag_definitions / reload_map_info service の responder として)。 -->
   <exec_depend>mapoi_server</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/mapoi_webui/package.xml
+++ b/mapoi_webui/package.xml
@@ -22,8 +22,13 @@
   <exec_depend>python3-flask</exec_depend>
   <exec_depend>python3-pil</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
-  <!-- mapoi_server への依存は #39 で解消 (tag_definitions を service 経由に変更)。
-       runtime には mapoi_server ノードが起動している必要があるが、package install 依存は不要。 -->
+  <!-- mapoi_server への依存:
+       - #39 (PR #59) で share/maps/tag_definitions.yaml の直読み依存は service 経由化により解消
+       - #60 で mapoi_editor.launch.yaml が mapoi_server の launch を include するため、
+         exec_depend として再追加 (ament_index で share dir を解決するため)
+       - 加えて runtime には mapoi_server ノードが起動している必要あり
+         (tag_definitions / reload_map_info service の responder として) -->
+  <exec_depend>mapoi_server</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## 概要

Close #60

`mapoi_webui` の運用シナリオを 3 つに整理し、それぞれに対応する launch / 実装を整備:

| シナリオ | 起動 launch | 用途 |
|---|---|---|
| A | `mapoi_webui.launch.yaml` (既存) | 既に動いている system に webui を後付け、operator UI |
| B | `mapoi_webui/launch/mapoi_editor.launch.yaml` (新規) | デスクトップで POI/Route 編集のみ、ロボット動作なし |
| C | `mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml` (変更なし) | 統合運用 / デモ |

scenario B の実現のため `mapoi_bringup` を configurable に拡張し、editor launch から minimal config で include する設計。

## 変更内容

### 1. `mapoi_server/launch/mapoi_bringup.launch.yaml`
- `with_nav_server` (default `true`) と `with_rviz_publisher` (default `true`) arg を追加
- `mapoi_nav_server` / `mapoi_rviz2_publisher` の起動を `if: $(var with_nav_server)` / `if: $(var with_rviz_publisher)` で条件化
- default `true` で **既存挙動と完全互換**、editor 等 minimal 用途で `false` に切替可能

### 2. `mapoi_webui/launch/mapoi_editor.launch.yaml` (新規)
- `mapoi_bringup` を `with_nav_server=false` / `with_rviz_publisher=false` / `simulator=none` で include
- `mapoi_webui_node` を起動
- 結果: `mapoi_server` + `mapoi_webui` の 2 プロセスのみ起動

### 3. `mapoi_webui/package.xml`
- `<exec_depend>mapoi_server</exec_depend>` を再追加 (#39 で削除した share/yaml 直読み依存とは別の **launch composition 依存**)
- editor launch が `mapoi_server/launch/mapoi_bringup.launch.yaml` を include するため、ament_index で share dir を解決する必要

### 4. `mapoi_webui/mapoi_webui/mapoi_webui_node.py` — graceful service handling
- `call_reload_map_info` を `_call_service_sync` 経由に変更、`response.success` まで確認 (旧実装は `call_async` fire-and-forget で server-side 失敗が silent failure になっていた)
- **`publish_with_subscriber_check()` helper** を新設: publish 前に `subscription_count == 0` を検出して warning を返す
- `/api/nav/{goal,route,cancel,pause,resume,initialpose}` の 6 endpoint を helper 経由に置換 → `mapoi_nav_server` 未起動時の silent failure を解消

### 5. `mapoi_webui/README.md`
- 起動方法を 3 シナリオ (A/B/C) に整理
- REST API ごとの server 依存早見表を追加
- 開発者規約「Flask thread から ROS 2 service / publisher を呼ぶ際は **必ず** helper 経由」を明文化

## 動作確認 (Humble)

```bash
colcon build --packages-up-to mapoi_webui mapoi_turtlebot3_example   # clean
```

editor launch:
```bash
ros2 launch mapoi_webui mapoi_editor.launch.yaml \
  maps_path:=/path/to/maps map_name:=turtlebot3_world
```

確認:
- **process check**: `mapoi_server` + `mapoi_webui_node` の 2 プロセスのみ (nav_server / rviz_publisher / sim bridge は起動しない)
- **`ros2 service list`**: `/get_tag_definitions`, `/reload_map_info`, `/get_maps_info` を確認
- **`curl /api/tag_definitions`**: service 経由で system tags 取得成功
- **`curl -X POST /api/nav/goal`** (nav_server なし): `{"success": true, "warning": "mapoi_goal_pose_poi に subscriber が見つかりません ..."}` を返却

## Test plan

- [x] Humble image でビルド clean
- [x] editor launch で 2 プロセスのみ起動を確認
- [x] `/api/tag_definitions` の service 経由取得を確認
- [x] publisher 系の subscriber 0 件時 warning 返却を確認
- [x] `mapoi_bringup` default 値での既存挙動互換性 (default `true` 維持)
- [ ] Codex review

## 関連

- #39 (PR #59): `_call_service_sync` helper の導入元 (本 PR で再利用 + `publish_with_subscriber_check` を追加)
- #61 (別 issue、後続): webui を Editor / Operator mode に分離 (本 PR の standalone 整備が前提)
