### PR TITLE
fix(rviz): mapoi_waypoint_marks → mapoi_route_marks 修正 + Display Name 整理 + publisher var 名整合 (Option B)

### DIFF
--- a/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
@@ -74,7 +74,7 @@ private:
   int id_buf_;
 
   // Publishers
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_waypoints_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_goals_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_events_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_routes_pub_;
 

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -22,7 +22,7 @@ MapoiRviz2Publisher::MapoiRviz2Publisher() : Node("mapoi_rviz2_publisher") {
   // 全 route を見たい場合は ros2 param set /mapoi_rviz2_publisher route_display_mode all で切替。
   this->declare_parameter<std::string>("route_display_mode", "selected");
 
-  marker_waypoints_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_goal_marks", 10);
+  marker_goals_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_goal_marks", 10);
   marker_events_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_event_marks", 10);
   marker_routes_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("mapoi_route_marks", 10);
 
@@ -467,12 +467,12 @@ void MapoiRviz2Publisher::timer_callback(){
     m_del.action = visualization_msgs::msg::Marker::DELETEALL;
     visualization_msgs::msg::MarkerArray ma_del;
     ma_del.markers.push_back(m_del);
-    marker_waypoints_pub_->publish(ma_del);
+    marker_goals_pub_->publish(ma_del);
     marker_events_pub_->publish(ma_del);
   }
   id_buf_ = id;
 
-  marker_waypoints_pub_->publish(ma_waypoints);
+  marker_goals_pub_->publish(ma_waypoints);
   marker_events_pub_->publish(ma_events);
 
   // Route LINE_STRIP markers (mapoi_route_marks topic)。

--- a/mapoi_turtlebot3_example/rviz/tb3_navigation2.rviz
+++ b/mapoi_turtlebot3_example/rviz/tb3_navigation2.rviz
@@ -525,7 +525,7 @@ Visualization Manager:
       Value: true
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
-      Name: MarkerArray
+      Name: POI Goals
       Namespaces:
         "": true
       Topic:
@@ -537,7 +537,7 @@ Visualization Manager:
       Value: true
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
-      Name: MarkerArray
+      Name: POI Events
       Namespaces:
         {}
       Topic:
@@ -549,7 +549,7 @@ Visualization Manager:
       Value: true
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
-      Name: MarkerArray
+      Name: Routes
       Namespaces:
         {}
       Topic:
@@ -557,7 +557,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /mapoi_waypoint_marks
+        Value: /mapoi_route_marks
       Value: true
   Enabled: true
   Global Options:


### PR DESCRIPTION
## 概要

ユーザーの実機検証で `tb3_navigation2.rviz` の topic 名 mismatch を発見。PR #83 (#68 P4 Route LINE_STRIP visualization) が RViz で見えていなかった原因。

## 変更内容

### 1. `tb3_navigation2.rviz` の bug fix

| line | 修正 |
|---|---|
| 560 | `Value: /mapoi_waypoint_marks` → `Value: /mapoi_route_marks` (publisher の正しい topic 名) |

`/mapoi_waypoint_marks` は存在しない topic で、PR #83 の Route LINE_STRIP visualization が RViz に表示されない原因だった。

### 2. `tb3_navigation2.rviz` の Display Name 整理

3 つの MarkerArray Display が全部 `Name: MarkerArray` で識別困難だったため descriptive に:

| 旧 | 新 |
|---|---|
| MarkerArray (`/mapoi_goal_marks`) | **POI Goals** |
| MarkerArray (`/mapoi_event_marks`) | **POI Events** |
| MarkerArray (`/mapoi_route_marks`) | **Routes** |

### 3. publisher member 名の整合 (mapoi_rviz2_publisher)

| 旧 | 新 |
|---|---|
| `marker_waypoints_pub_` | `marker_goals_pub_` |

publish 先 topic `/mapoi_goal_marks` と整合させ、コード読解時の混乱を解消。

`ma_waypoints` 局所変数は「goal POI + route waypoint 矢印を両方含む」MarkerArray の意味で保持。

## 動作確認 (Humble)

```bash
colcon build --packages-up-to mapoi_turtlebot3_example --symlink-install   # clean
```

実 GUI 動作 (実機検証推奨):
1. RViz 起動 → Display panel に `POI Goals` / `POI Events` / `Routes` の 3 つの MarkerArray が出る
2. POI Editor Panel の Display Settings で Route 切替 → **Routes Display で route LINE_STRIP が表示される** (旧 rviz では何も表示されなかった、本 PR で表示される)

## scope 外 (関連 issue で別途)

- `/waypoints` Display (line 524、Nav2 default 由来? mapoi 用ではない) は今回保持。要 mapoi_server 等の利用者調査
- topic 名 namespace 化 (例: `mapoi/goal_markers` 等の階層化) は破壊変更で別 issue (#70 系 + 新規 issue 起票予定)

## 関連

- PR #83 (#68、merged): Route LINE_STRIP visualization、本 PR で初めて RViz 表示が機能する
- PR #100 (#99、merged): Display Settings UI、本 PR の修正で route 切替の効果が visual に確認できる
- 別 issue (起票予定): topic 名 namespace 化 (post-release breaking)

## Test plan

- [x] Humble image でビルド clean (5 packages)
- [ ] (実機検証推奨) RViz Display panel に POI Goals / POI Events / Routes が出る
- [ ] (実機検証推奨) Routes Display で route LINE_STRIP が見える (Panel 切替も連動)
- [ ] Codex review