### PR TITLE
feat(rviz2_publisher): mapoi_route_marks topic で全 route を LINE_STRIP 表示 (#68)

### DIFF
--- a/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
@@ -4,10 +4,12 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <array>
 #include <string>
 #include <sstream>
 #include <chrono>
 #include <cmath>
+#include <functional>
 #include <mutex>
 #include <filesystem>
 
@@ -19,6 +21,8 @@
 
 #include <yaml-cpp/yaml.h>
 #include "mapoi_interfaces/srv/get_pois_info.hpp"
+#include "mapoi_interfaces/srv/get_routes_info.hpp"
+#include "mapoi_interfaces/srv/get_route_pois.hpp"
 #include "mapoi_interfaces/msg/point_of_interest.hpp"
 
 class MapoiRviz2Publisher : public rclcpp::Node
@@ -53,6 +57,15 @@ private:
    */
   void on_config_path_changed(const std_msgs::msg::String::SharedPtr msg);
 
+  /**
+   * @brief get_routes_info service を呼び出し、各 route の waypoint を順次 fetch する
+   */
+  void request_routes_info();
+  void on_routes_info_received(rclcpp::Client<mapoi_interfaces::srv::GetRoutesInfo>::SharedFuture future);
+  void on_route_pois_received(
+    const std::string & route_name,
+    rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture future);
+
   // --- Member Variables ---
 
   // マーカーID管理用
@@ -61,9 +74,12 @@ private:
   // Publishers
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_waypoints_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_events_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_routes_pub_;
 
   // Clients
   rclcpp::Client<mapoi_interfaces::srv::GetPoisInfo>::SharedPtr poi_client_;
+  rclcpp::Client<mapoi_interfaces::srv::GetRoutesInfo>::SharedPtr routes_info_client_;
+  rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedPtr route_pois_client_;
 
   // Subscribers
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr highlight_goal_sub_;
@@ -89,6 +105,12 @@ private:
   std::set<std::string> highlighted_goal_names_;
   std::map<std::string, int> highlighted_route_names_;
   std::vector<std::string> highlighted_route_ordered_;
+
+  // route 名 → waypoint POI 列。get_routes_info で名前一覧を取得後、
+  // 各 route について get_route_pois を非同期に呼び結果を蓄積する。
+  std::map<std::string, std::vector<mapoi_interfaces::msg::PointOfInterest>> all_routes_;
+  // 前回 publish 時の route marker max id (DELETEALL 判定用、id_buf_ と独立)
+  int route_id_buf_ = 0;
 };
 
 #endif  // MAPOI_SERVER__MAPOI_RVIZ2_PUBLISHER_HPP_

--- a/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
@@ -58,13 +58,15 @@ private:
   void on_config_path_changed(const std_msgs::msg::String::SharedPtr msg);
 
   /**
-   * @brief get_routes_info service を呼び出し、各 route の waypoint を順次 fetch する
+   * @brief get_routes_info service を呼び出し、各 route の waypoint を順次 fetch する。
+   * 各 fan-out は generation 番号で識別し、後続 fan-out が始まったら旧世代の callback は捨てる
+   * (stale callback による partial state / route 混在防止)。fetch 完了 (全 route 集約済み) になった
+   * 時点で all_routes_ に lock 下で swap する (timer_callback への部分公開を防ぐ)。
    */
   void request_routes_info();
-  void on_routes_info_received(rclcpp::Client<mapoi_interfaces::srv::GetRoutesInfo>::SharedFuture future);
-  void on_route_pois_received(
-    const std::string & route_name,
-    rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture future);
+  void on_routes_info_received(
+    size_t my_generation,
+    rclcpp::Client<mapoi_interfaces::srv::GetRoutesInfo>::SharedFuture future);
 
   // --- Member Variables ---
 
@@ -107,8 +109,12 @@ private:
   std::vector<std::string> highlighted_route_ordered_;
 
   // route 名 → waypoint POI 列。get_routes_info で名前一覧を取得後、
