### PR TITLE
feat(rviz2_publisher): mapoi_config_path subscribe で POI list を動的 refresh (#75)

### DIFF
--- a/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
@@ -42,6 +42,16 @@ private:
    */
   void on_poi_received(rclcpp::Client<mapoi_interfaces::srv::GetPoisInfo>::SharedFuture future);
 
+  /**
+   * @brief get_pois_info service を呼び出して pois_list_ を更新する共通処理
+   */
+  void request_pois_list();
+
+  /**
+   * @brief mapoi_config_path topic の変化検出時に POI list を再取得する
+   */
+  void on_config_path_changed(const std_msgs::msg::String::SharedPtr msg);
+
   // --- Member Variables ---
 
   // マーカーID管理用
@@ -57,8 +67,12 @@ private:
   // Subscribers
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr highlight_goal_sub_;
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr highlight_route_sub_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr config_path_sub_;
   void on_highlight_goal_received(const std_msgs::msg::String::SharedPtr msg);
   void on_highlight_route_received(const std_msgs::msg::String::SharedPtr msg);
+
+  // Config path tracking (mapoi_nav_server と同じ idempotent guard)
+  std::string last_config_path_;
 
   // Timers
   rclcpp::TimerBase::SharedPtr init_timer_;

--- a/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cmath>
 #include <mutex>
+#include <filesystem>
 
 #include <rclcpp/rclcpp.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
@@ -71,8 +72,12 @@ private:
   void on_highlight_goal_received(const std_msgs::msg::String::SharedPtr msg);
   void on_highlight_route_received(const std_msgs::msg::String::SharedPtr msg);
 
-  // Config path tracking (mapoi_nav_server と同じ idempotent guard)
+  // Config path + mtime guard。
+  // path だけ覚えると周期 publish に対して常に skip する一方、WebUI/Panel Save (内容のみ変更で path 不変)
+  // も skip してしまう。mtime も併せて見ることで SwitchMap (path 変更) と Save (mtime 変更) の両方を検出。
+  // single-thread executor 前提で書き込みは callback context のみ。MultiThreadedExecutor 移行時は mutex が必要。
   std::string last_config_path_;
+  std::filesystem::file_time_type last_config_mtime_{};
 
   // Timers
   rclcpp::TimerBase::SharedPtr init_timer_;

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -29,6 +29,12 @@ MapoiRviz2Publisher::MapoiRviz2Publisher() : Node("mapoi_rviz2_publisher") {
     "mapoi_highlight_route", 10,
     std::bind(&MapoiRviz2Publisher::on_highlight_route_received, this, _1));
 
+  // mapoi_config_path 変化検出で POI list を再取得 (WebUI / Panel 並び替え保存 / SwitchMap 対応)。
+  // QoS は mapoi_nav_server と同じ transient_local。後起動でも latched 値を受信できる。
+  config_path_sub_ = this->create_subscription<std_msgs::msg::String>(
+    "mapoi_config_path", rclcpp::QoS(1).transient_local(),
+    std::bind(&MapoiRviz2Publisher::on_config_path_changed, this, _1));
+
   // 初期化シーケンスをデッドロック回避のため少し遅延させて開始
   this->init_timer_ = this->create_wall_timer(100ms, std::bind(&MapoiRviz2Publisher::start_sequence, this));
 
@@ -50,11 +56,33 @@ void MapoiRviz2Publisher::start_sequence()
     return;
   }
 
-  auto request = std::make_shared<mapoi_interfaces::srv::GetPoisInfo::Request>();
   RCLCPP_INFO(this->get_logger(), "Requesting POI Info...");
