### PR TITLE
feat(poi_editor): Save 後に table を rebuild して行番号を visual order に揃える (#74)

### DIFF
--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -257,6 +257,12 @@ void PoiEditorPanel::SaveButton()
   auto request_reload_map_info = std::make_shared<std_srvs::srv::Trigger::Request>();
   auto result_reload_map_info = reload_map_info_client_->async_send_request(request_reload_map_info);
   rclcpp::spin_until_future_complete(service_node_, result_reload_map_info);
+
+  // Drag による reorder は Qt の visual order だけ変えるため、Save 後も verticalHeader の
+  // 番号は元の logical order のまま (例: [3, 1, 2] のように見える)。
+  // saved YAML を fetch し直して table を再構築することで visual = logical を揃え、
+  // 番号が 1, 2, 3, ... に並ぶようにする。drag 中の background highlight (Qt::green) も解除。
+  UpdatePoiTable();
 }
 
 // Subscription Callback

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -571,6 +571,10 @@ void PoiEditorPanel::UpdatePoiTable()
   PopulateTagFilter();
 
   ui_->PoiTable->clear();
+  // Drag による reorder で動いた verticalHeader の visual order は、
+  // 同じ rowCount で setRowCount し直しても reset されない (Qt 既知挙動)。
+  // 一度 0 行にしてから再生成することで visual = logical を強制する。
+  ui_->PoiTable->setRowCount(0);
   ui_->PoiTable->setRowCount(numRows);
   ui_->PoiTable->setColumnCount(5);
   ui_->PoiTable->setHorizontalHeaderLabels( QStringList() << tr("name") << tr("description") << tr("x, y, yaw") << tr("radius") << tr("tags" ) );


### PR DESCRIPTION
## 概要

Close #74

POI Editor Panel で行を drag 並び替えしても、Qt の `verticalHeader` 番号は **logical order のまま** (例: `[3, 1, 2]` のように見える)。Save 自体は visual order で正しく YAML に書き出されているが、Panel 表示が乱れたままで user に「番号が乱れている」印象を与えていた。

本 PR で **Save 完了後に table を rebuild** することで、行番号を visual order = `1, 2, 3, ...` に揃える。

## 変更内容

### `mapoi_rviz_plugins/src/poi_editor.cpp` の `SaveButton()`

`reload_map_info` service 完了後に **既存の `UpdatePoiTable()` を 1 行追加で呼ぶ**:

```cpp
rclcpp::spin_until_future_complete(service_node_, result_reload_map_info);

// Drag による reorder は Qt の visual order だけ変えるため、Save 後も verticalHeader の
// 番号は元の logical order のまま (例: [3, 1, 2] のように見える)。
// saved YAML を fetch し直して table を再構築することで visual = logical を揃え、
// 番号が 1, 2, 3, ... に並ぶようにする。drag 中の background highlight (Qt::green) も解除。
UpdatePoiTable();
```

### 効果

1. Save 後に `get_pois_info` で saved YAML から fresh data を fetch
2. table を clear + setItem で再構築 → visual = logical order
3. verticalHeader 番号が `1, 2, 3, ...` に揃う
4. drag 中の Qt::green background も解除
5. Save 完了の「視覚的フィードバック」として並び順確定が分かる

### 副作用

- `UpdatePoiTable()` は `ui_->SaveButton->setText("save")` を呼ぶため、`SAVED!` 緑表示が一瞬で「save」に戻る。これは「reload + table 再構築が完了 = 編集モードに戻った」と読める fbback で、UX 上はむしろ自然
- 既存ロジック (`UpdatePoiTable`) をそのまま流用しているためコード重複なし

## 動作確認 (Humble)

```bash
colcon build --packages-up-to mapoi_rviz_plugins   # clean
```

実 GUI 動作 (実機検証推奨):
1. POI Editor Panel を開く → 番号 `1, 2, 3, 4, 5`
2. 行 3 を一番上にドラッグ → Panel 表示は `[3, 1, 2, 4, 5]`、行 3 セルは Qt::green
3. Save クリック
4. **数秒後**: 行番号が `1, 2, 3, 4, 5` にリセット、background も白に戻る
5. YAML を直接確認 → `poi:` 順序は visual で並び替えた順 (元 row 3 が先頭)

## 関連

- #75 (P7、別 issue): mapoi_rviz2_publisher が POI list を refresh していない bug。本 PR で Panel は正しく refresh されるが、RViz の marker (#66 で追加した行番号 label 等) は古い list のまま。別 PR で対応予定

## Test plan

- [x] Humble image でビルド clean
- [ ] (実機検証推奨) Panel drag → Save → 行番号 reset を目視
- [ ] Codex review