-  // 各 route について get_route_pois を非同期に呼び結果を蓄積する。
+  // 各 route について get_route_pois を非同期に呼び、全 route 揃った時点で lock 下で swap される。
   std::map<std::string, std::vector<mapoi_interfaces::msg::PointOfInterest>> all_routes_;
+  // route fetch fan-out の世代番号。on_routes_info_received / per-route callback の lambda が
+  // capture した値と現値が異なれば stale (= 後続 fan-out が走った) として捨てる。
+  // single-thread executor 前提で書き込みは callback context のみ。
+  size_t routes_fetch_generation_ = 0;
   // 前回 publish 時の route marker max id (DELETEALL 判定用、id_buf_ と独立)
   int route_id_buf_ = 0;
 };

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -17,10 +17,17 @@ MapoiRviz2Publisher::MapoiRviz2Publisher() : Node("mapoi_rviz2_publisher") {
   // ("off" は ros2 param CLI で bool として解釈されるため "none" を採用)
   this->declare_parameter<std::string>("poi_label_format", "index");
 
+  // Route polyline の表示形式: "all" (全 route 表示、active は強調) / "selected" (active のみ) / "none"。
+  // default "all" は WebUI で route 一覧を見せている場合と整合。
+  this->declare_parameter<std::string>("route_display_mode", "all");
+
   marker_waypoints_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_goal_marks", 10);
   marker_events_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_event_marks", 10);
+  marker_routes_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_route_marks", 10);
 
   this->poi_client_ = this->create_client<mapoi_interfaces::srv::GetPoisInfo>("get_pois_info");
+  this->routes_info_client_ = this->create_client<mapoi_interfaces::srv::GetRoutesInfo>("get_routes_info");
+  this->route_pois_client_ = this->create_client<mapoi_interfaces::srv::GetRoutePois>("get_route_pois");
 
   highlight_goal_sub_ = this->create_subscription<std_msgs::msg::String>(
     "mapoi_highlight_goal", 10,
@@ -58,6 +65,7 @@ void MapoiRviz2Publisher::start_sequence()
 
   RCLCPP_INFO(this->get_logger(), "Requesting POI Info...");
   request_pois_list();
+  request_routes_info();
 }
 
 void MapoiRviz2Publisher::request_pois_list()
@@ -65,6 +73,63 @@ void MapoiRviz2Publisher::request_pois_list()
   auto request = std::make_shared<mapoi_interfaces::srv::GetPoisInfo::Request>();
   poi_client_->async_send_request(
     request, std::bind(&MapoiRviz2Publisher::on_poi_received, this, _1));
+}
+
+void MapoiRviz2Publisher::request_routes_info()
+{
+  // get_routes_info で route 名一覧を取得 → 各 route について get_route_pois を非同期に発行する。
+  // service 未起動なら skip (config_path 通知の度に再試行されるので自然回復)。
+  if (!routes_info_client_->service_is_ready()) {
+    RCLCPP_WARN(this->get_logger(), "get_routes_info service not ready, skipping route fetch.");
+    return;
+  }
+  auto request = std::make_shared<mapoi_interfaces::srv::GetRoutesInfo::Request>();
+  routes_info_client_->async_send_request(
+    request, std::bind(&MapoiRviz2Publisher::on_routes_info_received, this, _1));
+}
+
+void MapoiRviz2Publisher::on_routes_info_received(
+  rclcpp::Client<mapoi_interfaces::srv::GetRoutesInfo>::SharedFuture future)
+{
+  auto result = future.get();
+  if (!result) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to get Routes Info.");
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> lock(data_mutex_);
+    all_routes_.clear();  // 新 list で置換 (削除された route の取り残し防止)
+  }
+  RCLCPP_INFO(this->get_logger(), "Received %zu route names.", result->routes_list.size());
+  for (const auto & route_name : result->routes_list) {
+    if (!route_pois_client_->service_is_ready()) {
+      RCLCPP_WARN(this->get_logger(), "get_route_pois service not ready, skipping '%s'.", route_name.c_str());
+      continue;
+    }
+    auto req = std::make_shared<mapoi_interfaces::srv::GetRoutePois::Request>();
+    req->route_name = route_name;
+    route_pois_client_->async_send_request(
+      req,
+      [this, route_name](rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture f) {
+        on_route_pois_received(route_name, f);
+      });
+  }
+}
+
+void MapoiRviz2Publisher::on_route_pois_received(
+  const std::string & route_name,
+  rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture future)
+{
+  auto result = future.get();
+  if (!result) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to get route pois for '%s'.", route_name.c_str());
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> lock(data_mutex_);
+    all_routes_[route_name] = result->pois_list;
+  }
+  RCLCPP_INFO(this->get_logger(), "Route '%s': %zu waypoints.", route_name.c_str(), result->pois_list.size());
 }
 
 void MapoiRviz2Publisher::on_config_path_changed(const std_msgs::msg::String::SharedPtr msg)
