### PR TITLE
feat(webui): route active highlight を矢印・順序ラベルにも反映 + 非 active を dim 化 (#69 PR-1)

### DIFF
--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -439,7 +439,9 @@ class MapViewer {
 
       hitLine.bringToBack();
       this.routeLayers.push(hitLine);
-      this._routePolylines.push({ line, hitLine, routeIdx, color, latlngs });
+
+      const arrowMarkers = [];
+      const labelMarkers = [];
 
       // Draw teardrop direction markers along segments
       for (let i = 0; i < latlngs.length - 1; i++) {
@@ -460,6 +462,7 @@ class MapViewer {
           interactive: false,
         }).addTo(this.map);
         this.routeLayers.push(arrowMarker);
+        arrowMarkers.push(arrowMarker);
       }
 
       // Draw order labels at each waypoint
@@ -475,6 +478,12 @@ class MapViewer {
           interactive: false,
         }).addTo(this.map);
         this.routeLayers.push(labelMarker);
+        labelMarkers.push(labelMarker);
+      });
+
+      this._routePolylines.push({
+        line, hitLine, arrowMarkers, labelMarkers,
+        routeIdx, color, latlngs,
       });
     });
   }
@@ -492,15 +501,39 @@ class MapViewer {
   }
 
   /**
-   * Highlight a specific route on the map (solid, thicker line).
-   * Pass -1 to clear highlight.
+   * Highlight a specific route on the map.
+   *
+   * - routeIdx >= 0: active route を太線・実線・不透明にし、他 route は dim (薄い + 細線 + dashed)
+   *   にして焦点を作る。矢印・順序ラベルにも opacity を適用。
+   * - routeIdx === -1: 全 route を default 表示 (中程度の太さ + dashed + 通常 opacity) に戻す。
+   *
+   * 複数 route が同じ POI を経由して polyline が重なる視認性問題への (d) active highlight 対策。
    */
   highlightRoute(routeIdx) {
+    const hasActive = routeIdx >= 0;
     this._routePolylines.forEach((item) => {
-      if (item.routeIdx === routeIdx) {
+      const isActive = item.routeIdx === routeIdx;
+      if (hasActive && isActive) {
         item.line.setStyle({ weight: 5, opacity: 1.0, dashArray: null });
+        this._setMarkersOpacity(item.arrowMarkers, 1.0);
+        this._setMarkersOpacity(item.labelMarkers, 1.0);
+      } else if (hasActive && !isActive) {
+        item.line.setStyle({ weight: 2, opacity: 0.25, dashArray: '8, 6' });
+        this._setMarkersOpacity(item.arrowMarkers, 0.25);
+        this._setMarkersOpacity(item.labelMarkers, 0.25);
       } else {
         item.line.setStyle({ weight: 3, opacity: 0.7, dashArray: '8, 6' });
+        this._setMarkersOpacity(item.arrowMarkers, 1.0);
+        this._setMarkersOpacity(item.labelMarkers, 1.0);
+      }
+    });
+  }
+
+  _setMarkersOpacity(markers, opacity) {
+    if (!markers) return;
+    markers.forEach((m) => {
+      if (m && typeof m.setOpacity === 'function') {
+        m.setOpacity(opacity);
       }
     });
   }

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -22,7 +22,7 @@ class MapViewer {
     this.onPoiClick = null;      // callback(index)
     this.onRouteClick = null;    // callback(routeIndex)
     this._poseTool = null;       // pose tool state
-    this._routePolylines = [];   // { line, hitLine, routeIdx, color } for click & highlight
+    this._routePolylines = [];   // { line, hitLine, arrowMarkers, labelMarkers, routeIdx, color, latlngs } for click & highlight
 
     this.map.on('click', (e) => {
       if (this._poseTool) {
@@ -510,14 +510,17 @@ class MapViewer {
    * 複数 route が同じ POI を経由して polyline が重なる視認性問題への (d) active highlight 対策。
    */
   highlightRoute(routeIdx) {
-    const hasActive = routeIdx >= 0;
+    // 描画済みの _routePolylines に対象 routeIdx が実在する時のみ active state に入る。
+    // 非表示 / 未描画 / waypoint 不足等で対象 entry がない場合に全 route を dim にしない (Codex review medium #105)。
+    const activeExists = routeIdx >= 0
+      && this._routePolylines.some((item) => item.routeIdx === routeIdx);
     this._routePolylines.forEach((item) => {
       const isActive = item.routeIdx === routeIdx;
-      if (hasActive && isActive) {
+      if (activeExists && isActive) {
         item.line.setStyle({ weight: 5, opacity: 1.0, dashArray: null });
         this._setMarkersOpacity(item.arrowMarkers, 1.0);
         this._setMarkersOpacity(item.labelMarkers, 1.0);
-      } else if (hasActive && !isActive) {
+      } else if (activeExists && !isActive) {
         item.line.setStyle({ weight: 2, opacity: 0.25, dashArray: '8, 6' });
         this._setMarkersOpacity(item.arrowMarkers, 0.25);
         this._setMarkersOpacity(item.labelMarkers, 0.25);


### PR DESCRIPTION
## 概要

複数 route が同じ POI を経由して polyline が重なる視認性問題 (#69) への (d) active highlight 強化。

issue #69 を 2 PR に分割した PR-1。

- **PR-1 (本 PR)**: active highlight 強化 (矢印・順序ラベルへの opacity 反映 + 非 active の dim 化)
- **PR-2 (続編予定)**: parallel offset 実装 (各 route を route_index 分だけ法線方向に px シフト、zoom 対応)

Refs: #69

## 背景

WebUI で複数 route を同時表示すると、共通する経路区間で polyline が重なって判別困難。特に「同じ POI を通る 2 つの route」だと完全重複してしまう。

issue #69 の採用案は (b) parallel offset + (d) active highlight の組合せ。本 PR では先に (d) を実装する。

既存の `highlightRoute(routeIdx)` は polyline (`item.line`) のみ style 切替していたが、矢印 (`route-arrow` divIcon marker) や waypoint 順序ラベル (`route-order-label` divIcon marker) には反映されず、active focus が弱かった。

## 変更内容

### `mapoi_webui/web/js/map-viewer.js`

#### `_routePolylines` エントリーに markers を track

各 route の `arrowMarkers[]` と `labelMarkers[]` を `_routePolylines` のエントリーに含めるよう拡張。`showRoutes()` 内で marker 生成時に push し、route 単位でアクセス可能にする。

#### `highlightRoute(routeIdx)` を 3-state 化

| state | 条件 | line style | markers opacity |
|---|---|---|---|
| **active** | `routeIdx >= 0` かつ自分が active | `weight=5, opacity=1.0, 実線` | `1.0` |
| **dim** | `routeIdx >= 0` かつ自分が active 以外 | `weight=2, opacity=0.25, dashed` | `0.25` |
| **default** | `routeIdx === -1` (未選択) | `weight=3, opacity=0.7, dashed` (現状維持) | `1.0` |

#### `_setMarkersOpacity` ヘルパー

`L.marker` (divIcon) の `setOpacity()` を null-safe に一括適用する private helper。

## 互換性

- 既存の app.js 呼び出し (`highlightRoute(idx)` / `highlightRoute(-1)`) はそのまま動作
- `_routePolylines` は internal state のため外部 API への影響なし

## テスト計画

- [ ] WebUI で複数 route が定義された地図を表示し、route リストから 1 つを選択した時:
  - [ ] active route が太線・実線・不透明で前面に出る
  - [ ] 他 route が薄く (opacity 0.25) 表示される
  - [ ] active の矢印・順序ラベルが鮮明、非 active のそれらは薄くなる
- [ ] route 選択を解除 (`highlightRoute(-1)` 相当) した時、全 route が default 表示に戻る
- [ ] route polyline をクリックして active 切替が動作する

## 動作確認

現時点で実機/ブラウザでの確認は未実施。code review + 静的整合性での判断を依頼。

🤖 Generated with [Claude Code](https://claude.com/claude-code)