### PR TITLE
feat(poi_editor): SaveButton の Save success feedback (緑+SAVED) を 1.5 秒間 visible にする (#77)

### DIFF
--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -5,6 +5,7 @@
 
 #include <QFileDialog>
 #include <QStandardPaths>
+#include <QTimer>
 
 #include "ui_poi_editor.h"
 
@@ -262,7 +263,12 @@ void PoiEditorPanel::SaveButton()
   // 番号は元の logical order のまま (例: [3, 1, 2] のように見える)。
   // saved YAML を fetch し直して table を再構築することで visual = logical を揃え、
   // 番号が 1, 2, 3, ... に並ぶようにする。drag 中の background highlight (Qt::green) も解除。
-  UpdatePoiTable();
+  //
+  // delay を入れて SAVED + green を 1.5 秒見せてから rebuild する (issue #77)。
+  // 即時 rebuild だと UpdatePoiTable() が text/style を即 reset するため、Save 成功 feedback が
+  // ほぼ見えない (reload service が高速なほど顕著)。QTimer::singleShot で Qt event loop に戻して
+  // SAVED + green の paint を保証してから 1.5 秒後に rebuild。
+  QTimer::singleShot(1500, this, [this]() { UpdatePoiTable(); });
 }
 
 // Subscription Callback
@@ -594,6 +600,9 @@ void PoiEditorPanel::UpdatePoiTable()
   }
   is_table_color_ = true;
   ui_->SaveButton->setText("save");
+  // 空 list (numRows == 0) では setItem 由来の cellChanged 副作用が発火せず、SAVED 時の
+  // green stylesheet が残ったままになる症状 (issue #77 症状 2) を明示リセットで防ぐ。
+  ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
   UpdatePoiCount();
 }
 

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -268,7 +268,17 @@ void PoiEditorPanel::SaveButton()
   // 即時 rebuild だと UpdatePoiTable() が text/style を即 reset するため、Save 成功 feedback が
   // ほぼ見えない (reload service が高速なほど顕著)。QTimer::singleShot で Qt event loop に戻して
   // SAVED + green の paint を保証してから 1.5 秒後に rebuild。
-  QTimer::singleShot(1500, this, [this]() { UpdatePoiTable(); });
+  //
+  // 同じ 1.5 秒の間に再 Save 連打されると pending rebuild と新 Save flow が race するため、
+  // SaveButton を disable して連打防止。timer 完了時に setEnabled(true) で復帰。
+  // 注: 1.5 秒間に Reset / MapCombo 等の他 UpdatePoiTable 呼び出しが入ると順序競合あり得るが、
+  // 短い窓 + Save 直後の操作頻度低さから許容。必要なら future PR で member QTimer + cancel
+  // pattern に拡張可能。
+  ui_->SaveButton->setEnabled(false);
+  QTimer::singleShot(1500, this, [this]() {
+    UpdatePoiTable();
+    ui_->SaveButton->setEnabled(true);
+  });
 }
 
 // Subscription Callback


### PR DESCRIPTION
## 概要

Close #77

POI Editor Panel の SaveButton の Save success feedback (緑 + "SAVED!") に関する 2 つの症状を一括解消:

### 症状 1: 緑 + SAVED がほぼ見えない (PR #78 検証で発見)

`SaveButton()` で text を `SAVED!` + green に変えた直後に `UpdatePoiTable()` が走り、即座に `save` + white に戻る。reload service が高速なほど SAVED の表示時間が短く、ユーザーが Save 成功を視認できない。

### 症状 2: 空 POI list で green stylesheet が残る (PR #76 Codex round 2 low)

空 list では `setItem()` 由来の `cellChanged` 副作用が発火せず、`UpdatePoiTable()` 末尾の `setText("save")` で text は戻るが green style が残る。

## 修正内容

### `mapoi_rviz_plugins/src/poi_editor.cpp`

#### 1. `SaveButton()` 末尾: `UpdatePoiTable()` を QTimer で 1.5 秒 delay

```diff
   rclcpp::spin_until_future_complete(service_node_, result_reload_map_info);
-  UpdatePoiTable();
+  // delay を入れて SAVED + green を 1.5 秒見せてから rebuild する (issue #77)
+  QTimer::singleShot(1500, this, [this]() { UpdatePoiTable(); });
```

Qt event loop に戻して SAVED + green の paint を保証してから 1.5 秒後に rebuild。

#### 2. `UpdatePoiTable()` 末尾: stylesheet を明示リセット

```diff
   ui_->SaveButton->setText("save");
+  // 空 list でも green が残らないよう明示リセット (issue #77 症状 2)
+  ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
   UpdatePoiCount();
```

既存の他リセット箇所 (line 117/153/165) と同じ pattern。空 list (`numRows == 0`) でも cellChanged 副作用に依存せず確実に green が解除される。

#### 3. `<QTimer>` include 追加

## 設計判断

| 論点 | 採用 | 根拠 |
|---|---|---|
| delay 時間 | **1500ms** | 短すぎると視認難、長すぎると次操作の妨げ。1〜2 秒の中間値 |
| QTimer vs sleep | `QTimer::singleShot` (非同期) | sleep は Qt event loop を block して SAVED の paint も止まる、QTimer は event loop に戻して paint を確実に動かす |
| style 明示 reset の場所 | `UpdatePoiTable()` 末尾 | Save flow 以外の `UpdatePoiTable()` 呼び出し (新マップ load 等) でも一貫した state に戻す |
| stylesheet 値 | `QPushButton {background-color: white; color: black;}` | 既存の他 reset 箇所 (line 117/153/165) と完全一致 |

## 副作用

- `UpdatePoiTable()` を SaveButton から呼ぶ場面が delay 化され、reload 完了から 1.5 秒間は古い table 表示が残る (drag した順序のまま)。drag 中の Qt::green background highlight も 1.5 秒残るが、SAVED feedback と整合する自然な挙動
- `UpdatePoiTable()` の他呼び出し (line 103/108/152/164/308/551) は delay されない (直接呼出)、影響なし

## 動作確認 (Humble)

```bash
colcon build --packages-select mapoi_rviz_plugins --symlink-install   # clean
```

実 GUI 動作 (実機検証推奨):

### 症状 1 検証

1. POI Editor Panel で行を drag 並び替え
2. Save クリック
3. **期待**: SAVED + green が **1.5 秒間** はっきり見える
4. その後: green が消えて save に戻り、行頭番号が visual order に reset

### 症状 2 検証

1. POI Editor Panel で全 POI を削除して空にする
2. Save クリック
3. **期待**: SAVED + green が 1.5 秒見えた後、save + white に戻る (空 list でも green が残らない)

## 関連

- PR #76 (#74、merged): Save 後 table rebuild の本体 (本 issue の根本原因を導入)
- PR #78 (#75、merged): 検証時に症状 1 が顕在化
- Codex round 2 (PR #76): https://github.com/shimz-robotics/mapoi/pull/76#issuecomment-4320710824 (症状 2 出典)

## Test plan

- [x] Humble image でビルド clean
- [ ] (実機検証推奨) 症状 1: drag → Save → SAVED + green 1.5 秒可視
- [ ] (実機検証推奨) 症状 2: 空 list → Save → green 残らずに save + white 復帰
- [ ] Codex review