### PR TITLE
feat(webui): active route 先頭 POI とロボット現在位置を矢印で繋ぐ (#106)

### DIFF
--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -26,7 +26,7 @@ class MapViewer {
     this._activeRouteIdx = -1;   // 現在 active な route index (highlightRoute で更新)
     this._lastRobotPose = null;  // 最新 pose (updateRobotMarker で更新)
     this._robotConnectorLayers = []; // 現在のロボット位置 → active route 先頭 POI への connector
-    this._reachedRouteNames = new Set(); // 先頭 POI に一度到達した route 名の集合 (page 内 sticky)
+    this._reachedRouteSignatures = new Set(); // 到達済み route の "name|firstWaypoint" signature 集合 (page 内 sticky)
 
     this.map.on('click', (e) => {
       if (this._poseTool) {
@@ -400,12 +400,14 @@ class MapViewer {
       // Resolve waypoint names to LatLng positions
       const latlngs = [];
       const resolved = []; // { latlng, order }
+      let firstWaypointName = '';
       waypoints.forEach((wpName, i) => {
         const poi = poiByName[wpName];
         if (poi && poi.pose) {
           const ll = this.worldToLatLng(poi.pose.x, poi.pose.y);
           latlngs.push(ll);
           resolved.push({ latlng: ll, order: i + 1 });
+          if (!firstWaypointName) firstWaypointName = wpName;
         }
       });
 
@@ -487,7 +489,8 @@ class MapViewer {
 
       this._routePolylines.push({
         line, hitLine, arrowMarkers, labelMarkers,
-        routeIdx, routeName: route.name || '', color, latlngs,
+        routeIdx, routeName: route.name || '', firstWaypointName,
+        color, latlngs,
       });
     });
   }
@@ -503,11 +506,12 @@ class MapViewer {
     this._routePolylines = [];
     this.clearEditingRoutePreview();
     this._clearRobotConnector();
-    // 到達履歴 (_reachedRouteNames) は clearRoutes では reset しない。
+    // 到達履歴 (_reachedRouteSignatures) は clearRoutes では reset しない。
     // clearRoutes は visibility toggle / 編集 preview 出入り等の表示再描画でも
     // 呼ばれるため、ここで reset すると sticky 性が壊れる (Codex round 2 medium)。
-    // route 名は人間が決めた安定 ID なので、リネーム / 削除があっても stale entry
-    // は無害。新しい waypoint 構成が必要なら route 名を変えるのが期待される運用。
+    // signature は "routeName|firstWaypoint" 複合 ID で、先頭 POI 変更や
+    // map 切替で別 route が同名で再生成された場合は signature が変わる
+    // ため、自動的に fresh 評価される (Codex round 3 medium 対応)。
   }
 
   /**
@@ -694,14 +698,16 @@ class MapViewer {
    * - robot pose 未取得 (`_lastRobotPose === null`)
    * - active route の polyline entry が `_routePolylines` に無い
    *   (waypoint 不足 / 非表示等。PR #105 の activeExists と同じガード)
-   * - 当 route 名が `_reachedRouteNames` に登録済み (一度先頭 POI に到達)
-   *   route 走行中は connector が冗長で、後続 POI に向かって距離が再び
-   *   開いた時の再描画暴発を防ぐ。Set のキーは route 名 (安定 ID) なので、
-   *   表示再描画 (clearRoutes / visibility toggle / 編集 cancel 等) でも
-   *   sticky 性を維持。route リネームは新規 identity として扱う。
+   * - 当 route の signature (`routeName|firstWaypointName`) が
+   *   `_reachedRouteSignatures` に登録済み。複合 ID にすることで
+   *   - 表示再描画 (clearRoutes / visibility toggle / 編集 cancel 等) では
+   *     sticky 性を維持
+   *   - 同名のまま先頭 waypoint を変更した、map 切替で別 route が同名で
+   *     再生成された等のケースは signature が変わるため fresh 評価される
+   *     (Codex round 3 medium 対応)
    *
-   * 距離が ARRIVAL_THRESHOLD_M 未満になった瞬間に Set に登録し、以降同じ
-   * route 名の間は描画しない (page 内 sticky)。
+   * 距離が ARRIVAL_THRESHOLD_M 未満になった瞬間に signature を Set に登録し、
+   * 以降同 signature の間は描画しない (page 内 sticky)。
    *
    * polyline は active route と同色 + dashed (本線 polyline と差別化) で、
    * 中点に既存の route 矢印 SVG を再利用して方向を示す。
@@ -718,7 +724,8 @@ class MapViewer {
       (it) => it.routeIdx === this._activeRouteIdx,
     );
     if (!item || !item.latlngs || item.latlngs.length === 0) return;
-    if (item.routeName && this._reachedRouteNames.has(item.routeName)) return;
+    const signature = this._routeSignature(item);
+    if (signature && this._reachedRouteSignatures.has(signature)) return;
 
     const robotLatLng = this.worldToLatLng(
       this._lastRobotPose.x, this._lastRobotPose.y,
@@ -730,8 +737,8 @@ class MapViewer {
     const dx = this._lastRobotPose.x - firstWorld.x;
     const dy = this._lastRobotPose.y - firstWorld.y;
     if (Math.hypot(dx, dy) < ARRIVAL_THRESHOLD_M) {
-      if (item.routeName) {
-        this._reachedRouteNames.add(item.routeName);
+      if (signature) {
+        this._reachedRouteSignatures.add(signature);
       }
       return;
     }
@@ -768,5 +775,17 @@ class MapViewer {
       this.map.removeLayer(layer);
     });
     this._robotConnectorLayers = [];
+  }
+
+  /**
+   * route の到達履歴 sticky 用の identity signature。
+   * routeName 単独だと「同名のまま先頭 waypoint 差替え / map 切替で別 route 再生成」
+   * で stale entry が残る (Codex round 3 medium)。先頭 waypoint 名を加えた複合 ID
+   * にすることで、これらの identity 変化で signature が変わり fresh 評価される。
+   * routeName / firstWaypointName のいずれかが空なら identity 確定不可で空返し。
+   */
+  _routeSignature(item) {
+    if (!item || !item.routeName || !item.firstWaypointName) return '';
+    return `${item.routeName}|${item.firstWaypointName}`;
   }
 }

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -26,7 +26,7 @@ class MapViewer {
     this._activeRouteIdx = -1;   // 現在 active な route index (highlightRoute で更新)
     this._lastRobotPose = null;  // 最新 pose (updateRobotMarker で更新)
     this._robotConnectorLayers = []; // 現在のロボット位置 → active route 先頭 POI への connector
-    this._reachedRouteIndices = new Set(); // 先頭 POI に一度到達した route の index 集合 (sticky、clearRoutes でリセット)
+    this._reachedRouteNames = new Set(); // 先頭 POI に一度到達した route 名の集合 (page 内 sticky)
 
     this.map.on('click', (e) => {
       if (this._poseTool) {
@@ -487,7 +487,7 @@ class MapViewer {
 
       this._routePolylines.push({
         line, hitLine, arrowMarkers, labelMarkers,
-        routeIdx, color, latlngs,
+        routeIdx, routeName: route.name || '', color, latlngs,
       });
     });
   }
@@ -503,8 +503,11 @@ class MapViewer {
     this._routePolylines = [];
     this.clearEditingRoutePreview();
     this._clearRobotConnector();
-    // route データ refresh で waypoint 構成が変わり得るため到達履歴もリセット。
-    this._reachedRouteIndices.clear();
+    // 到達履歴 (_reachedRouteNames) は clearRoutes では reset しない。
+    // clearRoutes は visibility toggle / 編集 preview 出入り等の表示再描画でも
+    // 呼ばれるため、ここで reset すると sticky 性が壊れる (Codex round 2 medium)。
+    // route 名は人間が決めた安定 ID なので、リネーム / 削除があっても stale entry
+    // は無害。新しい waypoint 構成が必要なら route 名を変えるのが期待される運用。
   }
 
   /**
@@ -691,14 +694,14 @@ class MapViewer {
    * - robot pose 未取得 (`_lastRobotPose === null`)
    * - active route の polyline entry が `_routePolylines` に無い
    *   (waypoint 不足 / 非表示等。PR #105 の activeExists と同じガード)
-   * - 当 route が `_reachedRouteIndices` に登録済み (一度先頭 POI に到達)
+   * - 当 route 名が `_reachedRouteNames` に登録済み (一度先頭 POI に到達)
    *   route 走行中は connector が冗長で、後続 POI に向かって距離が再び
-   *   開いた時の再描画暴発を防ぐ。route 切替でも維持し、走行中に他 route
-   *   を覗いて戻った場合も再描画しない。clearRoutes (route データ refresh)
-   *   でのみリセット。
+   *   開いた時の再描画暴発を防ぐ。Set のキーは route 名 (安定 ID) なので、
+   *   表示再描画 (clearRoutes / visibility toggle / 編集 cancel 等) でも
+   *   sticky 性を維持。route リネームは新規 identity として扱う。
    *
    * 距離が ARRIVAL_THRESHOLD_M 未満になった瞬間に Set に登録し、以降同じ
-   * active route の間は描画しない (sticky)。
+   * route 名の間は描画しない (page 内 sticky)。
    *
    * polyline は active route と同色 + dashed (本線 polyline と差別化) で、
    * 中点に既存の route 矢印 SVG を再利用して方向を示す。
@@ -710,12 +713,12 @@ class MapViewer {
 
     this._clearRobotConnector();
     if (this._activeRouteIdx < 0) return;
-    if (this._reachedRouteIndices.has(this._activeRouteIdx)) return;
     if (!this._lastRobotPose || !this.metadata) return;
     const item = this._routePolylines.find(
       (it) => it.routeIdx === this._activeRouteIdx,
     );
     if (!item || !item.latlngs || item.latlngs.length === 0) return;
+    if (item.routeName && this._reachedRouteNames.has(item.routeName)) return;
 
     const robotLatLng = this.worldToLatLng(
       this._lastRobotPose.x, this._lastRobotPose.y,
@@ -727,7 +730,9 @@ class MapViewer {
     const dx = this._lastRobotPose.x - firstWorld.x;
     const dy = this._lastRobotPose.y - firstWorld.y;
     if (Math.hypot(dx, dy) < ARRIVAL_THRESHOLD_M) {
-      this._reachedRouteIndices.add(this._activeRouteIdx);
+      if (item.routeName) {
+        this._reachedRouteNames.add(item.routeName);
+      }
       return;
     }
 

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -26,6 +26,7 @@ class MapViewer {
     this._activeRouteIdx = -1;   // 現在 active な route index (highlightRoute で更新)
     this._lastRobotPose = null;  // 最新 pose (updateRobotMarker で更新)
     this._robotConnectorLayers = []; // 現在のロボット位置 → active route 先頭 POI への connector
+    this._reachedRouteIndices = new Set(); // 先頭 POI に一度到達した route の index 集合 (sticky、clearRoutes でリセット)
 
     this.map.on('click', (e) => {
       if (this._poseTool) {
@@ -502,6 +503,8 @@ class MapViewer {
     this._routePolylines = [];
     this.clearEditingRoutePreview();
     this._clearRobotConnector();
+    // route データ refresh で waypoint 構成が変わり得るため到達履歴もリセット。
+    this._reachedRouteIndices.clear();
   }
 
   /**
@@ -688,13 +691,26 @@ class MapViewer {
    * - robot pose 未取得 (`_lastRobotPose === null`)
    * - active route の polyline entry が `_routePolylines` に無い
    *   (waypoint 不足 / 非表示等。PR #105 の activeExists と同じガード)
+   * - 当 route が `_reachedRouteIndices` に登録済み (一度先頭 POI に到達)
+   *   route 走行中は connector が冗長で、後続 POI に向かって距離が再び
+   *   開いた時の再描画暴発を防ぐ。route 切替でも維持し、走行中に他 route
+   *   を覗いて戻った場合も再描画しない。clearRoutes (route データ refresh)
+   *   でのみリセット。
+   *
+   * 距離が ARRIVAL_THRESHOLD_M 未満になった瞬間に Set に登録し、以降同じ
+   * active route の間は描画しない (sticky)。
    *
    * polyline は active route と同色 + dashed (本線 polyline と差別化) で、
    * 中点に既存の route 矢印 SVG を再利用して方向を示す。
    */
   _updateRobotConnector() {
+    // 先頭 POI に「到達」と見なす世界距離 (m)。MVP として hardcoded。
+    // TODO(#108): 先頭 POI radius または Nav2 xy_goal_tolerance に置き換え検討。
+    const ARRIVAL_THRESHOLD_M = 0.1;
+
     this._clearRobotConnector();
     if (this._activeRouteIdx < 0) return;
+    if (this._reachedRouteIndices.has(this._activeRouteIdx)) return;
     if (!this._lastRobotPose || !this.metadata) return;
     const item = this._routePolylines.find(
       (it) => it.routeIdx === this._activeRouteIdx,
@@ -706,8 +722,14 @@ class MapViewer {
     );
     const firstLatLng = item.latlngs[0];
 
-    // ロボットが先頭 POI と同位置 (到着済み等) なら矢印が degenerate になるので skip。
-    if (robotLatLng.equals(firstLatLng)) return;
+    // 先頭 POI に到達済みなら Set に登録して以降描かない。
+    const firstWorld = this.latLngToWorld(firstLatLng);
+    const dx = this._lastRobotPose.x - firstWorld.x;
+    const dy = this._lastRobotPose.y - firstWorld.y;
+    if (Math.hypot(dx, dy) < ARRIVAL_THRESHOLD_M) {
+      this._reachedRouteIndices.add(this._activeRouteIdx);
+      return;
+    }
 
     const line = L.polyline([robotLatLng, firstLatLng], {
       color: item.color,

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -23,6 +23,9 @@ class MapViewer {
     this.onRouteClick = null;    // callback(routeIndex)
     this._poseTool = null;       // pose tool state
     this._routePolylines = [];   // { line, hitLine, arrowMarkers, labelMarkers, routeIdx, color, latlngs } for click & highlight
+    this._activeRouteIdx = -1;   // 現在 active な route index (highlightRoute で更新)
+    this._lastRobotPose = null;  // 最新 pose (updateRobotMarker で更新)
+    this._robotConnectorLayers = []; // 現在のロボット位置 → active route 先頭 POI への connector
 
     this.map.on('click', (e) => {
       if (this._poseTool) {
@@ -498,6 +501,7 @@ class MapViewer {
     this.routeLayers = [];
     this._routePolylines = [];
     this.clearEditingRoutePreview();
+    this._clearRobotConnector();
   }
 
   /**
@@ -530,6 +534,8 @@ class MapViewer {
         this._setMarkersOpacity(item.labelMarkers, 1.0);
       }
     });
+    this._activeRouteIdx = routeIdx;
+    this._updateRobotConnector();
   }
 
   _setMarkersOpacity(markers, opacity) {
@@ -653,6 +659,8 @@ class MapViewer {
         this.map.removeLayer(this.robotMarker);
         this.robotMarker = null;
       }
+      this._lastRobotPose = null;
+      this._updateRobotConnector();
       return;
     }
     const latlng = this.worldToLatLng(pose.x, pose.y);
@@ -667,5 +675,71 @@ class MapViewer {
         zIndexOffset: 2000,
       }).addTo(this.map);
     }
+    this._lastRobotPose = pose;
+    this._updateRobotConnector();
+  }
+
+  /**
+   * Draw or refresh a directional connector from the current robot position
+   * to the first waypoint of the active route.
+   *
+   * Guards (no-op の条件):
+   * - active route が選択されていない (`_activeRouteIdx === -1`)
+   * - robot pose 未取得 (`_lastRobotPose === null`)
+   * - active route の polyline entry が `_routePolylines` に無い
+   *   (waypoint 不足 / 非表示等。PR #105 の activeExists と同じガード)
+   *
+   * polyline は active route と同色 + dashed (本線 polyline と差別化) で、
+   * 中点に既存の route 矢印 SVG を再利用して方向を示す。
+   */
+  _updateRobotConnector() {
+    this._clearRobotConnector();
+    if (this._activeRouteIdx < 0) return;
+    if (!this._lastRobotPose || !this.metadata) return;
+    const item = this._routePolylines.find(
+      (it) => it.routeIdx === this._activeRouteIdx,
+    );
+    if (!item || !item.latlngs || item.latlngs.length === 0) return;
+
+    const robotLatLng = this.worldToLatLng(
+      this._lastRobotPose.x, this._lastRobotPose.y,
+    );
+    const firstLatLng = item.latlngs[0];
+
+    // ロボットが先頭 POI と同位置 (到着済み等) なら矢印が degenerate になるので skip。
+    if (robotLatLng.equals(firstLatLng)) return;
+
+    const line = L.polyline([robotLatLng, firstLatLng], {
+      color: item.color,
+      weight: 3,
+      opacity: 0.8,
+      dashArray: '4, 6',
+      interactive: false,
+    }).addTo(this.map);
+    line.bringToBack();
+    this._robotConnectorLayers.push(line);
+
+    const midLat = (robotLatLng.lat + firstLatLng.lat) / 2;
+    const midLng = (robotLatLng.lng + firstLatLng.lng) / 2;
+    const rotDeg = this.routeDirectionDeg(robotLatLng, firstLatLng);
+    const arrowIcon = L.divIcon({
+      className: 'route-arrow',
+      html: this.createRouteDirectionSvg(item.color, rotDeg, 18),
+      iconSize: [18, 18],
+      iconAnchor: [9, 9],
+    });
+    const arrowMarker = L.marker([midLat, midLng], {
+      icon: arrowIcon,
+      interactive: false,
+    }).addTo(this.map);
+    this._robotConnectorLayers.push(arrowMarker);
+  }
+
+  _clearRobotConnector() {
+    if (!this._robotConnectorLayers) return;
+    this._robotConnectorLayers.forEach((layer) => {
+      this.map.removeLayer(layer);
+    });
+    this._robotConnectorLayers = [];
   }
 }


### PR DESCRIPTION
## 概要

Issue #106 対応。active route が選択されているとき、ロボット現在位置 → 先頭 POI へ方向矢印付き polyline (connector) を描画する。

Close #106

## 変更内容

`mapoi_webui/web/js/map-viewer.js` のみ (frontend-only)。

### state 追加
- `_activeRouteIdx` — `highlightRoute()` で更新
- `_lastRobotPose` — `updateRobotMarker()` で更新
- `_robotConnectorLayers` — connector の polyline + arrow marker を保持

### 新メソッド
- `_updateRobotConnector()` — guard を通った時だけ polyline + 矢印を描画
- `_clearRobotConnector()` — layer を全 remove

### 既存メソッドの hook
- `clearRoutes()` — connector も clear
- `highlightRoute()` — 末尾で `_activeRouteIdx` 更新 + connector 再描画
- `updateRobotMarker()` — 末尾で `_lastRobotPose` 更新 + connector 再描画

### Guards (no-op の条件)
- active route 未選択 (`_activeRouteIdx === -1`)
- pose 未取得 (`_lastRobotPose === null`)
- active route の polyline entry が `_routePolylines` に無い
  - PR #105 medium fix の `activeExists` と同じ趣旨

## 設計判断・悩みどころ (Codex review に意見が欲しい点)

### (a) connector の style: active route と同色 + dashed (4, 6) + weight=3
- **採用理由**: 本線 polyline は active 時 `weight=5, 実線`。connector を dashed にして「実 route ではなく接続線」と差別化、かつ同色で「どの route の起点か」を示す
- **代案**: グレーや黒の中立色で「補助線」感を強める
- **判断軸**: 同色で一体感 vs 中立色で本線と独立

### (b) 矢印 marker の位置: 中点
- **採用理由**: 既存 route 内部の方向矢印が中点配置なので一貫
- **代案**: 終点 (先頭 POI) 直前に置くと「目的地はここ」が明確
- **判断軸**: 一貫性 vs 意味の明確さ

### (c) `latlngs[0]` を「先頭 POI 座標」として使用
- `showRoutes()` 内で valid POI のみ `latlngs.push(ll)` される (`map-viewer.js:431-447` 付近) ので、`latlngs[0]` は「最初の有効 waypoint」
- waypoint[0] が削除済 POI の場合、connector は waypoint[1] (= latlngs[0]) を指す
- **判断**: 「先頭 = 最初の有効 waypoint」と「先頭 = waypoint 配列 [0]」のどちらを取るか。本 PR は前者 (polyline 描画と一貫)

### (d) degenerate guard: `robotLatLng.equals(firstLatLng)` のみ
- 完全一致なら矢印 rotation NaN を確実に防げる
- **悩み**: `L.LatLng.equals` は pixel 完全一致のみ。AMCL 浮動小数誤差で「事実上同位置」でも僅差で degenerate に近い線が描かれる可能性
- **代案**: pixel 距離が threshold (例: 5px) 未満なら skip

### (e) 1Hz polling ごとの全 layer 再作成
- 現実装は `removeLayer` → 再 `addTo` で connector を作り直す
- **悩み**: チラつき / DOM コスト
- **最適化案**: polyline は `setLatLngs()`、矢印は `setLatLng()` + `setIcon()` でインプレース更新
- **判断**: 1Hz なら問題ない見込みだが実機検証で確認したい

## 動作確認

\`\`\`bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
\`\`\`

ブラウザ http://localhost:8765 で:
- [ ] route 選択 → ロボット位置 → 先頭 POI へ dashed 矢印が表示
- [ ] route 切替 → 新 route の color に追従
- [ ] 選択解除 → connector 消える
- [ ] active route の visibility checkbox off → connector 消える (entry 不在)
- [ ] waypoint < 2 の route を選択 → connector 描画されない (PR #105 と一貫)
- [ ] amcl_pose 未受信 → connector 描画されない
- [ ] AMCL update に追従して connector 起点が動く (1Hz)

## 関連
- #69 — route 視認性親 issue
- #105 (merged) — active highlight 強化、本 PR は (d) の延長