### PR TITLE
feat(rviz_plugins): POI Editor Panel に Display Settings group を追加 (#99)

### DIFF
--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -99,6 +99,12 @@ protected:
   QRadioButton * label_radio_none_ = nullptr;
   QDoubleSpinBox * arrow_size_spin_ = nullptr;
 
+  // 最後に publisher と一致が確認できた値の cache。SetParameters 失敗時に UI を revert する元になる。
+  // 初期値は publisher の declare_parameter default と一致 (sync 成功すればその値で更新される)。
+  std::string cached_route_mode_ = "selected";
+  std::string cached_label_fmt_ = "index";
+  double cached_arrow_size_ = 1.0;
+
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr poi_pose_sub_;
   void PoiPoseCallback(geometry_msgs::msg::PoseStamped::SharedPtr msg);
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr config_path_sub_;
@@ -115,7 +121,12 @@ protected:
 
   // Display Settings UI を mapoi_rviz2_publisher の現在 parameter 値に同期する。
   // onInitialize 末尾の初期同期と、SetParameters 失敗時の UI rollback の両方で使う。
+  // 成功時は cached_* を更新する。
   void SyncDisplaySettingsFromPublisher();
+
+  // service down 等で sync が失敗した場合、cached_* に基づいて UI を revert する。
+  // SyncDisplaySettingsFromPublisher() で sync を試みた後 (cache 未更新) のフォールバック用。
+  void RevertDisplaySettingsUiFromCache();
 
   std::string join(const std::vector<std::string>& v, const char* delim);
   std::vector<std::string> SplitSentence(std::string sentence,

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -113,6 +113,10 @@ protected:
   bool ValidatePois();
   double calcYaw(geometry_msgs::msg::Pose pose);
 
+  // Display Settings UI を mapoi_rviz2_publisher の現在 parameter 値に同期する。
+  // onInitialize 末尾の初期同期と、SetParameters 失敗時の UI rollback の両方で使う。
+  void SyncDisplaySettingsFromPublisher();
+
   std::string join(const std::vector<std::string>& v, const char* delim);
   std::vector<std::string> SplitSentence(std::string sentence,
                                          std::string delimiter);

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -2,6 +2,7 @@
 
 #ifndef Q_MOC_RUN
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/parameter_client.hpp>
 #include <filesystem>
 #include <set>
 
@@ -25,6 +26,8 @@
 
 #include <QMessageBox>
 #include <QLabel>
+#include <QRadioButton>
+#include <QDoubleSpinBox>
 
 namespace Ui {
 class PoiEditorUi;
@@ -82,6 +85,19 @@ protected:
   rclcpp::Client<mapoi_interfaces::srv::GetMapsInfo>::SharedPtr get_maps_info_client_;
   rclcpp::Client<mapoi_interfaces::srv::GetTagDefinitions>::SharedPtr get_tag_defs_client_;
   rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr reload_map_info_client_;
+
+  // Parameter client for /mapoi_rviz2_publisher (Display Settings UI が制御する)
+  rclcpp::AsyncParametersClient::SharedPtr rviz2_pub_param_client_;
+
+  // Display Settings widgets (programmatically created in constructor)
+  QRadioButton * route_radio_all_ = nullptr;
+  QRadioButton * route_radio_selected_ = nullptr;
+  QRadioButton * route_radio_none_ = nullptr;
+  QRadioButton * label_radio_index_ = nullptr;
+  QRadioButton * label_radio_name_ = nullptr;
+  QRadioButton * label_radio_both_ = nullptr;
+  QRadioButton * label_radio_none_ = nullptr;
+  QDoubleSpinBox * arrow_size_spin_ = nullptr;
 
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr poi_pose_sub_;
   void PoiPoseCallback(geometry_msgs::msg::PoseStamped::SharedPtr msg);

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -145,27 +145,40 @@ void PoiEditorPanel::onInitialize()
   }
 
   // Connect signals → set_parameters service call.
-  // service 未起動・spin timeout・SetParametersResult unsuccessful のいずれかで失敗した場合は
-  // UI を publisher の現在状態に rollback (UI/publisher state ズレ防止、Codex round 1 中)。
-  auto send_param = [this](const std::string & name, const rclcpp::ParameterValue & value) {
+  // 失敗 (service 未起動 / spin timeout / SetParametersResult unsuccessful) いずれの場合も:
+  //   1. SyncDisplaySettingsFromPublisher() で publisher 真値で UI 更新を試みる (sync 成功なら
+  //      UI = publisher で cache も更新される)
+  //   2. それも失敗 (= service 完全 down) なら RevertDisplaySettingsUiFromCache() で
+  //      最後に publisher と一致が確認できた値 (cached_*) に UI を戻す
+  // これで UI/publisher state ズレ問題は service 状態に関わらず必ず収束 (Codex round 1-3 中)。
+  auto fail_recovery = [this](const std::string & name, const std::string & reason) {
+    RCLCPP_WARN(LOGGER, "SetParameters failed for %s (%s), reverting UI", name.c_str(), reason.c_str());
+    SyncDisplaySettingsFromPublisher();
+    RevertDisplaySettingsUiFromCache();
+  };
+  auto send_param = [this, fail_recovery](const std::string & name, const rclcpp::ParameterValue & value) {
     if (!rviz2_pub_param_client_->service_is_ready()) {
-      RCLCPP_WARN(LOGGER, "mapoi_rviz2_publisher parameter service not ready (%s), syncing UI",
-        name.c_str());
-      SyncDisplaySettingsFromPublisher();
+      fail_recovery(name, "service not ready");
       return;
     }
     auto fut = rviz2_pub_param_client_->set_parameters({rclcpp::Parameter(name, value)});
     auto rc = rclcpp::spin_until_future_complete(service_node_, fut, 100ms);
     if (rc != rclcpp::FutureReturnCode::SUCCESS) {
-      RCLCPP_WARN(LOGGER, "SetParameters timeout for %s, syncing UI", name.c_str());
-      SyncDisplaySettingsFromPublisher();
+      fail_recovery(name, "spin timeout");
       return;
     }
     auto results = fut.get();
     if (results.empty() || !results[0].successful) {
-      RCLCPP_WARN(LOGGER, "SetParameters rejected for %s: %s, syncing UI",
-        name.c_str(), results.empty() ? "no result" : results[0].reason.c_str());
-      SyncDisplaySettingsFromPublisher();
+      fail_recovery(name, results.empty() ? "no result" : results[0].reason);
+      return;
+    }
+    // 成功: cache 更新 (publisher が受理した値 = 確定値、次回失敗時の revert 元として記憶)
+    if (name == "route_display_mode") {
+      cached_route_mode_ = value.get<std::string>();
+    } else if (name == "poi_label_format") {
+      cached_label_fmt_ = value.get<std::string>();
+    } else if (name == "arrow_size_ratio") {
+      cached_arrow_size_ = value.get<double>();
     }
   };
   auto send_string_param = [send_param](const std::string & name, const std::string & value) {
@@ -205,6 +218,7 @@ void PoiEditorPanel::SyncDisplaySettingsFromPublisher()
 {
   // CLI で先に変更されていた場合や SetParameters 失敗時に、UI を publisher の真値に寄せる。
   // 失敗時 (publisher 未起動 / timeout) は何もしない (UI は変えない、log は呼び出し側で出力)。
+  // 成功時は cache (cached_*) も同時に publisher 真値で更新する。
   if (!rviz2_pub_param_client_->wait_for_service(50ms)) {
     return;  // 短い wait、ready でなければ skip
   }
@@ -222,6 +236,11 @@ void PoiEditorPanel::SyncDisplaySettingsFromPublisher()
   const std::string route_mode = params[0].as_string();
   const std::string label_fmt = params[1].as_string();
   const double arrow_size = params[2].as_double();
+
+  // cache 更新 (publisher 真値が記憶される、次回 SetParameters 失敗時の revert 元として使用)
+  cached_route_mode_ = route_mode;
+  cached_label_fmt_ = label_fmt;
+  cached_arrow_size_ = arrow_size;
 
   // QSignalBlocker で setChecked / setValue が SetParameters を再発火させないようにする
   QSignalBlocker b1(route_radio_all_);
@@ -243,6 +262,33 @@ void PoiEditorPanel::SyncDisplaySettingsFromPublisher()
   else label_radio_index_->setChecked(true);  // default fallback
 
   arrow_size_spin_->setValue(arrow_size);
+}
+
+void PoiEditorPanel::RevertDisplaySettingsUiFromCache()
+{
+  // service 完全 down 等で SyncDisplaySettingsFromPublisher が no-op だった場合のフォールバック。
+  // cached_* は最後に publisher と一致が確認できた値 (初期同期 or 直前の SetParameters 成功時)。
+  // 通常は呼び出し側 (fail_recovery) で必ず Sync を試みた直後に呼ぶため、Sync 成功時は
+  // cache が UI と一致していて revert は no-op になる。
+  QSignalBlocker b1(route_radio_all_);
+  QSignalBlocker b2(route_radio_selected_);
+  QSignalBlocker b3(route_radio_none_);
+  QSignalBlocker b4(label_radio_index_);
+  QSignalBlocker b5(label_radio_name_);
+  QSignalBlocker b6(label_radio_both_);
+  QSignalBlocker b7(label_radio_none_);
+  QSignalBlocker b8(arrow_size_spin_);
+
+  if (cached_route_mode_ == "all") route_radio_all_->setChecked(true);
+  else if (cached_route_mode_ == "none") route_radio_none_->setChecked(true);
+  else route_radio_selected_->setChecked(true);
+
+  if (cached_label_fmt_ == "name") label_radio_name_->setChecked(true);
+  else if (cached_label_fmt_ == "both") label_radio_both_->setChecked(true);
+  else if (cached_label_fmt_ == "none") label_radio_none_->setChecked(true);
+  else label_radio_index_->setChecked(true);
+
+  arrow_size_spin_->setValue(cached_arrow_size_);
 }
 
 void PoiEditorPanel::onEnable()

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -145,24 +145,34 @@ void PoiEditorPanel::onInitialize()
   }
 
   // Connect signals → set_parameters service call.
-  // 100ms timeout で軽く spin、UI を block しすぎないようにする (失敗時は warning ログ)。
-  auto send_string_param = [this](const std::string & name, const std::string & value) {
+  // service 未起動・spin timeout・SetParametersResult unsuccessful のいずれかで失敗した場合は
+  // UI を publisher の現在状態に rollback (UI/publisher state ズレ防止、Codex round 1 中)。
+  auto send_param = [this](const std::string & name, const rclcpp::ParameterValue & value) {
     if (!rviz2_pub_param_client_->service_is_ready()) {
-      RCLCPP_WARN(LOGGER, "mapoi_rviz2_publisher parameter service not ready, skipping set %s",
+      RCLCPP_WARN(LOGGER, "mapoi_rviz2_publisher parameter service not ready (%s), syncing UI",
         name.c_str());
+      SyncDisplaySettingsFromPublisher();
       return;
     }
     auto fut = rviz2_pub_param_client_->set_parameters({rclcpp::Parameter(name, value)});
-    rclcpp::spin_until_future_complete(service_node_, fut, 100ms);
+    auto rc = rclcpp::spin_until_future_complete(service_node_, fut, 100ms);
+    if (rc != rclcpp::FutureReturnCode::SUCCESS) {
+      RCLCPP_WARN(LOGGER, "SetParameters timeout for %s, syncing UI", name.c_str());
+      SyncDisplaySettingsFromPublisher();
+      return;
+    }
+    auto results = fut.get();
+    if (results.empty() || !results[0].successful) {
+      RCLCPP_WARN(LOGGER, "SetParameters rejected for %s: %s, syncing UI",
+        name.c_str(), results.empty() ? "no result" : results[0].reason.c_str());
+      SyncDisplaySettingsFromPublisher();
+    }
   };
-  auto send_double_param = [this](const std::string & name, double value) {
-    if (!rviz2_pub_param_client_->service_is_ready()) {
-      RCLCPP_WARN(LOGGER, "mapoi_rviz2_publisher parameter service not ready, skipping set %s",
-        name.c_str());
-      return;
-    }
-    auto fut = rviz2_pub_param_client_->set_parameters({rclcpp::Parameter(name, value)});
-    rclcpp::spin_until_future_complete(service_node_, fut, 100ms);
+  auto send_string_param = [send_param](const std::string & name, const std::string & value) {
+    send_param(name, rclcpp::ParameterValue(value));
+  };
+  auto send_double_param = [send_param](const std::string & name, double value) {
+    send_param(name, rclcpp::ParameterValue(value));
   };
 
   // route_display_mode: toggled(checked=true) のみ反応 (false 側 toggle で重複 send しない)
@@ -187,50 +197,52 @@ void PoiEditorPanel::onInitialize()
   connect(arrow_size_spin_, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
     [send_double_param](double value) { send_double_param("arrow_size_ratio", value); });
 
-  // 初期同期: publisher から現在の parameter 値を読んで UI に反映 (Codex round 1 中)
-  // CLI で先に変更されていた場合や、Panel 起動時の publisher 状態に UI を寄せる目的。
-  // 失敗時 (publisher 未起動など) は default のまま (warning ログのみ)。
-  // service ready check + 200ms wait_for_service で起動待ち。
-  if (rviz2_pub_param_client_->wait_for_service(200ms)) {
-    auto fut = rviz2_pub_param_client_->get_parameters(
-      {"route_display_mode", "poi_label_format", "arrow_size_ratio"});
-    if (rclcpp::spin_until_future_complete(service_node_, fut, 500ms) ==
-        rclcpp::FutureReturnCode::SUCCESS) {
-      auto params = fut.get();
-      if (params.size() >= 3) {
-        const std::string route_mode = params[0].as_string();
-        const std::string label_fmt = params[1].as_string();
-        const double arrow_size = params[2].as_double();
+  // 初期同期: publisher から現在 parameter 値を読んで UI に反映
+  SyncDisplaySettingsFromPublisher();
+}
 
-        // QSignalBlocker で setChecked / setValue が SetParameters を再発火させないようにする
-        QSignalBlocker b1(route_radio_all_);
-        QSignalBlocker b2(route_radio_selected_);
-        QSignalBlocker b3(route_radio_none_);
-        QSignalBlocker b4(label_radio_index_);
-        QSignalBlocker b5(label_radio_name_);
-        QSignalBlocker b6(label_radio_both_);
-        QSignalBlocker b7(label_radio_none_);
-        QSignalBlocker b8(arrow_size_spin_);
-
-        if (route_mode == "all") route_radio_all_->setChecked(true);
-        else if (route_mode == "none") route_radio_none_->setChecked(true);
-        else route_radio_selected_->setChecked(true);  // default fallback
-
-        if (label_fmt == "name") label_radio_name_->setChecked(true);
-        else if (label_fmt == "both") label_radio_both_->setChecked(true);
-        else if (label_fmt == "none") label_radio_none_->setChecked(true);
-        else label_radio_index_->setChecked(true);  // default fallback
-
-        arrow_size_spin_->setValue(arrow_size);
-      }
-    } else {
-      RCLCPP_WARN(LOGGER, "Initial sync of Display Settings parameters timed out");
-    }
-  } else {
-    RCLCPP_INFO(LOGGER,
-      "mapoi_rviz2_publisher parameter service not ready at panel init, "
-      "Display Settings UI starts with defaults");
+void PoiEditorPanel::SyncDisplaySettingsFromPublisher()
+{
+  // CLI で先に変更されていた場合や SetParameters 失敗時に、UI を publisher の真値に寄せる。
+  // 失敗時 (publisher 未起動 / timeout) は何もしない (UI は変えない、log は呼び出し側で出力)。
+  if (!rviz2_pub_param_client_->wait_for_service(50ms)) {
+    return;  // 短い wait、ready でなければ skip
   }
+  auto fut = rviz2_pub_param_client_->get_parameters(
+    {"route_display_mode", "poi_label_format", "arrow_size_ratio"});
+  if (rclcpp::spin_until_future_complete(service_node_, fut, 200ms) !=
+      rclcpp::FutureReturnCode::SUCCESS) {
+    RCLCPP_WARN(LOGGER, "Sync of Display Settings parameters timed out");
+    return;
+  }
+  auto params = fut.get();
+  if (params.size() < 3) {
+    return;
+  }
+  const std::string route_mode = params[0].as_string();
+  const std::string label_fmt = params[1].as_string();
+  const double arrow_size = params[2].as_double();
+
+  // QSignalBlocker で setChecked / setValue が SetParameters を再発火させないようにする
+  QSignalBlocker b1(route_radio_all_);
+  QSignalBlocker b2(route_radio_selected_);
+  QSignalBlocker b3(route_radio_none_);
+  QSignalBlocker b4(label_radio_index_);
+  QSignalBlocker b5(label_radio_name_);
+  QSignalBlocker b6(label_radio_both_);
+  QSignalBlocker b7(label_radio_none_);
+  QSignalBlocker b8(arrow_size_spin_);
+
+  if (route_mode == "all") route_radio_all_->setChecked(true);
+  else if (route_mode == "none") route_radio_none_->setChecked(true);
+  else route_radio_selected_->setChecked(true);  // default fallback
+
+  if (label_fmt == "name") label_radio_name_->setChecked(true);
+  else if (label_fmt == "both") label_radio_both_->setChecked(true);
+  else if (label_fmt == "none") label_radio_none_->setChecked(true);
+  else label_radio_index_->setChecked(true);  // default fallback
+
+  arrow_size_spin_->setValue(arrow_size);
 }
 
 void PoiEditorPanel::onEnable()

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -6,6 +6,11 @@
 #include <QFileDialog>
 #include <QStandardPaths>
 #include <QTimer>
+#include <QGroupBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QButtonGroup>
+#include <QVBoxLayout>
 
 #include "ui_poi_editor.h"
 
@@ -75,6 +80,110 @@ void PoiEditorPanel::onInitialize()
   config_path_sub_ = node_->create_subscription<std_msgs::msg::String>(
     "mapoi_config_path", 10,
     std::bind(&PoiEditorPanel::ConfigPathCallback, this, std::placeholders::_1));
+
+  // Display Settings group: mapoi_rviz2_publisher の表示系 parameter を Panel から制御 (#99)
+  // - route_display_mode (all / selected / none): RadioButton
+  // - poi_label_format (index / name / both / none): RadioButton
+  // - arrow_size_ratio (double 0.0〜5.0): DoubleSpinBox
+  rviz2_pub_param_client_ =
+    std::make_shared<rclcpp::AsyncParametersClient>(service_node_, "/mapoi_rviz2_publisher");
+
+  auto * display_group = new QGroupBox("Display Settings", this);
+  auto * display_form = new QFormLayout(display_group);
+  display_form->setContentsMargins(8, 8, 8, 8);
+
+  // Route display mode
+  auto * route_h = new QHBoxLayout();
+  route_radio_all_ = new QRadioButton("all", this);
+  route_radio_selected_ = new QRadioButton("selected", this);
+  route_radio_none_ = new QRadioButton("none", this);
+  route_radio_selected_->setChecked(true);  // default in mapoi_rviz2_publisher
+  auto * route_group = new QButtonGroup(this);
+  route_group->setExclusive(true);
+  route_group->addButton(route_radio_all_);
+  route_group->addButton(route_radio_selected_);
+  route_group->addButton(route_radio_none_);
+  route_h->addWidget(route_radio_all_);
+  route_h->addWidget(route_radio_selected_);
+  route_h->addWidget(route_radio_none_);
+  route_h->addStretch();
+  display_form->addRow("Route:", route_h);
+
+  // POI label format
+  auto * label_h = new QHBoxLayout();
+  label_radio_index_ = new QRadioButton("index", this);
+  label_radio_name_ = new QRadioButton("name", this);
+  label_radio_both_ = new QRadioButton("both", this);
+  label_radio_none_ = new QRadioButton("none", this);
+  label_radio_index_->setChecked(true);  // default in mapoi_rviz2_publisher
+  auto * label_group = new QButtonGroup(this);
+  label_group->setExclusive(true);
+  label_group->addButton(label_radio_index_);
+  label_group->addButton(label_radio_name_);
+  label_group->addButton(label_radio_both_);
+  label_group->addButton(label_radio_none_);
+  label_h->addWidget(label_radio_index_);
+  label_h->addWidget(label_radio_name_);
+  label_h->addWidget(label_radio_both_);
+  label_h->addWidget(label_radio_none_);
+  label_h->addStretch();
+  display_form->addRow("POI label:", label_h);
+
+  // Arrow size ratio
+  arrow_size_spin_ = new QDoubleSpinBox(this);
+  arrow_size_spin_->setRange(0.0, 5.0);
+  arrow_size_spin_->setSingleStep(0.1);
+  arrow_size_spin_->setDecimals(2);
+  arrow_size_spin_->setValue(1.0);  // default in mapoi_rviz2_publisher
+  display_form->addRow("Arrow size:", arrow_size_spin_);
+
+  // Display Settings group を verticalLayout に append (Save 行の下)
+  if (auto * panel_layout = qobject_cast<QVBoxLayout *>(this->layout())) {
+    panel_layout->addWidget(display_group);
+  }
+
+  // Connect signals → set_parameters service call.
+  // 100ms timeout で軽く spin、UI を block しすぎないようにする (失敗時は warning ログ)。
+  auto send_string_param = [this](const std::string & name, const std::string & value) {
+    if (!rviz2_pub_param_client_->service_is_ready()) {
+      RCLCPP_WARN(LOGGER, "mapoi_rviz2_publisher parameter service not ready, skipping set %s",
+        name.c_str());
+      return;
+    }
+    auto fut = rviz2_pub_param_client_->set_parameters({rclcpp::Parameter(name, value)});
+    rclcpp::spin_until_future_complete(service_node_, fut, 100ms);
+  };
+  auto send_double_param = [this](const std::string & name, double value) {
+    if (!rviz2_pub_param_client_->service_is_ready()) {
+      RCLCPP_WARN(LOGGER, "mapoi_rviz2_publisher parameter service not ready, skipping set %s",
+        name.c_str());
+      return;
+    }
+    auto fut = rviz2_pub_param_client_->set_parameters({rclcpp::Parameter(name, value)});
+    rclcpp::spin_until_future_complete(service_node_, fut, 100ms);
+  };
+
+  // route_display_mode: toggled(checked=true) のみ反応 (false 側 toggle で重複 send しない)
+  connect(route_radio_all_, &QRadioButton::toggled,
+    [send_string_param](bool checked) { if (checked) send_string_param("route_display_mode", "all"); });
+  connect(route_radio_selected_, &QRadioButton::toggled,
+    [send_string_param](bool checked) { if (checked) send_string_param("route_display_mode", "selected"); });
+  connect(route_radio_none_, &QRadioButton::toggled,
+    [send_string_param](bool checked) { if (checked) send_string_param("route_display_mode", "none"); });
+
+  // poi_label_format
+  connect(label_radio_index_, &QRadioButton::toggled,
+    [send_string_param](bool checked) { if (checked) send_string_param("poi_label_format", "index"); });
+  connect(label_radio_name_, &QRadioButton::toggled,
+    [send_string_param](bool checked) { if (checked) send_string_param("poi_label_format", "name"); });
+  connect(label_radio_both_, &QRadioButton::toggled,
+    [send_string_param](bool checked) { if (checked) send_string_param("poi_label_format", "both"); });
+  connect(label_radio_none_, &QRadioButton::toggled,
+    [send_string_param](bool checked) { if (checked) send_string_param("poi_label_format", "none"); });
+
+  // arrow_size_ratio
+  connect(arrow_size_spin_, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+    [send_double_param](double value) { send_double_param("arrow_size_ratio", value); });
 }
 
 void PoiEditorPanel::onEnable()

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -157,12 +157,14 @@ void PoiEditorPanel::onInitialize()
     RevertDisplaySettingsUiFromCache();
   };
   auto send_param = [this, fail_recovery](const std::string & name, const rclcpp::ParameterValue & value) {
-    if (!rviz2_pub_param_client_->service_is_ready()) {
-      fail_recovery(name, "service not ready");
+    // service_is_ready() は cached state を返すだけで、AsyncParametersClient が
+    // 一度も spin されていないと stale で false を返す。wait_for_service で短い spin を挟む。
+    if (!rviz2_pub_param_client_->wait_for_service(100ms)) {
+      fail_recovery(name, "service not ready after 100ms wait");
       return;
     }
     auto fut = rviz2_pub_param_client_->set_parameters({rclcpp::Parameter(name, value)});
-    auto rc = rclcpp::spin_until_future_complete(service_node_, fut, 100ms);
+    auto rc = rclcpp::spin_until_future_complete(service_node_, fut, 500ms);
     if (rc != rclcpp::FutureReturnCode::SUCCESS) {
       fail_recovery(name, "spin timeout");
       return;

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -135,6 +135,8 @@ void PoiEditorPanel::onInitialize()
   arrow_size_spin_->setSingleStep(0.1);
   arrow_size_spin_->setDecimals(2);
   arrow_size_spin_->setValue(1.0);  // default in mapoi_rviz2_publisher
+  // keyboard 入力中は valueChanged を発火させず、Enter / focus loss / stepper 操作のみで反応 (Codex round 1 低)
+  arrow_size_spin_->setKeyboardTracking(false);
   display_form->addRow("Arrow size:", arrow_size_spin_);
 
   // Display Settings group を verticalLayout に append (Save 行の下)
@@ -184,6 +186,51 @@ void PoiEditorPanel::onInitialize()
   // arrow_size_ratio
   connect(arrow_size_spin_, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
     [send_double_param](double value) { send_double_param("arrow_size_ratio", value); });
+
+  // 初期同期: publisher から現在の parameter 値を読んで UI に反映 (Codex round 1 中)
+  // CLI で先に変更されていた場合や、Panel 起動時の publisher 状態に UI を寄せる目的。
+  // 失敗時 (publisher 未起動など) は default のまま (warning ログのみ)。
+  // service ready check + 200ms wait_for_service で起動待ち。
+  if (rviz2_pub_param_client_->wait_for_service(200ms)) {
+    auto fut = rviz2_pub_param_client_->get_parameters(
+      {"route_display_mode", "poi_label_format", "arrow_size_ratio"});
+    if (rclcpp::spin_until_future_complete(service_node_, fut, 500ms) ==
+        rclcpp::FutureReturnCode::SUCCESS) {
+      auto params = fut.get();
+      if (params.size() >= 3) {
+        const std::string route_mode = params[0].as_string();
+        const std::string label_fmt = params[1].as_string();
+        const double arrow_size = params[2].as_double();
+
+        // QSignalBlocker で setChecked / setValue が SetParameters を再発火させないようにする
+        QSignalBlocker b1(route_radio_all_);
+        QSignalBlocker b2(route_radio_selected_);
+        QSignalBlocker b3(route_radio_none_);
+        QSignalBlocker b4(label_radio_index_);
+        QSignalBlocker b5(label_radio_name_);
+        QSignalBlocker b6(label_radio_both_);
+        QSignalBlocker b7(label_radio_none_);
+        QSignalBlocker b8(arrow_size_spin_);
+
+        if (route_mode == "all") route_radio_all_->setChecked(true);
+        else if (route_mode == "none") route_radio_none_->setChecked(true);
+        else route_radio_selected_->setChecked(true);  // default fallback
+
+        if (label_fmt == "name") label_radio_name_->setChecked(true);
+        else if (label_fmt == "both") label_radio_both_->setChecked(true);
+        else if (label_fmt == "none") label_radio_none_->setChecked(true);
+        else label_radio_index_->setChecked(true);  // default fallback
+
+        arrow_size_spin_->setValue(arrow_size);
+      }
+    } else {
+      RCLCPP_WARN(LOGGER, "Initial sync of Display Settings parameters timed out");
+    }
+  } else {
+    RCLCPP_INFO(LOGGER,
+      "mapoi_rviz2_publisher parameter service not ready at panel init, "
+      "Display Settings UI starts with defaults");
+  }
 }
 
 void PoiEditorPanel::onEnable()


### PR DESCRIPTION
## 概要

Close #99

PR #83 (#68 P4 RViz Route visualization、merged) のユーザーフィードバックで「\`route_display_mode\` 等の表示 parameter は CLI ではなく Panel button から切替たい」要望。

POI Editor Panel に **Display Settings group** を追加し、以下 3 parameter を GUI から制御可能に:

| parameter | UI widget | 効果 |
|---|---|---|
| `route_display_mode` | RadioButton (3 択: all / selected / none) | Route polyline 表示の細かさ |
| `poi_label_format` | RadioButton (4 択: index / name / both / none) | POI label の format |
| `arrow_size_ratio` | DoubleSpinBox (0.0〜5.0、step 0.1) | POI 矢印サイズの radius 比率 |

## 変更内容

### `mapoi_rviz_plugins/src/poi_editor.cpp`

`onInitialize()` 末尾に Display Settings group の構築 + signal 接続を追加。widgets は **`.ui` を編集せず cpp で programmatically 構築** (XML 拡張回避、追加・修正が容易):

\`\`\`cpp
auto * display_group = new QGroupBox("Display Settings", this);
auto * display_form = new QFormLayout(display_group);
// Route / POI label の RadioButton groups + Arrow size の DoubleSpinBox を追加
// QButtonGroup で exclusive 化、toggled(true) のみ反応で重複 send 抑制

if (auto * panel_layout = qobject_cast<QVBoxLayout *>(this->layout())) {
  panel_layout->addWidget(display_group);  // Save 行の下に append
}

// AsyncParametersClient で /mapoi_rviz2_publisher に SetParameters service call
\`\`\`

### `mapoi_rviz_plugins/include/.../poi_editor.hpp`

- `<rclcpp/parameter_client.hpp>` include 追加
- `<QRadioButton>` / `<QDoubleSpinBox>` include 追加
- 9 個の widget pointer + AsyncParametersClient member 追加

## 設計判断

| 論点 | 採用 | 根拠 |
|---|---|---|
| widget 構築方法 | **cpp で programmatic** (.ui 編集なし) | XML 編集の verbose さを回避、追加・修正が容易、issue #99 scope に集中 |
| 配置 | Save 行の下 (verticalLayout の末尾) | Save 操作との重なり防止、表示設定は「viewing」で編集とは別と読める |
| signal 接続 | toggled(true) のみ反応 | RadioButton は select/deselect で 2 回 toggle 信号を出すため、true 側のみで重複 send 回避 |
| service call ブロック | 100ms timeout で spin | UI 応答性 (block 100ms 以下)、失敗時は warning ログで継続 |
| service 未起動 | service_is_ready() check + skip | Panel が publisher より先に起動したケースで crash 防止 |
| default 値 | mapoi_rviz2_publisher の declare_parameter と一致 | CLI 変更がない通常起動で UI と publisher 状態が一致 |
| CLI との並走 | 排他にしない | ROS CLI (\`ros2 param set\`) も引き続き有効、上書き合戦は user 責任 |

## 既知の限界 (本 PR scope 外)

- **Panel 起動時に CLI で先に parameter 変更されていた場合、UI が default を表示** (publisher 側の真値と不一致)。修正案: 起動時に \`get_parameters\` で初期同期。今回は scope に入れず、明示的な user フィードバック待ち
- **2 paths (Panel UI と CLI) からの上書き合戦**: 両方が短時間に変更すると最後の 1 つが残る。実用上 race は稀

## 動作確認

\`\`\`bash
colcon build --packages-select mapoi_rviz_plugins --symlink-install   # clean
\`\`\`

実 GUI 動作 (実機検証推奨):
1. Panel を開く → 下部に **Display Settings** group が出る
2. Route の RadioButton で all/selected/none を切替 → RViz 表示が即座に変化
3. POI label の RadioButton で index/name/both/none を切替 → label 表示形式が変化
4. Arrow size の DoubleSpinBox で 0.5 / 1.0 / 2.0 等を入れる → 矢印サイズが変化
5. CLI \`ros2 param get /mapoi_rviz2_publisher route_display_mode\` で UI 操作後の parameter 値が反映確認

## 関連

- issue #99 (本 PR): Panel UI 切替 button (PR #83 のユーザーフィードバック由来)
- PR #83 (merged): \`route_display_mode\` parameter を導入 (本 PR で UI 化)
- PR #72 (merged): \`arrow_size_ratio\` parameter
- PR #73 (merged): \`poi_label_format\` parameter

## Test plan

- [x] Humble image でビルド clean
- [ ] (実機検証推奨) Panel に Display Settings group が表示
- [ ] (実機検証推奨) 各 widget 切替で RViz 表示が変化
- [ ] (実機検証推奨) ROS CLI と Panel UI の双方向動作確認
- [ ] Codex review