### PR TITLE
feat(rviz2_publisher): POI label を行番号化 + poi_label_format parameter (#66)

### DIFF
--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -150,6 +150,7 @@ RViz2 上に POI のマーカーを表示するためのノードです。
 | パラメータ名 | 型 | デフォルト | 説明 |
 | --- | --- | --- | --- |
 | `arrow_size_ratio` | `double` | `1.0` | POI 矢印の scale を radius に対する比率で指定 (`arrow_length = radius × ratio`)。Route 矢印 (waypoint 間) は radius 概念を持たないので対象外。`ros2 param set` で runtime 変更も次周期に反映 |
+| `poi_label_format` | `string` | `"index"` | POI label の表示形式: `"index"` = POI Editor 行番号 (1-based 通し、tag フィルタ非依存) / `"name"` = POI 名 / `"both"` = `"<index>: <name>"` / `"none"` = 非表示 |
 
 #### サブスクライバー
 

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -12,6 +12,11 @@ MapoiRviz2Publisher::MapoiRviz2Publisher() : Node("mapoi_rviz2_publisher") {
   // default 1.0 = radius と同じ長さ。Route 矢印 (waypoint 間) は radius 概念を持たないので対象外。
   this->declare_parameter<double>("arrow_size_ratio", 1.0);
 
+  // POI label の表示形式: "index" (POI Editor 行番号、1-based) / "name" / "both" (= "<index>: <name>") / "none"。
+  // default "index" は WebUI 上の行と RViz label を直接対応させ、文字長を抑えて重なりを減らす。
+  // ("off" は ros2 param CLI で bool として解釈されるため "none" を採用)
+  this->declare_parameter<std::string>("poi_label_format", "index");
+
   marker_waypoints_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_goal_marks", 10);
   marker_events_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_event_marks", 10);
 
@@ -121,6 +126,18 @@ void MapoiRviz2Publisher::timer_callback(){
     m.scale.z = length * (0.1 / 0.3);  // head diameter
   };
 
+  // POI label の format ("index" / "name" / "both" / "none") を runtime parameter で切替。
+  // 空文字列を返した場合は label を生成しない (none モード)。
+  const std::string label_format =
+    this->get_parameter("poi_label_format").as_string();
+  auto build_label = [&label_format](size_t index_one_based, const std::string & name) -> std::string {
+    if (label_format == "none") return "";
+    if (label_format == "name") return name;
+    if (label_format == "both") return std::to_string(index_one_based) + ": " + name;
+    // default "index" (および未知の値)
+    return std::to_string(index_one_based);
+  };
+
   visualization_msgs::msg::Marker default_text_marker = default_arrow_marker;
   default_text_marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
   default_text_marker.scale.x = 0.2; default_text_marker.scale.y = 0.2; default_text_marker.scale.z = 0.2;
@@ -163,7 +180,9 @@ void MapoiRviz2Publisher::timer_callback(){
     target.markers.push_back(m);
   };
 
+  size_t poi_index_one_based = 0;
   for (const auto & poi : pois_list_) {
+    poi_index_one_based += 1;  // POI Editor (mapoi_config.yaml の poi: 順) 行番号、1-based、tag フィルタ非依存
     geometry_msgs::msg::Pose pose = poi.pose;
 
     // POI radius を床面の円で描画 (全 POI 共通)。
@@ -209,20 +228,16 @@ void MapoiRviz2Publisher::timer_callback(){
         ma_waypoints.markers.push_back(m_waypoint);
         id += 1;
 
-        visualization_msgs::msg::Marker m_text = default_text_marker;
-        {
-          auto it = highlighted_route_names_.find(poi.name);
-          if (it != highlighted_route_names_.end()) {
-            m_text.text = "[" + std::to_string(it->second) + "] " + poi.name;
-          } else {
-            m_text.text = poi.name;
-          }
+        const std::string label_text = build_label(poi_index_one_based, poi.name);
+        if (!label_text.empty()) {
+          visualization_msgs::msg::Marker m_text = default_text_marker;
+          m_text.text = label_text;
+          m_text.pose = pose;
+          m_text.pose.position.z = 0.1;
+          m_text.id = id;
+          ma_waypoints.markers.push_back(m_text);
+          id += 1;
         }
-        m_text.pose = pose;
-        m_text.pose.position.z = 0.1;
-        m_text.id = id;
-        ma_waypoints.markers.push_back(m_text);
-        id += 1;
       }
       else if(tag == "event"){
         visualization_msgs::msg::Marker m_event = default_arrow_marker;
@@ -234,13 +249,16 @@ void MapoiRviz2Publisher::timer_callback(){
         ma_events.markers.push_back(m_event);
         id += 1;
 
-        visualization_msgs::msg::Marker m_text = default_text_marker;
-        m_text.text = poi.name;
-        m_text.pose = pose;
-        m_text.pose.position.z = 0.1;
-        m_text.id = id;
-        ma_events.markers.push_back(m_text);
-        id += 1;
+        const std::string label_text = build_label(poi_index_one_based, poi.name);
+        if (!label_text.empty()) {
+          visualization_msgs::msg::Marker m_text = default_text_marker;
+          m_text.text = label_text;
+          m_text.pose = pose;
+          m_text.pose.position.z = 0.1;
+          m_text.id = id;
+          ma_events.markers.push_back(m_text);
+          id += 1;
+        }
       }
       else if(tag == "origin"){
         visualization_msgs::msg::Marker m_event = default_arrow_marker;


### PR DESCRIPTION
## 概要

Close #66

POI label を従来の name 表示から **POI Editor 行番号 (1-based 通し、tag フィルタ非依存)** に変更。複数 POI が密集すると label が重なって読めない問題を、文字長を抑えることで軽減する。

WebUI POI Editor の行と RViz label を直接対応付けられるようになり、選別やデバッグの効率が上がる。format は parameter で `index` / `name` / `both` / `none` の 4 値から選択可能。

## 変更内容

### parameter 追加

```yaml
poi_label_format:
  type: string
  default_value: "index"
  description: |
    POI label の表示形式:
      - "index": POI Editor 行番号 (1-based 通し、tag フィルタ非依存) ← 新 default
      - "name":  POI 名 (旧挙動)
      - "both":  "<index>: <name>"
      - "none":  非表示 (TEXT marker 自体を生成しない)
    注: "off" は ros2 param CLI で bool 解釈されるため "none" を採用
```

### 実装

- `poi_index_one_based` counter を POI loop に追加: 全 POI を tag に関わらず通し番号で数える (POI Editor の表示順 = mapoi_config.yaml の `poi:` 順と一致)
- `build_label(index, name)` lambda で format に応じた文字列生成
  - `none` 時は空文字列 → TEXT marker 自体を skip
- goal / event の各 POI label に適用 (origin / custom-only POI には label なし、既存挙動)
- 既存の `"[N] name"` route highlight prefix は **削除**
  - route 順序は `mapoi_route_marks` の連結矢印で visual に表現済み
  - label 内で 2 重に持つ意味が薄く、POI 行番号と route step 番号の混同も避けられる

### 設計判断 (#66 残論点への決定)

| 論点 | 採用 | 根拠 |
|---|---|---|
| 番号体系 | **1-based 通し番号** (tag フィルタ非依存) | POI Editor は 1-based 表示が直感的、tag フィルタで番号が変わらない方が POI 同定しやすい |
| route highlight prefix | **削除** | route 順序は連結矢印で visual に表現済み、label 内で重複しない |
| format 切替 | **parameter** (`index` / `name` / `both` / `none`) | runtime で `ros2 param set` 切替可能、scope に応じて選べる |

## 動作確認 (Humble)

```bash
colcon build --packages-up-to mapoi_server   # clean
colcon test --packages-select mapoi_server   # 全件 pass
```

runtime test (`turtlebot3_world` map、5 POI):

| `poi_label_format` | label 出力 |
|---|---|
| `index` (default) | `1`, `2`, `3`, `4`, `5` |
| `name` | `elevator_hall`, `meeting_room_a`, ... (旧挙動) |
| `both` | `1: elevator_hall`, `2: meeting_room_a`, ... |
| `none` | TEXT marker 0 件 (非表示) |

`ros2 param set /mapoi_rviz2_publisher poi_label_format <value>` で **動的切替** も確認。

## 後方互換

- 旧挙動 (POI 名表示) が必要なら `poi_label_format:=name` で復元可能
- highlighted_route_names_ data 自体は subscription / 内部状態として維持 (label 表示にだけ使われていなかったため、削除は scope creep として後追い)

## Test plan

- [x] Humble image でビルド clean
- [x] colcon test 全件 pass
- [x] 4 つの format で label 出力を検証
- [x] `ros2 param set` で動的切替確認
- [ ] (実機検証推奨) RViz で実際に label が変わること、密集 POI で重なりが軽減されることを目視
- [ ] Codex review

## 関連

- #65 (PR #72、merged): arrow_size_ratio
- #67 (PR #71、merged): radius 円描画
- #68 (P4): Route visualization (本 PR で route highlight 除去のため、改修時に再考)
- #70 (visualization 仕様再整理、リリース後): topic 統合等の破壊的変更
