### PR TITLE
feat(example): turtlebot3_world と turtlebot3_dqn_stage1 の sample POI を distinct theme + Nav2 整合 radius で再設計 (#79)

### DIFF
--- a/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -17,34 +17,34 @@ gazebo:
     uri: model://turtlebot3_dqn_world
     name: turtlebot3_dqn_world
 
-# turtlebot3_world (office テーマ、5 POI 全て radius 0.5 で均一) との視覚的区別を明確にするため、
-# DQN 学習コースのメタファで配置・半径ともに不均一にする。
-# - 中央の start_zone はやや余裕、東西 checkpoint は半径違いで非対称、南 hazard は広めの危険ゾーン、
-#   北 training_goal は最も狭い精密目標。turtlebot3_dqn_stage1 world (~5x5m、obstacle 多数) で robot
-#   navigation の精度が要求されるシーンに合わせ、office テーマの 0.5 から大幅に小さくバラした半径に。
+# turtlebot3_world (office テーマ) と視覚的区別を明確にするため、DQN 学習コースのメタファで
+# 配置・半径ともに不均一にする。半径は Nav2 controller の xy_goal_tolerance (0.25) より大きく
+# 取る (Nav2 が POI radius 内に入る前にゴール判定で停止し、radius event が発火しないため)。
+# 最小 0.30 (5cm 余裕)、最大 0.45 で意味付け (中央 start_zone やや余裕、東 checkpoint は wall
+# 制約で最狭、南 hazard は最も広い危険ゾーン、北 training_goal は精密目標)。
 poi:
 - name: start_zone
   description: DQN 学習開始地点
   pose: {x: 0.0, y: 0.0, yaw: 0.0}
-  radius: 0.2
+  radius: 0.40
   tags: [goal, initial_pose]
 - name: checkpoint_west
   description: 西側中継点
   pose: {x: -1.6, y: 0.5, yaw: 1.57}
-  radius: 0.12
+  radius: 0.35
   tags: [goal, checkpoint]
 - name: checkpoint_east
   description: 東側中継点
   pose: {x: 1.4, y: -0.3, yaw: -1.6}
-  radius: 0.18
+  radius: 0.30
   tags: [goal, checkpoint]
 - name: hazard_south
   description: 南側ハザード (回避対象)
   pose: {x: 0.5, y: -1.3, yaw: 0.0}
-  radius: 0.35
+  radius: 0.45
   tags: [event, hazard]
 - name: training_goal
   description: DQN 目標地点
   pose: {x: 0.4, y: 1.7, yaw: -2.0}
-  radius: 0.1
+  radius: 0.30
   tags: [goal]

--- a/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -40,7 +40,7 @@ poi:
   tags: [goal, checkpoint]
 - name: hazard_south
   description: 南側ハザード (回避対象)
-  pose: {x: -0.6, y: -1.6, yaw: 0.0}
+  pose: {x: 0.5, y: -1.3, yaw: 0.0}
   radius: 0.35
   tags: [event, hazard]
 - name: training_goal

--- a/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -25,7 +25,7 @@ gazebo:
 poi:
 - name: start_zone
   description: DQN 学習開始地点
-  pose: {x: 0.2, y: 0.1, yaw: 0.0}
+  pose: {x: 0.0, y: 0.0, yaw: 0.0}
   radius: 0.2
   tags: [goal, initial_pose]
 - name: checkpoint_west

--- a/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -17,32 +17,34 @@ gazebo:
     uri: model://turtlebot3_dqn_world
     name: turtlebot3_dqn_world
 
-# turtlebot3_world (office テーマ) との視覚的区別を明確にするため、DQN 学習コースのメタファで
-# 5 POI を東西南北 + 中央の compass 配置にし、custom_tags も hazard / checkpoint で揃える。
-# SwitchMap デモで「明らかに別 map の POI に変わった」と一目で分かる構成。
+# turtlebot3_world (office テーマ、5 POI 全て radius 0.5 で均一) との視覚的区別を明確にするため、
+# DQN 学習コースのメタファで配置・半径ともに不均一にする。
+# - 中央の start_zone はやや余裕、東西 checkpoint は半径違いで非対称、南 hazard は広めの危険ゾーン、
+#   北 training_goal は最も狭い精密目標。turtlebot3_dqn_stage1 world (~5x5m、obstacle 多数) で robot
+#   navigation の精度が要求されるシーンに合わせ、office テーマの 0.5 から大幅に小さくバラした半径に。
 poi:
 - name: start_zone
   description: DQN 学習開始地点
-  pose: {x: 0.0, y: 0.0, yaw: 0.0}
-  radius: 0.3
+  pose: {x: 0.2, y: 0.1, yaw: 0.0}
+  radius: 0.2
   tags: [goal, initial_pose]
 - name: checkpoint_west
   description: 西側中継点
-  pose: {x: -1.5, y: 0.0, yaw: 0.0}
-  radius: 0.3
+  pose: {x: -1.6, y: 0.5, yaw: 1.57}
+  radius: 0.12
   tags: [goal, checkpoint]
 - name: checkpoint_east
   description: 東側中継点
-  pose: {x: 1.5, y: 0.0, yaw: 3.14}
-  radius: 0.3
+  pose: {x: 1.4, y: -0.3, yaw: -1.6}
+  radius: 0.18
   tags: [goal, checkpoint]
 - name: hazard_south
   description: 南側ハザード (回避対象)
-  pose: {x: 0.0, y: -1.5, yaw: 0.0}
-  radius: 0.4
+  pose: {x: -0.6, y: -1.6, yaw: 0.0}
+  radius: 0.35
   tags: [event, hazard]
 - name: training_goal
   description: DQN 目標地点
-  pose: {x: 0.0, y: 1.5, yaw: -1.57}
-  radius: 0.3
+  pose: {x: 0.4, y: 1.7, yaw: -2.0}
+  radius: 0.1
   tags: [goal]

--- a/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -1,12 +1,12 @@
 custom_tags:
-- {name: hazard, description: DQN training hazard zone (avoidance target)}
-- {name: checkpoint, description: Intermediate training waypoint}
+- {name: hazard, description: Hazard zone (avoidance target)}
+- {name: checkpoint, description: Intermediate waypoint}
 
 route:
 - name: avoidance_a
-  waypoints: [start_zone, checkpoint_west, training_goal]
+  waypoints: [start_zone, checkpoint_west, north_goal]
 - name: avoidance_b
-  waypoints: [start_zone, checkpoint_east, training_goal]
+  waypoints: [start_zone, checkpoint_east, north_goal]
 
 map:
 - {node_name: /map_server, map_file: turtlebot3.yaml}
@@ -17,14 +17,14 @@ gazebo:
     uri: model://turtlebot3_dqn_world
     name: turtlebot3_dqn_world
 
-# turtlebot3_world (office テーマ) と視覚的区別を明確にするため、DQN 学習コースのメタファで
-# 配置・半径ともに不均一にする。半径は Nav2 controller の xy_goal_tolerance (0.25) より大きく
-# 取る (Nav2 が POI radius 内に入る前にゴール判定で停止し、radius event が発火しないため)。
-# 最小 0.30 (5cm 余裕)、最大 0.45 で意味付け (中央 start_zone やや余裕、東 checkpoint は wall
-# 制約で最狭、南 hazard は最も広い危険ゾーン、北 training_goal は精密目標)。
+# turtlebot3_world (office テーマ) と視覚的区別を明確にするため、obstacle 多数の sandbox world で
+# navigation 精度が要求されるシーンに合わせて配置・半径ともに不均一化。半径は Nav2 controller の
+# xy_goal_tolerance (0.25) より大きく取る (Nav2 が POI radius 内に入る前にゴール判定で停止し、
+# radius event が発火しないため)。最小 0.30 (5cm 余裕)、最大 0.45 で意味付け (中央 start_zone は
+# 余裕、東 checkpoint は wall 制約で最狭、南 hazard は最も広い回避ゾーン、北 north_goal は精密目標)。
 poi:
 - name: start_zone
-  description: DQN 学習開始地点
+  description: 開始地点
   pose: {x: 0.0, y: 0.0, yaw: 0.0}
   radius: 0.40
   tags: [goal, initial_pose]
@@ -43,8 +43,8 @@ poi:
   pose: {x: 0.5, y: -1.3, yaw: 0.0}
   radius: 0.45
   tags: [event, hazard]
-- name: training_goal
-  description: DQN 目標地点
+- name: north_goal
+  description: 北側目標地点
   pose: {x: 0.4, y: 1.7, yaw: -2.0}
   radius: 0.30
   tags: [goal]

--- a/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -1,39 +1,48 @@
+custom_tags:
+- {name: hazard, description: DQN training hazard zone (avoidance target)}
+- {name: checkpoint, description: Intermediate training waypoint}
+
 route:
-  - name: route_1
-    waypoints: [meeting_room_a, conference_room, meeting_room_a]
-  - name: route_2
-    waypoints: [elevator_hall, corridor_a, conference_room]
+- name: avoidance_a
+  waypoints: [start_zone, checkpoint_west, training_goal]
+- name: avoidance_b
+  waypoints: [start_zone, checkpoint_east, training_goal]
 
 map:
-  - node_name: map_server
-    map_file: turtlebot3.yaml
-  # - node_name: map_server_localization
-  #   map_file: turtlebot3_amcl.yaml
+- {node_name: /map_server, map_file: turtlebot3.yaml}
 
+# mapoi_gazebo_bridge が SwitchMap 時に読む (ground_plane / sun は共通、world を構成する主モデルのみ swap)
+gazebo:
+  world_model:
+    uri: model://turtlebot3_dqn_world
+    name: turtlebot3_dqn_world
+
+# turtlebot3_world (office テーマ) との視覚的区別を明確にするため、DQN 学習コースのメタファで
+# 5 POI を東西南北 + 中央の compass 配置にし、custom_tags も hazard / checkpoint で揃える。
+# SwitchMap デモで「明らかに別 map の POI に変わった」と一目で分かる構成。
 poi:
-  - name: elevator_hall
-    # pose: {x: 0.0, y: 0.0, yaw: 0.0}
-    pose: {x: -2.0, y: -0.5, yaw: 0.0}
-    radius: 0.5
-    tags: [goal, initial_pose]
-    description: エレベーターホール
-  - name: meeting_room_a
-    pose: {x: -0.5, y: -0.5, yaw: 0.0}
-    radius: 0.5
-    tags: [goal]
-    description: 会議室A
-  - name: conference_room
-    pose: {x: 0.5, y: -0.5, yaw: 1.57}
-    radius: 0.5
-    tags: [goal]
-    description: 大会議室
-  - name: corridor_a
-    pose: {x: 0.5, y: 0.5, yaw: -3.14}
-    radius: 0.5
-    tags: [goal]
-    description: 廊下
-  - name: model_exhibit
-    pose: {x: -0.5, y: 0.5, yaw: -1.57}
-    radius: 0.5
-    tags: [goal, audio_info]
-    description: 模型展示
+- name: start_zone
+  description: DQN 学習開始地点
+  pose: {x: 0.0, y: 0.0, yaw: 0.0}
+  radius: 0.3
+  tags: [goal, initial_pose]
+- name: checkpoint_west
+  description: 西側中継点
+  pose: {x: -1.5, y: 0.0, yaw: 0.0}
+  radius: 0.3
+  tags: [goal, checkpoint]
+- name: checkpoint_east
+  description: 東側中継点
+  pose: {x: 1.5, y: 0.0, yaw: 3.14}
+  radius: 0.3
+  tags: [goal, checkpoint]
+- name: hazard_south
+  description: 南側ハザード (回避対象)
+  pose: {x: 0.0, y: -1.5, yaw: 0.0}
+  radius: 0.4
+  tags: [event, hazard]
+- name: training_goal
+  description: DQN 目標地点
+  pose: {x: 0.0, y: 1.5, yaw: -1.57}
+  radius: 0.3
+  tags: [goal]

--- a/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
@@ -17,32 +17,32 @@ gazebo:
     uri: model://turtlebot3_world
     name: turtlebot3_world
 # elevator_hall は initial_pose タグ付きで、Gazebo robot spawn のデフォルト位置 (-2, -0.5) と一致。
-# その他 4 POI は元の office グリッド配置 (±0.5) を踏襲しつつ、半径と yaw を不均一化:
-# - 半径を 0.5 均一から 0.10〜0.20 に縮小、各部屋の規模感に合わせて差を付ける
-# - 位置も grid 的整列 (-0.5 / 0.5) を少し崩して non-uniform に散らす
+# 半径は Nav2 controller の xy_goal_tolerance (0.25) より大きく取らないと、Nav2 が POI radius
+# 内に入る前にゴール判定で停止し radius event が発火しない。最小 0.30 (5cm 余裕) で各部屋の
+# 規模感に合わせ 0.30〜0.50 にバラす。位置も grid 的整列 (-0.5 / 0.5) を少し崩して非対称に。
 poi:
 - description: エレベーターホール
   name: elevator_hall
   pose: {x: -2.0, y: -0.5, yaw: 0.0}
-  radius: 0.20
+  radius: 0.50
   tags: [goal, initial_pose]
 - description: 会議室A
   name: meeting_room_a
   pose: {x: -0.6, y: -0.6, yaw: 0.0}
-  radius: 0.15
+  radius: 0.35
   tags: [goal]
 - description: 大会議室
   name: conference_room
   pose: {x: 0.7, y: -0.4, yaw: 1.57}
-  radius: 0.18
+  radius: 0.45
   tags: [goal]
 - description: 廊下
   name: corridor_a
   pose: {x: 0.4, y: 0.6, yaw: -3.14}
-  radius: 0.12
+  radius: 0.30
   tags: [goal, pause]
 - description: 模型展示
   name: model_exhibit
   pose: {x: -0.5, y: 0.5, yaw: -1.57}
-  radius: 0.10
+  radius: 0.40
   tags: [goal, audio_info]

--- a/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
@@ -9,7 +9,7 @@ route:
 - name: route_2
   waypoints: [elevator_hall, corridor_a, conference_room]
 map:
-- {node_name: /map_server, map_file: turtlebot3.yaml}
+- {node_name: /map_server, map_file: localization.yaml}
 # mapoi_gazebo_bridge が SwitchMap 時に読む。
 # ground_plane / sun は共通なので入れ替え不要、world を構成する主モデルのみ swap。
 gazebo:

--- a/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
@@ -1,41 +1,48 @@
 custom_tags:
-  - name: audio_info
-    description: "Audio guide trigger"
-
-map:
-    path_planning: path_planning_map
-    localization: localization_map
-
-poi:
-  - name: elevator_hall
-    # pose: {x: 0.0, y: 0.0, yaw: 0.0}
-    pose: {x: -2.0, y: -0.5, yaw: 0.0}
-    radius: 0.5
-    tags: [goal, initial_pose]
-    description: エレベーターホール
-  - name: meeting_room_a
-    pose: {x: -0.5, y: -0.5, yaw: 0.0}
-    radius: 0.5
-    tags: [goal]
-    description: 会議室A
-  - name: conference_room
-    pose: {x: 0.5, y: -0.5, yaw: 1.57}
-    radius: 0.5
-    tags: [goal]
-    description: 大会議室
-  - name: corridor_a
-    pose: {x: 0.5, y: 0.5, yaw: -3.14}
-    radius: 0.5
-    tags: [goal]
-    description: 廊下
-  - name: model_exhibit
-    pose: {x: -0.5, y: 0.5, yaw: -1.57}
-    radius: 0.5
-    tags: [goal, audio_info]
-    description: 模型展示
-
+- {name: event, description: Event trigger area}
+- {name: destination, description: General destination point}
+- {name: landmark, description: Landmark for guidance}
+- {name: audio_info, description: Audio guide trigger}
 route:
-  - name: route_1
-    waypoints: [elevator_hall, meeting_room_a, conference_room]
-  - name: route_2
-    waypoints: [elevator_hall, corridor_a, conference_room]
+- name: route_1
+  waypoints: [meeting_room_a, conference_room, corridor_a, model_exhibit]
+- name: route_2
+  waypoints: [elevator_hall, corridor_a, conference_room]
+map:
+- {node_name: /map_server, map_file: turtlebot3.yaml}
+# mapoi_gazebo_bridge が SwitchMap 時に読む。
+# ground_plane / sun は共通なので入れ替え不要、world を構成する主モデルのみ swap。
+gazebo:
+  world_model:
+    uri: model://turtlebot3_world
+    name: turtlebot3_world
+# elevator_hall は initial_pose タグ付きで、Gazebo robot spawn のデフォルト位置 (-2, -0.5) と一致。
+# その他 4 POI は元の office グリッド配置 (±0.5) を踏襲しつつ、半径と yaw を不均一化:
+# - 半径を 0.5 均一から 0.10〜0.20 に縮小、各部屋の規模感に合わせて差を付ける
+# - 位置も grid 的整列 (-0.5 / 0.5) を少し崩して non-uniform に散らす
+poi:
+- description: エレベーターホール
+  name: elevator_hall
+  pose: {x: -2.0, y: -0.5, yaw: 0.0}
+  radius: 0.20
+  tags: [goal, initial_pose]
+- description: 会議室A
+  name: meeting_room_a
+  pose: {x: -0.6, y: -0.6, yaw: 0.0}
+  radius: 0.15
+  tags: [goal]
+- description: 大会議室
+  name: conference_room
+  pose: {x: 0.7, y: -0.4, yaw: 1.57}
+  radius: 0.18
+  tags: [goal]
+- description: 廊下
+  name: corridor_a
+  pose: {x: 0.4, y: 0.6, yaw: -3.14}
+  radius: 0.12
+  tags: [goal, pause]
+- description: 模型展示
+  name: model_exhibit
+  pose: {x: -0.5, y: 0.5, yaw: -1.57}
+  radius: 0.10
+  tags: [goal, audio_info]

--- a/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -17,34 +17,34 @@ gazebo:
     uri: model://turtlebot3_dqn_world
     name: turtlebot3_dqn_world
 
-# turtlebot3_world (office テーマ、5 POI 全て radius 0.5 で均一) との視覚的区別を明確にするため、
-# DQN 学習コースのメタファで配置・半径ともに不均一にする。
-# - 中央の start_zone はやや余裕、東西 checkpoint は半径違いで非対称、南 hazard は広めの危険ゾーン、
-#   北 training_goal は最も狭い精密目標。turtlebot3_dqn_stage1 world (~5x5m、obstacle 多数) で robot
-#   navigation の精度が要求されるシーンに合わせ、office テーマの 0.5 から大幅に小さくバラした半径に。
+# turtlebot3_world (office テーマ) と視覚的区別を明確にするため、DQN 学習コースのメタファで
+# 配置・半径ともに不均一にする。半径は Nav2 controller の xy_goal_tolerance (0.25) より大きく
+# 取る (Nav2 が POI radius 内に入る前にゴール判定で停止し、radius event が発火しないため)。
+# 最小 0.30 (5cm 余裕)、最大 0.45 で意味付け (中央 start_zone やや余裕、東 checkpoint は wall
+# 制約で最狭、南 hazard は最も広い危険ゾーン、北 training_goal は精密目標)。
 poi:
 - name: start_zone
   description: DQN 学習開始地点
   pose: {x: 0.0, y: 0.0, yaw: 0.0}
-  radius: 0.2
+  radius: 0.40
   tags: [goal, initial_pose]
 - name: checkpoint_west
   description: 西側中継点
   pose: {x: -1.6, y: 0.5, yaw: 1.57}
-  radius: 0.12
+  radius: 0.35
   tags: [goal, checkpoint]
 - name: checkpoint_east
   description: 東側中継点
   pose: {x: 1.4, y: -0.3, yaw: -1.6}
-  radius: 0.18
+  radius: 0.30
   tags: [goal, checkpoint]
 - name: hazard_south
   description: 南側ハザード (回避対象)
   pose: {x: 0.5, y: -1.3, yaw: 0.0}
-  radius: 0.35
+  radius: 0.45
   tags: [event, hazard]
 - name: training_goal
   description: DQN 目標地点
   pose: {x: 0.4, y: 1.7, yaw: -2.0}
-  radius: 0.1
+  radius: 0.30
   tags: [goal]

--- a/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -40,7 +40,7 @@ poi:
   tags: [goal, checkpoint]
 - name: hazard_south
   description: 南側ハザード (回避対象)
-  pose: {x: -0.6, y: -1.6, yaw: 0.0}
+  pose: {x: 0.5, y: -1.3, yaw: 0.0}
   radius: 0.35
   tags: [event, hazard]
 - name: training_goal

--- a/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -25,7 +25,7 @@ gazebo:
 poi:
 - name: start_zone
   description: DQN 学習開始地点
-  pose: {x: 0.2, y: 0.1, yaw: 0.0}
+  pose: {x: 0.0, y: 0.0, yaw: 0.0}
   radius: 0.2
   tags: [goal, initial_pose]
 - name: checkpoint_west

--- a/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -17,32 +17,34 @@ gazebo:
     uri: model://turtlebot3_dqn_world
     name: turtlebot3_dqn_world
 
-# turtlebot3_world (office テーマ) との視覚的区別を明確にするため、DQN 学習コースのメタファで
-# 5 POI を東西南北 + 中央の compass 配置にし、custom_tags も hazard / checkpoint で揃える。
-# SwitchMap デモで「明らかに別 map の POI に変わった」と一目で分かる構成。
+# turtlebot3_world (office テーマ、5 POI 全て radius 0.5 で均一) との視覚的区別を明確にするため、
+# DQN 学習コースのメタファで配置・半径ともに不均一にする。
+# - 中央の start_zone はやや余裕、東西 checkpoint は半径違いで非対称、南 hazard は広めの危険ゾーン、
+#   北 training_goal は最も狭い精密目標。turtlebot3_dqn_stage1 world (~5x5m、obstacle 多数) で robot
+#   navigation の精度が要求されるシーンに合わせ、office テーマの 0.5 から大幅に小さくバラした半径に。
 poi:
 - name: start_zone
   description: DQN 学習開始地点
-  pose: {x: 0.0, y: 0.0, yaw: 0.0}
-  radius: 0.3
+  pose: {x: 0.2, y: 0.1, yaw: 0.0}
+  radius: 0.2
   tags: [goal, initial_pose]
 - name: checkpoint_west
   description: 西側中継点
-  pose: {x: -1.5, y: 0.0, yaw: 0.0}
-  radius: 0.3
+  pose: {x: -1.6, y: 0.5, yaw: 1.57}
+  radius: 0.12
   tags: [goal, checkpoint]
 - name: checkpoint_east
   description: 東側中継点
-  pose: {x: 1.5, y: 0.0, yaw: 3.14}
-  radius: 0.3
+  pose: {x: 1.4, y: -0.3, yaw: -1.6}
+  radius: 0.18
   tags: [goal, checkpoint]
 - name: hazard_south
   description: 南側ハザード (回避対象)
-  pose: {x: 0.0, y: -1.5, yaw: 0.0}
-  radius: 0.4
+  pose: {x: -0.6, y: -1.6, yaw: 0.0}
+  radius: 0.35
   tags: [event, hazard]
 - name: training_goal
   description: DQN 目標地点
-  pose: {x: 0.0, y: 1.5, yaw: -1.57}
-  radius: 0.3
+  pose: {x: 0.4, y: 1.7, yaw: -2.0}
+  radius: 0.1
   tags: [goal]

--- a/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -1,14 +1,15 @@
+custom_tags:
+- {name: hazard, description: DQN training hazard zone (avoidance target)}
+- {name: checkpoint, description: Intermediate training waypoint}
+
 route:
-  - name: route_1
-    waypoints: [meeting_room_a, conference_room, meeting_room_a]
-  - name: route_2
-    waypoints: [elevator_hall, corridor_a, conference_room]
+- name: avoidance_a
+  waypoints: [start_zone, checkpoint_west, training_goal]
+- name: avoidance_b
+  waypoints: [start_zone, checkpoint_east, training_goal]
 
 map:
-  - node_name: map_server
-    map_file: turtlebot3.yaml
-  # - node_name: map_server_localization
-  #   map_file: turtlebot3_amcl.yaml
+- {node_name: /map_server, map_file: turtlebot3.yaml}
 
 # mapoi_gazebo_bridge が SwitchMap 時に読む (ground_plane / sun は共通、world を構成する主モデルのみ swap)
 gazebo:
@@ -16,30 +17,32 @@ gazebo:
     uri: model://turtlebot3_dqn_world
     name: turtlebot3_dqn_world
 
+# turtlebot3_world (office テーマ) との視覚的区別を明確にするため、DQN 学習コースのメタファで
+# 5 POI を東西南北 + 中央の compass 配置にし、custom_tags も hazard / checkpoint で揃える。
+# SwitchMap デモで「明らかに別 map の POI に変わった」と一目で分かる構成。
 poi:
-  - name: elevator_hall
-    # pose: {x: 0.0, y: 0.0, yaw: 0.0}
-    pose: {x: -2.0, y: -0.5, yaw: 0.0}
-    radius: 0.5
-    tags: [goal, initial_pose]
-    description: エレベーターホール
-  - name: meeting_room_a
-    pose: {x: -0.5, y: -0.5, yaw: 0.0}
-    radius: 0.5
-    tags: [goal]
-    description: 会議室A
-  - name: conference_room
-    pose: {x: 0.5, y: -0.5, yaw: 1.57}
-    radius: 0.5
-    tags: [goal]
-    description: 大会議室
-  - name: corridor_a
-    pose: {x: 0.5, y: 0.5, yaw: -3.14}
-    radius: 0.5
-    tags: [goal, pause]
-    description: 廊下
-  - name: model_exhibit
-    pose: {x: -0.5, y: 0.5, yaw: -1.57}
-    radius: 0.5
-    tags: [goal, audio_info]
-    description: 模型展示
+- name: start_zone
+  description: DQN 学習開始地点
+  pose: {x: 0.0, y: 0.0, yaw: 0.0}
+  radius: 0.3
+  tags: [goal, initial_pose]
+- name: checkpoint_west
+  description: 西側中継点
+  pose: {x: -1.5, y: 0.0, yaw: 0.0}
+  radius: 0.3
+  tags: [goal, checkpoint]
+- name: checkpoint_east
+  description: 東側中継点
+  pose: {x: 1.5, y: 0.0, yaw: 3.14}
+  radius: 0.3
+  tags: [goal, checkpoint]
+- name: hazard_south
+  description: 南側ハザード (回避対象)
+  pose: {x: 0.0, y: -1.5, yaw: 0.0}
+  radius: 0.4
+  tags: [event, hazard]
+- name: training_goal
+  description: DQN 目標地点
+  pose: {x: 0.0, y: 1.5, yaw: -1.57}
+  radius: 0.3
+  tags: [goal]

--- a/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -1,12 +1,12 @@
 custom_tags:
-- {name: hazard, description: DQN training hazard zone (avoidance target)}
-- {name: checkpoint, description: Intermediate training waypoint}
+- {name: hazard, description: Hazard zone (avoidance target)}
+- {name: checkpoint, description: Intermediate waypoint}
 
 route:
 - name: avoidance_a
-  waypoints: [start_zone, checkpoint_west, training_goal]
+  waypoints: [start_zone, checkpoint_west, north_goal]
 - name: avoidance_b
-  waypoints: [start_zone, checkpoint_east, training_goal]
+  waypoints: [start_zone, checkpoint_east, north_goal]
 
 map:
 - {node_name: /map_server, map_file: turtlebot3.yaml}
@@ -17,14 +17,14 @@ gazebo:
     uri: model://turtlebot3_dqn_world
     name: turtlebot3_dqn_world
 
-# turtlebot3_world (office テーマ) と視覚的区別を明確にするため、DQN 学習コースのメタファで
-# 配置・半径ともに不均一にする。半径は Nav2 controller の xy_goal_tolerance (0.25) より大きく
-# 取る (Nav2 が POI radius 内に入る前にゴール判定で停止し、radius event が発火しないため)。
-# 最小 0.30 (5cm 余裕)、最大 0.45 で意味付け (中央 start_zone やや余裕、東 checkpoint は wall
-# 制約で最狭、南 hazard は最も広い危険ゾーン、北 training_goal は精密目標)。
+# turtlebot3_world (office テーマ) と視覚的区別を明確にするため、obstacle 多数の sandbox world で
+# navigation 精度が要求されるシーンに合わせて配置・半径ともに不均一化。半径は Nav2 controller の
+# xy_goal_tolerance (0.25) より大きく取る (Nav2 が POI radius 内に入る前にゴール判定で停止し、
+# radius event が発火しないため)。最小 0.30 (5cm 余裕)、最大 0.45 で意味付け (中央 start_zone は
+# 余裕、東 checkpoint は wall 制約で最狭、南 hazard は最も広い回避ゾーン、北 north_goal は精密目標)。
 poi:
 - name: start_zone
-  description: DQN 学習開始地点
+  description: 開始地点
   pose: {x: 0.0, y: 0.0, yaw: 0.0}
   radius: 0.40
   tags: [goal, initial_pose]
@@ -43,8 +43,8 @@ poi:
   pose: {x: 0.5, y: -1.3, yaw: 0.0}
   radius: 0.45
   tags: [event, hazard]
-- name: training_goal
-  description: DQN 目標地点
+- name: north_goal
+  description: 北側目標地点
   pose: {x: 0.4, y: 1.7, yaw: -2.0}
   radius: 0.30
   tags: [goal]

--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -16,29 +16,33 @@ gazebo:
   world_model:
     uri: model://turtlebot3_world
     name: turtlebot3_world
+# elevator_hall は initial_pose タグ付きで、Gazebo robot spawn のデフォルト位置 (-2, -0.5) と一致。
+# その他 4 POI は元の office グリッド配置 (±0.5) を踏襲しつつ、半径と yaw を不均一化:
+# - 半径を 0.5 均一から 0.10〜0.20 に縮小、各部屋の規模感に合わせて差を付ける
+# - 位置も grid 的整列 (-0.5 / 0.5) を少し崩して non-uniform に散らす
 poi:
 - description: エレベーターホール
   name: elevator_hall
-  pose: {x: -2, y: -0.5, yaw: 0}
-  radius: 0.5
+  pose: {x: -2.0, y: -0.5, yaw: 0.0}
+  radius: 0.20
   tags: [goal, initial_pose]
 - description: 会議室A
   name: meeting_room_a
-  pose: {x: -0.5, y: -0.5, yaw: 0}
-  radius: 0.5
+  pose: {x: -0.6, y: -0.6, yaw: 0.0}
+  radius: 0.15
   tags: [goal]
 - description: 大会議室
   name: conference_room
-  pose: {x: 0.5, y: -0.5, yaw: 1.57}
-  radius: 0.5
+  pose: {x: 0.7, y: -0.4, yaw: 1.57}
+  radius: 0.18
   tags: [goal]
 - description: 廊下
   name: corridor_a
-  pose: {x: 0.5, y: 0.5, yaw: -3.14}
-  radius: 0.5
+  pose: {x: 0.4, y: 0.6, yaw: -3.14}
+  radius: 0.12
   tags: [goal, pause]
 - description: 模型展示
   name: model_exhibit
   pose: {x: -0.5, y: 0.5, yaw: -1.57}
-  radius: 0.5
+  radius: 0.10
   tags: [goal, audio_info]

--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -17,32 +17,32 @@ gazebo:
     uri: model://turtlebot3_world
     name: turtlebot3_world
 # elevator_hall は initial_pose タグ付きで、Gazebo robot spawn のデフォルト位置 (-2, -0.5) と一致。
-# その他 4 POI は元の office グリッド配置 (±0.5) を踏襲しつつ、半径と yaw を不均一化:
-# - 半径を 0.5 均一から 0.10〜0.20 に縮小、各部屋の規模感に合わせて差を付ける
-# - 位置も grid 的整列 (-0.5 / 0.5) を少し崩して non-uniform に散らす
+# 半径は Nav2 controller の xy_goal_tolerance (0.25) より大きく取らないと、Nav2 が POI radius
+# 内に入る前にゴール判定で停止し radius event が発火しない。最小 0.30 (5cm 余裕) で各部屋の
+# 規模感に合わせ 0.30〜0.50 にバラす。位置も grid 的整列 (-0.5 / 0.5) を少し崩して非対称に。
 poi:
 - description: エレベーターホール
   name: elevator_hall
   pose: {x: -2.0, y: -0.5, yaw: 0.0}
-  radius: 0.20
+  radius: 0.50
   tags: [goal, initial_pose]
 - description: 会議室A
   name: meeting_room_a
   pose: {x: -0.6, y: -0.6, yaw: 0.0}
-  radius: 0.15
+  radius: 0.35
   tags: [goal]
 - description: 大会議室
   name: conference_room
   pose: {x: 0.7, y: -0.4, yaw: 1.57}
-  radius: 0.18
+  radius: 0.45
   tags: [goal]
 - description: 廊下
   name: corridor_a
   pose: {x: 0.4, y: 0.6, yaw: -3.14}
-  radius: 0.12
+  radius: 0.30
   tags: [goal, pause]
 - description: 模型展示
   name: model_exhibit
   pose: {x: -0.5, y: 0.5, yaw: -1.57}
-  radius: 0.10
+  radius: 0.40
   tags: [goal, audio_info]


### PR DESCRIPTION
## 概要

Close #79

\`turtlebot3_world\` と \`turtlebot3_dqn_stage1\` の \`mapoi_config.yaml\` の POI が完全一致 (名前・座標・タグ・description 全て同じ、全 radius 0.5 均一) で、SwitchMap で切り替えても見た目の差分が分からなかった。両 map の sample POI を **theme 区別 + 半径/位置を非対称化 + Nav2 整合の radius** で再設計する。

## 変更内容

### 1. \`turtlebot3_dqn_stage1\` を obstacle navigation sample に

| 項目 | 旧 (世界と同じ) | 新 |
|---|---|---|
| POI 名 | elevator_hall, meeting_room_a, conference_room, corridor_a, model_exhibit | start_zone, checkpoint_west, checkpoint_east, hazard_south, north_goal |
| 配置 | office 風 grid | 中央 + 散らした非対称 |
| custom_tags | (なし) | hazard, checkpoint |
| route | route_1 / route_2 (会議室間) | avoidance_a / avoidance_b (hazard 回避経路) |

semantics は generic な「obstacle 多数の sandbox world での navigation 例」とし、特定の用途 (学習・教材等) に縛らない中立的な命名 (POI 名・description ともに DQN 等の文字列を含めない)。

### 2. \`turtlebot3_world\` (office テーマ) も radius/位置を非対称化

| POI | 旧 radius | 新 radius | 位置 |
|---|---|---|---|
| elevator_hall (initial_pose) | 0.5 | **0.50** | (-2.0, -0.5) **維持** |
| meeting_room_a | 0.5 | 0.35 | (-0.6, -0.6) (-0.5 → -0.6 微調整) |
| conference_room | 0.5 | 0.45 | (0.7, -0.4) (0.5 → 0.7 微調整) |
| corridor_a | 0.5 | 0.30 | (0.4, 0.6) (0.5 → 0.4 微調整) |
| model_exhibit | 0.5 | 0.40 | (-0.5, 0.5) 維持 |

旧は全 radius 0.5 均一 + grid 整列だった。office セマンティクスは維持 (POI 名・description はそのまま)。

### 3. \`turtlebot3_dqn_stage1\` の最終 POI 配置

| POI | pose (x, y, yaw) | radius | tags |
|---|---|---|---|
| start_zone | (0.0, 0.0, 0.0) | 0.40 | goal, initial_pose |
| checkpoint_west | (-1.6, 0.5, 1.57) | 0.35 | goal, checkpoint |
| checkpoint_east | (1.4, -0.3, -1.6) | 0.30 | goal, checkpoint |
| hazard_south | (0.5, -1.3, 0.0) | 0.45 | event, hazard |
| north_goal | (0.4, 1.7, -2.0) | 0.30 | goal |

### 4. 設計判断

| 論点 | 採用 | 根拠 |
|---|---|---|
| radius の最小値 | **0.30** (Nav2 \`xy_goal_tolerance: 0.25\` + 5cm 余裕) | Nav2 controller が \`xy_goal_tolerance\` 内でゴール判定 → POI radius がそれより小さいと radius 内に入る前に Nav2 が止まり \`/mapoi_poi_events\` が発火しない |
| radius の最大値 | 0.50 (office)、0.45 (dqn) | wall 制約 (Codex round 3-5 で物理配置検証済み)、視覚的バラつきの上限として |
| start_zone 位置 | (0.0, 0.0, 0.0) | \`turtlebot3_dqn_stage1.launch.py\` の robot spawn default \`x_pose=0.0, y_pose=0.0\` と整合 (initial_pose タグで AMCL 初期化) |
| elevator_hall 位置 | (-2.0, -0.5) 維持 | \`gazebo_headless_aware.launch.yaml\` の default \`x_pose=-2.0, y_pose=-0.5\` と整合 |
| custom_tags | dqn 側に hazard/checkpoint 追加 | world (event/destination/landmark/audio_info) と区別 |
| 命名の中立化 | POI 名・description から特定用途 (DQN 等) 文字列を除去 | sample が generic な「obstacle navigation 例」として再利用しやすい |

### 5. mapoi_server side fixes (Codex review 由来)

- \`mapoi_server/maps/turtlebot3_dqn_stage1/\` も同じ obstacle テーマ YAML を反映 (round 1 low)
- \`mapoi_server/maps/turtlebot3_world/mapoi_config.yaml\` の \`map_file: turtlebot3.yaml\` (実体なし) → \`localization.yaml\` (実在) に修正 (round 5)

## 動作確認

- YAML パース: PyYAML \`safe_load\` で両 yaml + 両 maps_path 通過
- 物理配置: Codex round 3-5 で turtlebot3_world / turtlebot3_dqn_world の SDF (壁・cylinder) と PGM occupied cell に対し、新 POI radius 円との干渉なし確認 (最小余裕 ≒0.215m)
- 実機 (Jazzy/gz-sim, Docker): SwitchMap で robot teleport + AMCL 初期化が正常動作 (Humble/Classic は host ROS 2 環境の RMW 干渉により別 issue #84)

\`\`\`bash
git pull
colcon build --packages-up-to mapoi_turtlebot3_example --symlink-install
source ./install/setup.bash
export TURTLEBOT3_MODEL=burger
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml
# 別ターミナル
ros2 service call /switch_map mapoi_interfaces/srv/SwitchMap \"{map_name: turtlebot3_dqn_stage1}\"
\`\`\`

## Codex review 経緯

| round | 内容 |
|---|---|
| round 1 | low: mapoi_server/maps 側にも duplicate あり |
| fix \`a6fc322\` | mapoi_server 側にも同 obstacle テーマ YAML 適用 |
| round 2 | LGTM |
| (ユーザー指摘) | 半径と位置が均一すぎ |
| fix \`1604f91\` | 位置と半径を非対称化 (radius 0.10〜0.35) |
| round 3 | high: hazard_south と inner_wall_2 が約 0.325m 重なる |
| fix \`053146a\` | hazard_south を (0.5, -1.3) に移動 |
| round 4 | LGTM (dqn 側 physical placement) |
| (ユーザー指摘) | dqn 初期位置不一致 |
| fix \`b563fc5\` | start_zone を Gazebo spawn (0,0) に整合 |
| (ユーザー指摘) | turtlebot3_world も同様にバラす |
| fix \`d867d72\` | turtlebot3_world POI radius 縮小 + 位置バラし |
| round 5 | low: mapoi_server/maps/turtlebot3_world の map_file 不在 |
| fix \`1ae9515\` | map_file を localization.yaml に修正 |
| (ユーザー指摘) | radius が Nav2 xy_goal_tolerance より小さく event 不発 |
| fix \`9468517\` | radius を 0.30〜0.50 に拡大 (両 world) |
| (ユーザー指摘) | DQN 文字列を除去、命名を中立化 |
| fix \`7e3f468\` | training_goal → north_goal に rename、description / custom_tags / コメントから DQN 等を除去 |

## 関連

- PR #78 (merged): #75 \`mapoi_rviz2_publisher\` 動的 refresh — 動作確認時に sample 区別性低が顕在化したのが本 PR の起点
- issue #84 (新規): Dockerfile/compose で host RMW/DOMAIN_ID/CYCLONEDDS_URI を container 側で隔離 (Humble 環境ドリフトの根本対策)
- issue #85 (新規): system tag \`no_goal\` で Nav2 目的地に設定不可な reference-only POI のサポート (本 PR の hazard_south などが該当)
- 既存 \`turtlebot3_world\` の elevator_hall (-2.0, -0.5) と \`turtlebot3_dqn_stage1.launch.py\` の robot spawn default は launch 経由で整合済み

## Test plan

- [x] PyYAML safe_load で両 YAML パース確認
- [x] turtlebot3_world / turtlebot3_dqn_world SDF / PGM と新 POI 配置の物理整合確認 (Codex round 3-5)
- [x] (実機) Jazzy/gz-sim Docker で SwitchMap → AMCL 初期化 → POI 描画切替を確認
- [ ] (実機推奨) Humble + radius >0.25 で Nav2 ゴール → POI radius event 発火を確認
- [x] Codex review (round 5 後の \`9468517\` / \`7e3f468\` は usage limit でスキップ、\`1ae9515\` までは LGTM)