### PR TITLE
fix(compose): image タグを distro 別 (mapoi:dev-${ROS_DISTRO}) にして並行運用 + 切替時 rebuild 不要に (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ ROS_DISTRO=jazzy docker compose build
 ROS_DISTRO=jazzy docker compose up demo
 ```
 
+ローカル image は `mapoi:dev-${ROS_DISTRO}` / `mapoi:demo-${ROS_DISTRO}` の形 (例: `mapoi:dev-jazzy` / `mapoi:demo-humble`) で distro 別に保存されます。Humble と Jazzy を同時に保持・並行実行可能で、distro 切替時の rebuild も不要です。
+
 pull 済みイメージを使う場合は `ghcr.io/shimz-robotics/mapoi:jazzy` を直接 `docker run` する方が手軽です（上の「ビルド済みイメージから試す」節を参照）。Jazzy は Nav2 lifecycle 立ち上げに 30〜60 秒かかるので起動直後に kill しないでください。
 
 ## 主な機能

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,16 @@
 #   xhost +local:docker
 #
 # 開発用 (bind mount + bash):
-#   docker compose run --rm dev
+#   docker compose run --rm dev                   # default Humble (Gazebo Classic)
+#   ROS_DISTRO=jazzy docker compose run --rm dev  # Jazzy (gz-sim)
 #
 # お試し/デモ (Turtlebot3 + Gazebo + mapoi):
 #   docker compose up demo
-#
-# Jazzy を試す場合（Gazebo Harmonic）:
-#   ROS_DISTRO=jazzy docker compose build
 #   ROS_DISTRO=jazzy docker compose up demo
+#
+# image タグは ROS_DISTRO を含む形 (例: mapoi:dev-humble / mapoi:dev-jazzy) で
+# distro 別に保持される。distro 切替時の rebuild は不要、両方を同時並行で持てる。
+# 初回 build は明示的に: ROS_DISTRO=<distro> docker compose build dev (or demo)
 services:
   dev:
     build:
@@ -21,7 +23,11 @@ services:
         ROS_DISTRO: ${ROS_DISTRO:-humble}
         USER_ID: ${USER_ID:-1000}
         GROUP_ID: ${GROUP_ID:-1000}
-    image: mapoi:dev
+    # image タグに ROS_DISTRO を含めて distro 別に保持する。
+    # 共通タグ (mapoi:dev) だと build arg を変えても 'docker compose run' は前回 build を
+    # silently 再利用する (ARG 変更で cache invalidate されるのは build 時のみ)。
+    # distro 別タグなら humble / jazzy 両 image を独立保持でき、切替時の rebuild も並行運用も不要。
+    image: mapoi:dev-${ROS_DISTRO:-humble}
     network_mode: host
     ipc: host
     environment:
@@ -49,7 +55,8 @@ services:
         ROS_DISTRO: ${ROS_DISTRO:-humble}
         USER_ID: ${USER_ID:-1000}
         GROUP_ID: ${GROUP_ID:-1000}
-    image: mapoi:demo
+    # dev と同じく distro 別タグで保持
+    image: mapoi:demo-${ROS_DISTRO:-humble}
     network_mode: host
     ipc: host
     environment:


### PR DESCRIPTION
## 概要

Close #90

`docker-compose.yml` の image タグが共通 (`mapoi:dev` / `mapoi:demo`) のため、build arg `ROS_DISTRO` で複数 distro (humble / jazzy) を切り替える設計と相性が悪く、切替時に明示的 `docker compose build` を打たないと前回 build を silently 再利用する罠があった。

実例: 2026-04-27 PR #82 検証で `ROS_DISTRO=humble docker compose run --rm dev` を実行したのに container 内が前回 jazzy build のまま (gz-sim が動いている) で、ユーザーが気付くまで時間ロス。

本 PR で image タグに `${ROS_DISTRO:-humble}` を埋め込み、distro 別タグ (`mapoi:dev-humble` / `mapoi:dev-jazzy`) にする。

## 変更内容

### `docker-compose.yml`

```diff
   dev:
-    image: mapoi:dev
+    image: mapoi:dev-${ROS_DISTRO:-humble}

   demo:
-    image: mapoi:demo
+    image: mapoi:demo-${ROS_DISTRO:-humble}
```

ヘッダコメントも humble / jazzy 両方の使用例 + image タグ命名規則の注記を追記。

### `README.md`

Jazzy compose 節に distro 別タグ命名規則と並行運用の説明を 1 行追記 (Codex round 1 low #3 対応)。

## 効果

| 項目 | 変更前 | 変更後 |
|---|---|---|
| 切替時 rebuild | 必要 (`docker compose build`) | 不要 (各 distro 別 image で保持) |
| 並行運用 | 不可 (1 image を上書き) | 可 (humble / jazzy 同時保持) |
| どの image で動くか | tag からは不明 | tag に distro 名で自明 |

## 動作確認

```bash
$ docker compose config | grep -E '^\s+image:'
    image: mapoi:demo-humble
    image: mapoi:dev-humble

$ ROS_DISTRO=jazzy docker compose config | grep -E '^\s+image:'
    image: mapoi:demo-jazzy
    image: mapoi:dev-jazzy
```

期待どおり distro 別タグに resolve される。

## 影響と migration

- 既存の `mapoi:dev` / `mapoi:demo` image は **local tag として残るが新 compose からは未参照になる (orphan tag)** → 不要なら手動 `docker image rm mapoi:dev mapoi:demo` で cleanup (Codex round 1 low #2 表現修正)
- 各 distro での **初回利用時は必ず `docker compose build` が必要** (旧 image の再利用が行われないため)
- 既存の build / run コマンド (`docker compose build dev` / `docker compose run --rm dev`) はそのまま動作、image tag が透明に切替わる
- CI / 公開 image tag の運用に影響あれば調整必要 (現状 CI は `docker/build-push-action` で ghcr tag を直接管理しており、本 PR の compose tag 変更とは独立、影響なし [Codex round 1 確認済み])

## 関連

- 別 issue #84 (Dockerfile/compose で host RMW/DOMAIN_ID/CYCLONEDDS_URI 隔離): 同じ docker-compose hygiene 系、独立 PR で対応予定
- 検証契機: PR #82 (#79 sample POI) の Humble Docker 検証で罠を踏んだ
- lessons codify 済 (auto memory `lessons.md` 2026-04-27)

## Test plan

- [x] `docker compose config` で humble / jazzy 両方の resolve 確認
- [ ] (実機推奨) `ROS_DISTRO=humble docker compose build dev` → `docker compose run --rm dev` で humble 起動
- [ ] (実機推奨) `ROS_DISTRO=jazzy docker compose build dev` → `ROS_DISTRO=jazzy docker compose run --rm dev` で jazzy 起動
- [ ] (実機推奨) 両 image が `docker images` で並列保持されることを確認
- [x] Codex review (round 1 + round 2 LGTM)