### PR TITLE
fix(nav_server): on_config_path_changed を path + mtime guard に変更 (#80)

### DIFF
--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -13,6 +13,7 @@
 #include <unordered_set>
 #include <cmath>
 #include <mutex>
+#include <filesystem>
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
@@ -112,7 +113,10 @@ private:
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr config_path_sub_;
   rclcpp::Client<mapoi_interfaces::srv::GetTagDefinitions>::SharedPtr tag_defs_client_;
 
+  // path だけだと WebUI/Panel Save (path 不変、内容のみ変更) を取りこぼすため、mtime も併用。
+  // single-thread executor 前提で書き込みは callback context のみ。詳細は PR #78 (#75) と issue #80。
   std::string last_config_path_;
+  std::filesystem::file_time_type last_config_mtime_{};
   std::unordered_set<std::string> system_tags_;
   bool system_tags_loaded_ = false;
   std::unordered_map<std::string, bool> poi_inside_state_;  // key: poi.name

--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -114,9 +114,15 @@ private:
   rclcpp::Client<mapoi_interfaces::srv::GetTagDefinitions>::SharedPtr tag_defs_client_;
 
   // path だけだと WebUI/Panel Save (path 不変、内容のみ変更) を取りこぼすため、mtime も併用。
-  // single-thread executor 前提で書き込みは callback context のみ。詳細は PR #78 (#75) と issue #80。
+  // guard は fetch 成功 callback (on_pois_info_received) で確定し、失敗時は pending のまま
+  // 次回 publish で retry する。pending_guard_active_ が false の時 (start_sequence 経由の初回 fetch)
+  // は guard 確定処理を skip。single-thread executor 前提で書き込みは callback context のみ。
+  // 詳細は PR #78 (#75) と issue #80。
   std::string last_config_path_;
   std::filesystem::file_time_type last_config_mtime_{};
+  std::string pending_config_path_;
+  std::filesystem::file_time_type pending_config_mtime_{};
+  bool pending_guard_active_ = false;
   std::unordered_set<std::string> system_tags_;
   bool system_tags_loaded_ = false;
   std::unordered_map<std::string, bool> poi_inside_state_;  // key: poi.name

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -213,16 +213,18 @@ void MapoiNavServer::on_pois_info_received(rclcpp::Client<mapoi_interfaces::srv:
   }
   RCLCPP_INFO(this->get_logger(), "Received %zu Tagged POIs.", pois_list_.size());
   rebuild_event_pois();
-  auto_publish_initial_pose();
 
   // config_path 由来の fetch (on_config_path_changed → get_pois_list) が成功した時のみ guard を確定。
   // start_sequence 経由の初回 fetch では pending_guard_active_ が false で、ここは no-op。
   // fetch 失敗 (result == nullptr) で早期 return した場合も pending を残し、次回 publish で retry する。
+  // auto_publish_initial_pose() は last_config_path_ を見て二重発火判定するため、guard 確定を先に行う。
   if (pending_guard_active_) {
     last_config_path_ = pending_config_path_;
     last_config_mtime_ = pending_config_mtime_;
     pending_guard_active_ = false;
   }
+
+  auto_publish_initial_pose();
 }
 
 std::vector<mapoi_interfaces::msg::PointOfInterest> MapoiNavServer::select_initial_pose_pois(

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -625,11 +625,24 @@ void MapoiNavServer::on_system_tags_received(
 
 void MapoiNavServer::on_config_path_changed(const std_msgs::msg::String::SharedPtr msg)
 {
-  if (msg->data == last_config_path_) {
-    return;
+  // mapoi_server は config path 文字列を周期 publish (default 5s) する。path だけで dedup すると
+  // SwitchMap (path 変更) は拾えるが、WebUI/Panel Save (path 不変、内容のみ変更) を取りこぼし、
+  // event_pois_ が古いまま radius event 監視が外れる。YAML mtime も併せて比較する (PR #78 と同 pattern)。
+  const std::string & current_path = msg->data;
+  std::filesystem::file_time_type current_mtime{};
+  std::error_code ec;
+  auto stat_mtime = std::filesystem::last_write_time(current_path, ec);
+  if (!ec) {
+    current_mtime = stat_mtime;
+    if (current_path == last_config_path_ && current_mtime == last_config_mtime_) {
+      return;  // 周期 publish (path も内容も不変) → skip
+    }
   }
-  last_config_path_ = msg->data;
-  RCLCPP_INFO(this->get_logger(), "Map config changed: %s — refreshing POI list.", msg->data.c_str());
+  // stat 失敗時は dedup 不能とみなし refresh を試みる (起動 race などで一時的に発生し得る)
+
+  last_config_path_ = current_path;
+  last_config_mtime_ = current_mtime;
+  RCLCPP_INFO(this->get_logger(), "Map config changed: %s — refreshing POI list.", current_path.c_str());
   {
     std::lock_guard<std::mutex> lock(data_mutex_);
     poi_inside_state_.clear();

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -214,6 +214,15 @@ void MapoiNavServer::on_pois_info_received(rclcpp::Client<mapoi_interfaces::srv:
   RCLCPP_INFO(this->get_logger(), "Received %zu Tagged POIs.", pois_list_.size());
   rebuild_event_pois();
   auto_publish_initial_pose();
+
+  // config_path 由来の fetch (on_config_path_changed → get_pois_list) が成功した時のみ guard を確定。
+  // start_sequence 経由の初回 fetch では pending_guard_active_ が false で、ここは no-op。
+  // fetch 失敗 (result == nullptr) で早期 return した場合も pending を残し、次回 publish で retry する。
+  if (pending_guard_active_) {
+    last_config_path_ = pending_config_path_;
+    last_config_mtime_ = pending_config_mtime_;
+    pending_guard_active_ = false;
+  }
 }
 
 std::vector<mapoi_interfaces::msg::PointOfInterest> MapoiNavServer::select_initial_pose_pois(
@@ -640,8 +649,12 @@ void MapoiNavServer::on_config_path_changed(const std_msgs::msg::String::SharedP
   }
   // stat 失敗時は dedup 不能とみなし refresh を試みる (起動 race などで一時的に発生し得る)
 
-  last_config_path_ = current_path;
-  last_config_mtime_ = current_mtime;
+  // guard は fetch 成功時 (on_pois_info_received) に確定。失敗時は pending のまま、
+  // 次回 publish (周期 5s) で path/mtime が同じでも guard が前回値のままなので retry される。
+  pending_config_path_ = current_path;
+  pending_config_mtime_ = current_mtime;
+  pending_guard_active_ = true;
+
   RCLCPP_INFO(this->get_logger(), "Map config changed: %s — refreshing POI list.", current_path.c_str());
   {
     std::lock_guard<std::mutex> lock(data_mutex_);


### PR DESCRIPTION
## 概要

Close #80

PR #78 (#75 \`mapoi_rviz2_publisher\` 動的 refresh) で発見・修正した path-only dedup の同根バグを \`mapoi_nav_server\` 側にも適用する mirror fix。

\`mapoi_server\` は config path 文字列を周期 publish (default 5s) するため、subscriber 側で \`if (msg->data == last_config_path_) return;\` の path-only dedup をすると、WebUI/Panel Save (path 不変、内容のみ変更) の通知を取りこぼす。SwitchMap (path 変更) では guard を通過するが、同 map 内の編集では radius event 監視対象 (\`event_pois_\`) が古いまま。

## 変更内容

### \`mapoi_server/src/mapoi_nav_server.cpp\` の \`on_config_path_changed\` (PR #78 と同 pattern)

\`\`\`cpp
const std::string & current_path = msg->data;
std::filesystem::file_time_type current_mtime{};
std::error_code ec;
auto stat_mtime = std::filesystem::last_write_time(current_path, ec);
if (!ec) {
  current_mtime = stat_mtime;
  if (current_path == last_config_path_ && current_mtime == last_config_mtime_) {
    return;  // 周期 publish (path も内容も不変) → skip
  }
}
// stat 失敗時は dedup 不能とみなし refresh を試みる
\`\`\`

### \`mapoi_server/include/mapoi_server/mapoi_nav_server.hpp\`

- \`std::filesystem::file_time_type last_config_mtime_\` を追加
- \`#include <filesystem>\` を追加

### 設計判断 (PR #78 を踏襲)

| 論点 | 採用 | 根拠 |
|---|---|---|
| dedup key | path + mtime の組合せ | SwitchMap (path 変更) と Save (mtime 変更) の両方を検出 |
| stat 失敗時の挙動 | dedup 不能とみなし refresh を試みる | 起動 race などで一時的に発生し得るが、次回 publish で正常 stat に戻る |
| guard 値の更新タイミング | \`get_pois_list()\` 呼び出しの前に更新 | mapoi_rviz2_publisher (PR #78) は service readiness 判定後に更新したが、\`mapoi_nav_server::get_pois_list()\` は \`while (!wait_for_service(1s)) {...}\` で blocking retry するため、PR #78 の medium 指摘は本質的に当たらない (中で必ず成功する設計) |

### 副作用

- 既存挙動と互換: SwitchMap (path 変更) は今まで通り動く + 新たに Save (mtime 変更) も検出
- \`event_pois_\` を Save 後にクリア + 再 fetch する流れは既存のまま (\`poi_inside_state_\` も同様)
- \`mapoi_rviz2_publisher\` (PR #78) と同じ pattern なので、両 callback の挙動が一致して保守性向上

## 動作確認 (Humble)

\`\`\`bash
colcon build --packages-select mapoi_server --symlink-install   # clean
\`\`\`

実 GUI 動作 (実機検証推奨):
1. mapoi_bringup 起動 → robot を event タグ付き POI の半径外に配置
2. WebUI で event タグの POI を 1 つ追加 + Save (path 不変、内容のみ変更)
3. 追加した POI の半径内に robot を移動
4. **\`/mapoi_poi_events\` topic で event 発火** することを確認 (本 PR 適用前は発火しなかった想定)
5. SwitchMap で別 map に切替 → 新 map の event 監視が動くことを確認 (既存挙動の retain 確認)

## 関連

- PR #78 (merged, \`2ab61bc\`): #75 \`mapoi_rviz2_publisher\` 動的 refresh — 同根バグの本流 fix、本 PR はその mirror
- Codex round 1 (PR #78): https://github.com/shimz-robotics/mapoi/pull/78#issuecomment-4320736358 — 同 bug を発見した契機

## Test plan

- [x] Humble image でビルド clean
- [ ] (実機検証推奨) WebUI で event POI 追加 → robot 接近 → event 発火を目視
- [ ] (実機検証推奨) SwitchMap で既存挙動の回帰なしを確認
- [ ] Codex review