### PR TITLE
feat(rviz2_publisher): POI radius を床面の円 (LINE_STRIP) で全 POI に描画 (#67)

### DIFF
--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -106,16 +106,59 @@ void MapoiRviz2Publisher::timer_callback(){
   default_text_marker.scale.x = 0.2; default_text_marker.scale.y = 0.2; default_text_marker.scale.z = 0.2;
   default_text_marker.color.r = 0.0; default_text_marker.color.g = 0.0; default_text_marker.color.b = 0.0; default_text_marker.color.a = 1.0;
 
-  visualization_msgs::msg::Marker default_cylinder_marker = default_arrow_marker;
-  default_cylinder_marker.type = visualization_msgs::msg::Marker::CYLINDER;
-  default_cylinder_marker.scale.x = 1.0*2; default_cylinder_marker.scale.y = 1.0*2; default_cylinder_marker.scale.z = 0.1;
-  default_cylinder_marker.color.r = 0.64; default_cylinder_marker.color.g = 0.89; default_cylinder_marker.color.b = 0.85; default_cylinder_marker.color.a = 0.3;
+  // POI radius を床面の円 (LINE_STRIP) で描画する template。
+  // CYLINDER と異なり top-down view で map / costmap と Z 重なりにくく、視界を遮らない。
+  visualization_msgs::msg::Marker default_circle_marker = default_arrow_marker;
+  default_circle_marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  default_circle_marker.scale.x = 0.03;  // line width (m)
+  default_circle_marker.scale.y = 0.0; default_circle_marker.scale.z = 0.0;
+  default_circle_marker.pose.orientation.w = 1.0;  // identity (LINE_STRIP の point は world 座標で指定するため)
 
   visualization_msgs::msg::MarkerArray ma_waypoints;
   visualization_msgs::msg::MarkerArray ma_events;
   int id = 0;
+
+  // 円の頂点数 (滑らかさと marker サイズの trade-off、36 角形 = 10度刻みで十分)
+  constexpr int CIRCLE_SEGMENTS = 36;
+  // 円を描く床面の z (map / costmap よりわずかに上、0.01m)
+  constexpr double CIRCLE_Z = 0.01;
+  // 円の透明度 (薄めにして他 marker や map を遮らない)
+  constexpr float CIRCLE_ALPHA = 0.5f;
+  auto add_radius_circle = [&](const geometry_msgs::msg::Pose & p, double radius,
+                               float r, float g, float b,
+                               int marker_id,
+                               visualization_msgs::msg::MarkerArray & target) {
+    visualization_msgs::msg::Marker m = default_circle_marker;
+    m.id = marker_id;
+    m.color.r = r; m.color.g = g; m.color.b = b; m.color.a = CIRCLE_ALPHA;
+    m.points.reserve(CIRCLE_SEGMENTS + 1);
+    for (int i = 0; i <= CIRCLE_SEGMENTS; ++i) {
+      const double angle = 2.0 * M_PI * static_cast<double>(i) / CIRCLE_SEGMENTS;
+      geometry_msgs::msg::Point pt;
+      pt.x = p.position.x + radius * std::cos(angle);
+      pt.y = p.position.y + radius * std::sin(angle);
+      pt.z = CIRCLE_Z;
+      m.points.push_back(pt);
+    }
+    target.markers.push_back(m);
+  };
+
   for (const auto & poi : pois_list_) {
     geometry_msgs::msg::Pose pose = poi.pose;
+
+    // POI radius を床面の円で描画 (全 POI 共通)。
+    // primary tag の color を採用 (goal 優先 → event → origin → 該当なしで gray)。
+    if (poi.radius > 0.0) {
+      float cr = 0.5f, cg = 0.5f, cb = 0.5f;  // default gray (custom tag only)
+      visualization_msgs::msg::MarkerArray * circle_target = &ma_events;
+      for (const auto & tag : poi.tags) {
+        if (tag == "goal")   { cr = 0.0f; cg = 1.0f; cb = 0.0f; circle_target = &ma_waypoints; break; }
+        if (tag == "event")  { cr = 0.0f; cg = 0.0f; cb = 1.0f; circle_target = &ma_events;    break; }
+        if (tag == "origin") { cr = 1.0f; cg = 0.0f; cb = 0.0f; circle_target = &ma_events;    break; }
+      }
+      add_radius_circle(pose, poi.radius, cr, cg, cb, id, *circle_target);
+      id += 1;
+    }
 
     for(const auto & tag : poi.tags){
       if(tag == "goal"){
@@ -154,15 +197,6 @@ void MapoiRviz2Publisher::timer_callback(){
         m_event.color.r = 0.0; m_event.color.g = 0.0; m_event.color.b = 1.0; m_event.color.a = 0.7;
         m_event.id = id;
         ma_events.markers.push_back(m_event);
-        id += 1;
-
-        visualization_msgs::msg::Marker m_area = default_cylinder_marker;
-        m_area.pose = pose;
-        m_area.pose.position.z = 0.1;
-        m_area.scale.x = poi.radius * 2;
-        m_area.scale.y = poi.radius * 2;
-        m_area.id = id;
-        ma_events.markers.push_back(m_area);
         id += 1;
 
         visualization_msgs::msg::Marker m_text = default_text_marker;

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -147,14 +147,27 @@ void MapoiRviz2Publisher::timer_callback(){
     geometry_msgs::msg::Pose pose = poi.pose;
 
     // POI radius を床面の円で描画 (全 POI 共通)。
-    // primary tag の color を採用 (goal 優先 → event → origin → 該当なしで gray)。
+    // primary tag の color を採用。優先順位は tags 配列の順序ではなく
+    // goal > event > origin で固定 (poi.tags が ["event", "goal"] のような順でも goal が勝つ)。
     if (poi.radius > 0.0) {
-      float cr = 0.5f, cg = 0.5f, cb = 0.5f;  // default gray (custom tag only)
+      const auto has_tag = [&poi](const std::string & target) {
+        for (const auto & t : poi.tags) {
+          if (t == target) return true;
+        }
+        return false;
+      };
+
+      float cr = 0.5f, cg = 0.5f, cb = 0.5f;  // default gray (recognized tag none)
       visualization_msgs::msg::MarkerArray * circle_target = &ma_events;
-      for (const auto & tag : poi.tags) {
-        if (tag == "goal")   { cr = 0.0f; cg = 1.0f; cb = 0.0f; circle_target = &ma_waypoints; break; }
-        if (tag == "event")  { cr = 0.0f; cg = 0.0f; cb = 1.0f; circle_target = &ma_events;    break; }
-        if (tag == "origin") { cr = 1.0f; cg = 0.0f; cb = 0.0f; circle_target = &ma_events;    break; }
+      if (has_tag("goal")) {
+        cr = 0.0f; cg = 1.0f; cb = 0.0f;
+        circle_target = &ma_waypoints;
+      } else if (has_tag("event")) {
+        cr = 0.0f; cg = 0.0f; cb = 1.0f;
+        circle_target = &ma_events;
+      } else if (has_tag("origin")) {
+        cr = 1.0f; cg = 0.0f; cb = 0.0f;
+        circle_target = &ma_events;
       }
       add_radius_circle(pose, poi.radius, cr, cg, cb, id, *circle_target);
       id += 1;

--- a/mapoi_turtlebot3_example/rviz/tb3_navigation2.rviz
+++ b/mapoi_turtlebot3_example/rviz/tb3_navigation2.rviz
@@ -545,6 +545,18 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
+        Value: /mapoi_event_marks
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
         Value: /mapoi_waypoint_marks
       Value: true
   Enabled: true


### PR DESCRIPTION
## 概要

Close #67

RViz 上で POI の `radius` (影響範囲、event detection に使われる値) が visual に出ていなかった。本 PR で全 POI に対して **床面の円 (LINE_STRIP)** で radius を描画する。

加えて、`/mapoi_event_marks` の RViz Display が config に存在しなかった既存 bug (event タグ POI の青矢印が表示されなかった) も同時に解消する。

## 変更内容

### 1. `mapoi_server/src/mapoi_rviz2_publisher.cpp`

- helper lambda `add_radius_circle` を追加: 36 角形の LINE_STRIP で円を生成
- 全 POI に対して radius > 0 ならば円 marker を `ma_waypoints` または `ma_events` に push
- 円の color は POI の primary tag に応じて:
  - `goal` → 緑 (mapoi_goal_marks)
  - `event` → 青 (mapoi_event_marks)
  - `origin` → 赤 (mapoi_event_marks)
  - 該当 tag なし (custom tag のみ等) → 灰 (mapoi_event_marks)
- 床面 z=0.01 (map / costmap よりわずかに上)、半透明 alpha 0.5
- event タグ POI の従来 CYLINDER 描画 (m_area) は削除、LINE_STRIP 円に統合

### 2. `mapoi_turtlebot3_example/rviz/tb3_navigation2.rviz`

- `/mapoi_event_marks` の MarkerArray Display を新規追加
- これ自体は本 PR スコープを超えるが、event タグ POI が元々 RViz で見えなかった既存 bug を同時解消するため最小修正として含める

## 設計判断

### 円 vs シリンダー
issue #67 検討の通り、CYLINDER は top-down view で map / costmap と Z 重なって視界を遮る。LINE_STRIP 円は床面に薄く描かれるだけで、map と重ねて見るユースケースに最適。

### マーカー topic 構成
現状の 2 topic (`mapoi_goal_marks` / `mapoi_event_marks`) を維持。topic 統合や namespace 設計を含む全体的な仕様再整理は **#70 (破壊的変更、リリース後対応)** で別途扱う。本 PR は現構成を維持しつつ機能追加と最小限の Display 追加にとどめる。

## 動作確認 (Humble)

```bash
colcon build --packages-up-to mapoi_server                            # clean
colcon test --packages-select mapoi_server                             # 全件 pass
```

runtime test (`turtlebot3_dqn_stage1` map、5 POI 全 goal タグ):
```bash
ros2 topic echo /mapoi_goal_marks --once | grep "^  type:" | sort | uniq -c
# 結果:
#       5   type: 0    # ARROW (POI 矢印)
#       5   type: 4    # LINE_STRIP (今回追加した radius 円)
#       5   type: 9    # TEXT_VIEW_FACING (POI 名 label)
```

全 POI に対して radius 円が publish されることを確認。

## 関連

- #65 (P1: marker scale): 後続、radius 連動 scale を実装する場合は本 PR の radius 円と整合的に
- #66 (P2: label 行番号化): 後続、別 PR
- #70 (visualization redesign): 破壊的変更、リリース後対応。本 PR は #70 着手時に再整理されうる前提
- 別途 issue 候補: 古い `/mapoi_waypoint_marks` Display 残存 (#37 と同類の rviz config cleanup)

## Test plan

- [x] Humble image でビルド clean
- [x] colcon test 全件 pass
- [x] runtime: LINE_STRIP marker が全 POI 分 publish されることを確認
- [x] rviz config に `/mapoi_event_marks` Display 追加を YAML parse で確認
- [ ] (実機検証推奨) RViz 起動して radius 円が見えること、color が tag に応じて切り替わること
- [ ] Codex review