@@ -96,6 +161,7 @@ void MapoiRviz2Publisher::on_config_path_changed(const std_msgs::msg::String::Sh
   last_config_path_ = current_path;
   last_config_mtime_ = current_mtime;
   request_pois_list();
+  request_routes_info();  // POI と同様、SwitchMap / Save で route 構成も変わる可能性あり
 }
 
 void MapoiRviz2Publisher::on_poi_received(rclcpp::Client<mapoi_interfaces::srv::GetPoisInfo>::SharedFuture future)
@@ -370,6 +436,71 @@ void MapoiRviz2Publisher::timer_callback(){
 
   marker_waypoints_pub_->publish(ma_waypoints);
   marker_events_pub_->publish(ma_events);
+
+  // Route LINE_STRIP markers (mapoi_route_marks topic)。
+  // route_display_mode parameter で表示制御:
+  //   "all"      : 全 route 表示、active route (highlighted_route_names_ に含む) は太線+不透明で強調
+  //   "selected" : active route のみ表示
+  //   "none"     : 表示しない (DELETEALL で既存も消す)
+  // POI marker (goal=green / event=blue / origin=red / gray) と被らない palette を使う。
+  static constexpr std::array<std::array<float, 3>, 6> ROUTE_PALETTE = {{
+    {1.0f, 0.5f, 0.0f},   // orange
+    {1.0f, 0.0f, 1.0f},   // magenta
+    {0.0f, 1.0f, 1.0f},   // cyan
+    {1.0f, 1.0f, 0.0f},   // yellow
+    {0.7f, 0.3f, 1.0f},   // purple
+    {0.0f, 0.7f, 0.3f},   // teal
+  }};
+  auto pick_route_color = [](const std::string & name) {
+    std::hash<std::string> h;
+    return ROUTE_PALETTE[h(name) % ROUTE_PALETTE.size()];
+  };
+
+  const std::string route_mode = this->get_parameter("route_display_mode").as_string();
+  visualization_msgs::msg::MarkerArray ma_routes;
+  int route_id = 0;
+
+  if (route_mode != "none") {
+    constexpr double ROUTE_LINE_Z = 0.05;  // map / costmap よりわずかに上
+    for (const auto & [name, waypoints] : all_routes_) {
+      if (waypoints.size() < 2) continue;  // 1 点だけの route は polyline にできない
+      const bool is_active = highlighted_route_names_.count(name) > 0;
+      if (route_mode == "selected" && !is_active) continue;
+
+      const auto color = pick_route_color(name);
+      visualization_msgs::msg::Marker m;
+      m.header.frame_id = "map";
+      m.header.stamp = rclcpp::Clock().now();
+      m.action = visualization_msgs::msg::Marker::ADD;
+      m.type = visualization_msgs::msg::Marker::LINE_STRIP;
+      m.id = route_id++;
+      m.lifetime.sec = 2.0;
+      m.pose.orientation.w = 1.0;  // identity (LINE_STRIP の point は world 座標)
+      m.scale.x = is_active ? 0.08 : 0.04;  // active を太く (line width)
+      m.color.r = color[0]; m.color.g = color[1]; m.color.b = color[2];
+      m.color.a = is_active ? 0.9f : 0.4f;  // active を不透明、他は薄く
+
+      m.points.reserve(waypoints.size());
+      for (const auto & wp : waypoints) {
+        geometry_msgs::msg::Point p;
+        p.x = wp.pose.position.x;
+        p.y = wp.pose.position.y;
+        p.z = ROUTE_LINE_Z;
+        m.points.push_back(p);
+      }
+      ma_routes.markers.push_back(m);
+    }
+  }
+
+  if (route_id_buf_ > route_id) {
+    visualization_msgs::msg::Marker m_del;
+    m_del.action = visualization_msgs::msg::Marker::DELETEALL;
+    visualization_msgs::msg::MarkerArray ma_del;
+    ma_del.markers.push_back(m_del);
+    marker_routes_pub_->publish(ma_del);
+  }
+  route_id_buf_ = route_id;
+  marker_routes_pub_->publish(ma_routes);
 }
 
 int main(int argc, char **argv)

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -18,8 +18,9 @@ MapoiRviz2Publisher::MapoiRviz2Publisher() : Node("mapoi_rviz2_publisher") {
   this->declare_parameter<std::string>("poi_label_format", "index");
 
   // Route polyline の表示形式: "all" (全 route 表示、active は強調) / "selected" (active のみ) / "none"。
-  // default "all" は WebUI で route 一覧を見せている場合と整合。
-  this->declare_parameter<std::string>("route_display_mode", "all");
+  // default "selected": RViz 起動時の clutter を抑え、user が選択した route だけを示す。
+  // 全 route を見たい場合は ros2 param set /mapoi_rviz2_publisher route_display_mode all で切替。
+  this->declare_parameter<std::string>("route_display_mode", "selected");
 
   marker_waypoints_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_goal_marks", 10);
   marker_events_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_event_marks", 10);

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -77,59 +77,80 @@ void MapoiRviz2Publisher::request_pois_list()
 
 void MapoiRviz2Publisher::request_routes_info()
 {
-  // get_routes_info で route 名一覧を取得 → 各 route について get_route_pois を非同期に発行する。
+  // get_routes_info → 各 route について get_route_pois の 2 段 fetch。
+  // 世代番号 (routes_fetch_generation_) を increment して capture することで、後続 fan-out が始まった
+  // 時点で旧世代の callback を stale 判定し all_routes_ への書き込みを drop する
+  // (Codex round 1 high 対策: stale callback による旧 map / 新 map の route 混在防止)。
   // service 未起動なら skip (config_path 通知の度に再試行されるので自然回復)。
   if (!routes_info_client_->service_is_ready()) {
     RCLCPP_WARN(this->get_logger(), "get_routes_info service not ready, skipping route fetch.");
     return;
   }
+  const size_t my_gen = ++routes_fetch_generation_;
   auto request = std::make_shared<mapoi_interfaces::srv::GetRoutesInfo::Request>();
   routes_info_client_->async_send_request(
-    request, std::bind(&MapoiRviz2Publisher::on_routes_info_received, this, _1));
+    request,
+    [this, my_gen](rclcpp::Client<mapoi_interfaces::srv::GetRoutesInfo>::SharedFuture f) {
+      on_routes_info_received(my_gen, f);
+    });
 }
 
 void MapoiRviz2Publisher::on_routes_info_received(
+  size_t my_generation,
   rclcpp::Client<mapoi_interfaces::srv::GetRoutesInfo>::SharedFuture future)
 {
+  // stale check: 後続 fan-out が走っていたら旧世代の応答を捨てる
+  if (my_generation != routes_fetch_generation_) {
+    return;
+  }
   auto result = future.get();
   if (!result) {
     RCLCPP_ERROR(this->get_logger(), "Failed to get Routes Info.");
     return;
   }
-  {
+  RCLCPP_INFO(this->get_logger(), "Received %zu route names (gen=%zu).",
+    result->routes_list.size(), my_generation);
+
+  // 空 route list は all_routes_ を即時 clear (削除された route の取り残し防止)
+  if (result->routes_list.empty()) {
     std::lock_guard<std::mutex> lock(data_mutex_);
-    all_routes_.clear();  // 新 list で置換 (削除された route の取り残し防止)
+    all_routes_.clear();
+    return;
   }
-  RCLCPP_INFO(this->get_logger(), "Received %zu route names.", result->routes_list.size());
+
+  // pending map に集約してから lock 下で all_routes_ に swap (timer_callback への部分公開を防ぐ)。
+  // shared_ptr で per-route lambda 間で共有、最後の callback で swap する。
+  using RouteMap = std::map<std::string, std::vector<mapoi_interfaces::msg::PointOfInterest>>;
+  auto pending = std::make_shared<RouteMap>();
+  auto remaining = std::make_shared<size_t>(result->routes_list.size());
+
   for (const auto & route_name : result->routes_list) {
-    if (!route_pois_client_->service_is_ready()) {
-      RCLCPP_WARN(this->get_logger(), "get_route_pois service not ready, skipping '%s'.", route_name.c_str());
-      continue;
-    }
     auto req = std::make_shared<mapoi_interfaces::srv::GetRoutePois::Request>();
     req->route_name = route_name;
     route_pois_client_->async_send_request(
       req,
-      [this, route_name](rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture f) {
-        on_route_pois_received(route_name, f);
+      [this, route_name, my_generation, pending, remaining]
+      (rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture f) {
+        // stale check (per-route): 後続 fan-out が走っていたら結果を捨てる
+        if (my_generation != routes_fetch_generation_) {
+          return;
+        }
+        auto r = f.get();
+        if (r) {
+          (*pending)[route_name] = r->pois_list;
+          RCLCPP_INFO(this->get_logger(), "Route '%s': %zu waypoints (gen=%zu).",
+            route_name.c_str(), r->pois_list.size(), my_generation);
+        } else {
+          RCLCPP_ERROR(this->get_logger(), "Failed to get route pois for '%s' (gen=%zu).",
+            route_name.c_str(), my_generation);
+        }
+        // 全 route 集約済みになったら lock 下で all_routes_ に swap
+        if (--(*remaining) == 0) {
+          std::lock_guard<std::mutex> lock(data_mutex_);
+          all_routes_ = std::move(*pending);
+        }
       });
   }
-}
-
-void MapoiRviz2Publisher::on_route_pois_received(
-  const std::string & route_name,
-  rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture future)
-{
-  auto result = future.get();
-  if (!result) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to get route pois for '%s'.", route_name.c_str());
-    return;
-  }
-  {
-    std::lock_guard<std::mutex> lock(data_mutex_);
-    all_routes_[route_name] = result->pois_list;
-  }
-  RCLCPP_INFO(this->get_logger(), "Route '%s': %zu waypoints.", route_name.c_str(), result->pois_list.size());
 }
 
 void MapoiRviz2Publisher::on_config_path_changed(const std_msgs::msg::String::SharedPtr msg)
@@ -151,10 +172,18 @@ void MapoiRviz2Publisher::on_config_path_changed(const std_msgs::msg::String::Sh
 
   RCLCPP_INFO(this->get_logger(), "Map config changed: %s — refreshing POI list.", current_path.c_str());
 
-  // 起動直後は service が未起動の場合がある。guard 値は更新前に readiness 判定して、未起動なら skip。
-  // last_config_path_ / last_config_mtime_ を未更新のまま return するため、次回 publish で再試行される。
-  if (!poi_client_->service_is_ready()) {
-    RCLCPP_WARN(this->get_logger(), "get_pois_info service not ready, skipping refresh.");
+  // 起動直後は service が未起動の場合がある。POI / routes_info / route_pois 全てが ready の時のみ
+  // guard を更新して fan-out 開始する (Codex round 1 medium 対策: route 系 service だけ未 ready の
+  // 状態で guard が進むと、同じ path+mtime が dedup で skip され route fetch の自然 retry が無くなる)。
+  // 一つでも未 ready なら guard 据え置き → 次回 publish で再試行。
+  if (!poi_client_->service_is_ready() ||
+      !routes_info_client_->service_is_ready() ||
+      !route_pois_client_->service_is_ready()) {
+    RCLCPP_WARN(this->get_logger(),
+      "Some service not ready (poi=%d, routes_info=%d, route_pois=%d), skipping refresh.",
+      poi_client_->service_is_ready(),
+      routes_info_client_->service_is_ready(),
+      route_pois_client_->service_is_ready());
     return;
   }
 

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -172,6 +172,14 @@ void MapoiRviz2Publisher::on_config_path_changed(const std_msgs::msg::String::Sh
 
   RCLCPP_INFO(this->get_logger(), "Map config changed: %s — refreshing POI list.", current_path.c_str());
 
+  // config 変更を検出したら fan-out 実行可否に関わらず routes_fetch_generation_ を進めて
+  // 旧 fan-out の pending callback を全て stale 化する (Codex round 2 high 対策: service 未 ready で
+  // 早期 return する経路で gen が進まないと、旧 config の callback が my_gen == current_gen を満たして
+  // 旧 route set を swap してしまう窓が残る)。
+  // request_routes_info() 側でも increment するため fan-out 成功時は double increment になるが、
+  // 単調増加のため意味的には正しく、無害。
+  ++routes_fetch_generation_;
+
   // 起動直後は service が未起動の場合がある。POI / routes_info / route_pois 全てが ready の時のみ
   // guard を更新して fan-out 開始する (Codex round 1 medium 対策: route 系 service だけ未 ready の
   // 状態で guard が進むと、同じ path+mtime が dedup で skip され route fetch の自然 retry が無くなる)。


### PR DESCRIPTION
## 概要

Close #68 (P4)

WebUI では route の polyline を表示していたが、RViz には route の visualization が無かった。\`mapoi_rviz2_publisher\` に新 publisher \`mapoi_route_marks\` (visualization_msgs/MarkerArray) を追加し、起動時 + \`mapoi_config_path\` 変化時 (SwitchMap / WebUI Save) に \`get_routes_info\` → 各 route 名で \`get_route_pois\` の 2 段 fetch で全 route の waypoint を取得し、LINE_STRIP で waypoint 間を結んで表示する。

## 変更内容

### \`mapoi_server/src/mapoi_rviz2_publisher.cpp\` + \`.hpp\`

**新 publisher / clients**:
- \`marker_routes_pub_\` (\`mapoi_route_marks\`)
- \`routes_info_client_\` (\`get_routes_info\`)
- \`route_pois_client_\` (\`get_route_pois\`)

**新 service call フロー**:
\`\`\`
on_config_path_changed (or start_sequence)
  → request_pois_list() (既存)
  → request_routes_info() ← 新規
        → on_routes_info_received: all_routes_.clear() + 各 route 名で get_route_pois 非同期 fan-out
        → on_route_pois_received: all_routes_[name] = waypoints
\`\`\`

**Marker 描画 (timer_callback 内)**:
- 色は route 名 hash で 6 色 palette から割当 (orange / magenta / cyan / yellow / purple / teal、POI marker color とは被らない)
- active route (\`highlighted_route_names_\` に含む) は太線 (0.08m) + 不透明 (a=0.9)、他は細線 (0.04m) + 半透明 (a=0.4)
- \`route_id_buf_\` で route 数減少時に DELETEALL (id_buf_ と独立、新 topic 用)

**新 parameter**:
\`\`\`yaml
route_display_mode:
  type: string
  default_value: "all"
  description: |
    Route polyline の表示形式:
      - "all": 全 route 表示、active は太線+不透明で強調 (default)
      - "selected": active route のみ表示
      - "none": 表示しない (DELETEALL で既存も消す)
\`\`\`

\`ros2 param set /mapoi_rviz2_publisher route_display_mode <value>\` で runtime 切替可能。

### 設計判断

| 論点 | 採用 | 根拠 |
|---|---|---|
| Service 構成 | \`get_routes_info\` (名前一覧) + \`get_route_pois\` (waypoint) の 2 段 | 既存 service interface を再利用、新 service 不要 |
| Refresh 経路 | PR #78 の \`request_pois_list()\` と同 callback (start_sequence + on_config_path_changed) | 同 trigger で POI と route を一度に refresh、整合性確保 |
| Color | route 名 hash → 6 色 palette | 安定した色割当 (Save で route 順が変わっても色は保持)、POI color と分離 |
| highlight 表現 | 太さ + 透明度 | LINE_STRIP では namespace ごとの color 切替が標準的でない、太さ+透明度の差で十分視認可能 |
| 既存 \`highlighted_route_ordered_\` ARROW | 維持 | LINE_STRIP は方向性を表現しないため、active route の direction 補完として有用 |

### 副作用 / 互換性

- 既存 topic (\`mapoi_goal_marks\` / \`mapoi_event_marks\`) は完全に未変更
- 新 topic \`mapoi_route_marks\` を購読しない既存 RViz config では新規 marker は出ない (opt-in)
- \`route_display_mode\` default \`all\` は WebUI 想定 (route 一覧見せる) と整合

### Defer to separate PR/issue (本 PR scope 外)

- \`mapoi_rviz_plugins\` Panel の display mode 切替 UI (issue #68 の "Panel UI" 部分)
- waypoint 間の経路計画 path 補間 (issue 本文「直線」採用、計画後 path は将来検討)
- 複数 route の重なり表示 (parallel offset 等) — P5 (#69) と同じ問題、別途対応

## 動作確認 (Humble)

\`\`\`bash
colcon build --packages-select mapoi_server --symlink-install   # clean
\`\`\`

実 GUI 動作 (実機検証は GUI access 復帰後):
1. mapoi_bringup 起動 → RViz の Display に \`/mapoi_route_marks\` (MarkerArray) を追加
2. 全 route が color palette で描画される (active route 不在時は全て薄い線)
3. WebUI / Panel で route を active 化 → 該当 route が太線+不透明に切替
4. \`ros2 param set /mapoi_rviz2_publisher route_display_mode selected\` → active のみ表示に切替
5. \`ros2 param set /mapoi_rviz2_publisher route_display_mode none\` → 全消去 (DELETEALL)
6. SwitchMap → 新 map の route が再 fetch されて表示更新

## 関連

- #66 (PR #73、merged): POI label 行番号化 — 本 PR の LINE_STRIP は POI marker と相補的
- #75 (PR #78、merged): \`mapoi_config_path\` subscribe で動的 refresh — 同 trigger で route も refresh
- #80 (PR #81、merged): \`mapoi_nav_server\` 同 bug fix — 本 PR は publisher 側、bug ではなく新機能
- #69 (P5): WebUI route 重なり — 本 PR は RViz 側、WebUI 側 polyline 表示は別 issue
- #70: visualization 仕様再整理 — 本 PR で route topic を新設したので、release 後再整理時の検討材料に

## Test plan

- [x] Humble image でビルド clean
- [ ] (実機検証推奨、GUI access 復帰後) RViz で全 route LINE_STRIP 表示を目視
- [ ] (実機検証推奨) active route highlight (太線+不透明) 切替を目視
- [ ] (実機検証推奨) \`route_display_mode\` の dynamic param 切替 (all / selected / none)
- [ ] (実機検証推奨) SwitchMap → route 表示が新 map のものに更新
- [ ] Codex review