-  
+  request_pois_list();
+}
+
+void MapoiRviz2Publisher::request_pois_list()
+{
+  auto request = std::make_shared<mapoi_interfaces::srv::GetPoisInfo::Request>();
   poi_client_->async_send_request(
     request, std::bind(&MapoiRviz2Publisher::on_poi_received, this, _1));
+}
+
+void MapoiRviz2Publisher::on_config_path_changed(const std_msgs::msg::String::SharedPtr msg)
+{
+  // 同じ path なら skip (起動時 latched 値の二重 fetch + 無関係な再 publish の抑止)
+  if (msg->data == last_config_path_) {
+    return;
+  }
+  last_config_path_ = msg->data;
+  RCLCPP_INFO(this->get_logger(), "Map config changed: %s — refreshing POI list.", msg->data.c_str());
+
+  // 起動直後は service が未起動の場合があるため非ブロッキングで判定。
+  // skip しても次回の config_path 通知 (Save / SwitchMap) で再 fetch される。
+  if (!poi_client_->service_is_ready()) {
+    RCLCPP_WARN(this->get_logger(), "get_pois_info service not ready, skipping refresh.");
+    return;
+  }
+  request_pois_list();
 }
 
 void MapoiRviz2Publisher::on_poi_received(rclcpp::Client<mapoi_interfaces::srv::GetPoisInfo>::SharedFuture future)

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -69,19 +69,32 @@ void MapoiRviz2Publisher::request_pois_list()
 
 void MapoiRviz2Publisher::on_config_path_changed(const std_msgs::msg::String::SharedPtr msg)
 {
-  // 同じ path なら skip (起動時 latched 値の二重 fetch + 無関係な再 publish の抑止)
-  if (msg->data == last_config_path_) {
-    return;
+  // mapoi_server は config path 文字列を周期 publish (default 5s) する。path だけで dedup すると
+  // SwitchMap (path 変更) は拾えるが、WebUI/Panel Save (path 不変、内容のみ変更) を取りこぼす。
+  // YAML ファイルの mtime も併せて比較し、両 case を検出する。
+  const std::string & current_path = msg->data;
+  std::filesystem::file_time_type current_mtime{};
+  std::error_code ec;
+  auto stat_mtime = std::filesystem::last_write_time(current_path, ec);
+  if (!ec) {
+    current_mtime = stat_mtime;
+    if (current_path == last_config_path_ && current_mtime == last_config_mtime_) {
+      return;  // 周期 publish (path も内容も不変) → skip
+    }
   }
-  last_config_path_ = msg->data;
-  RCLCPP_INFO(this->get_logger(), "Map config changed: %s — refreshing POI list.", msg->data.c_str());
+  // stat 失敗時は dedup 不能とみなし fetch を試みる (起動 race などで一時的に発生し得る)
 
-  // 起動直後は service が未起動の場合があるため非ブロッキングで判定。
-  // skip しても次回の config_path 通知 (Save / SwitchMap) で再 fetch される。
+  RCLCPP_INFO(this->get_logger(), "Map config changed: %s — refreshing POI list.", current_path.c_str());
+
+  // 起動直後は service が未起動の場合がある。guard 値は更新前に readiness 判定して、未起動なら skip。
+  // last_config_path_ / last_config_mtime_ を未更新のまま return するため、次回 publish で再試行される。
   if (!poi_client_->service_is_ready()) {
     RCLCPP_WARN(this->get_logger(), "get_pois_info service not ready, skipping refresh.");
     return;
   }
+
+  last_config_path_ = current_path;
+  last_config_mtime_ = current_mtime;
   request_pois_list();
 }
 


### PR DESCRIPTION
## 概要

Close #75

`mapoi_rviz2_publisher` は起動時 (`start_sequence`) に `get_pois_info` を 1 回だけ呼んで以降 cache しており、WebUI / Panel の Save 並び替えや SwitchMap 後も RViz marker (POI 矢印 / radius 円 / 行番号 label) が古い list のまま残っていた。

`mapoi_config_path` topic 購読を追加し、変化検出で再 fetch する。`mapoi_nav_server` に既にある同 pattern を模倣。

## 変更内容

### `mapoi_server/src/mapoi_rviz2_publisher.cpp` + `.hpp`

```cpp
// constructor
config_path_sub_ = this->create_subscription<std_msgs::msg::String>(
  "mapoi_config_path", rclcpp::QoS(1).transient_local(),
  std::bind(&MapoiRviz2Publisher::on_config_path_changed, this, _1));

// callback
void MapoiRviz2Publisher::on_config_path_changed(const std_msgs::msg::String::SharedPtr msg)
{
  if (msg->data == last_config_path_) return;  // 起動時 latched 値の二重 fetch 抑止
  last_config_path_ = msg->data;
  RCLCPP_INFO(this->get_logger(), "Map config changed: %s — refreshing POI list.", msg->data.c_str());

  if (!poi_client_->service_is_ready()) {
    RCLCPP_WARN(this->get_logger(), "get_pois_info service not ready, skipping refresh.");
    return;  // 次回 config_path 通知で再試行
  }
  request_pois_list();
}
```

### 設計判断

| 論点 | 採用 | 根拠 |
|---|---|---|
| QoS | `rclcpp::QoS(1).transient_local()` | `mapoi_nav_server` と整合、後起動でも latched 値を受信 |
| 重複 fetch 抑止 | `last_config_path_` で同 path skip | 起動時の latched 値と timer による再 publish の両方を抑制 |
| service 未起動時の挙動 | `service_is_ready()` 非ブロッキング判定 + warning skip | callback context での `wait_for_service` ブロックを避ける、次回通知 (Save / SwitchMap) で自然回復 |
| 共通処理切り出し | `request_pois_list()` helper | `start_sequence` と新 callback の重複を排除 |

### 副作用

- 起動時に `start_sequence` (init_timer) と `on_config_path_changed` (latched 値) の両方が `request_pois_list` を呼ぶ可能性 → `last_config_path_` guard で 2 回目は skip。仮に race で両方通っても `pois_list_` の上書きが 2 回発生するだけで害はない
- 既存の `pois_list_` は `data_mutex_` で保護されており、callback 上の代入も既存パターンを踏襲

## 動作確認 (Humble)

```bash
colcon build --packages-select mapoi_server --symlink-install   # clean
```

実 GUI 動作 (実機検証推奨):
1. `mapoi_bringup` 起動 → RViz で POI 番号 `1, 2, 3, 4, 5` 確認
2. Panel で並び替え + Save (or WebUI で POI 削除 + Save)
3. **数秒以内に RViz の番号 / 矢印 / radius 円が更新される** ことを目視
4. SwitchMap で別 map に切り替えて、新 map の POI が RViz に出ることを確認

## 関連

- #66 (PR #73、merged): RViz label の行番号化 — 本 PR で refresh が動けば、並び替え後の新番号が即時反映される
- #74 (PR #76、merged): POI Editor Panel の Save 後 rebuild — Panel 側の番号表示は #76 で、RViz marker 側の更新は本 PR で完結
- `mapoi_server/src/mapoi_nav_server.cpp:626-639` — 同 pattern の参考実装

## Test plan

- [x] Humble image でビルド clean
- [x] (実機検証推奨) Panel 並び替え → Save → RViz marker 数秒以内更新を目視
- [x] (実機検証推奨) SwitchMap → 新 map の POI が RViz に出ることを確認
- [x] Codex review