### PR TITLE
fix(webui): route 編集ライフサイクルで MapViewer の選択状態がずれる問題を解消

### DIFF
--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -273,6 +273,15 @@
   // Route editing state change — redraw routes with editing preview
   routeEditor.onEditingChange = () => {
     redrawRoutes();
+    // editRoute / copyRoute は selectedIndex を直接変えるが onSelectionChange を
+    // 発火しないため、ここで highlightRoute を再適用して MapViewer 側の
+    // _activeRouteIdx と同期する。これがないと「route A 選択 → route B Edit →
+    // Cancel」で sidebar は B selected でも _activeRouteIdx は A のままになり、
+    // robot connector が古い route の先頭 POI を指し続ける (PR #107 Codex round
+    // 2/3 medium 残課題)。
+    if (routeEditor.selectedIndex >= 0) {
+      mapViewer.highlightRoute(routeEditor.selectedIndex);
+    }
   };
 
   // Route visibility toggle


### PR DESCRIPTION
## 概要

PR #107 (#106) Codex round 2/3 で medium として指摘された route 編集ライフサイクルの drift を解消。

## 背景

`mapoi_webui/web/js/route-editor.js` の `editRoute(idx)` / `copyRoute(idx)` は `this.selectedIndex = idx` を直接更新するが、`onSelectionChange` callback は発火しない（`_fireEditingChange()` のみ呼ぶ）。

一方 `app.js` の `onEditingChange` handler は `redrawRoutes()` のみで、`highlightRoute(selectedIndex)` を呼ばない。

→ MapViewer 側の `_activeRouteIdx` は古い route を指したまま、sidebar との表示乖離が発生。

## 再現手順

1. route A をクリックして選択 → connector が A の先頭 POI を指す
2. route B の Edit ボタンを押す
3. Cancel ボタンで編集を閉じる
4. sidebar は route B が selected 表示だが、map 上の connector / highlight は依然 A を指している

similarly:
- copy → 新規 route の Edit form が開くが highlight は元 route のまま
- save 後の dirtyChange は別 handler で highlight 同期されるのでこちらは正常

## 修正

`app.js:273-276` の `onEditingChange` handler を visibility / dirty handler と同じパターンに揃える:

\`\`\`js
routeEditor.onEditingChange = () => {
  redrawRoutes();
  if (routeEditor.selectedIndex >= 0) {
    mapViewer.highlightRoute(routeEditor.selectedIndex);
  }
};
\`\`\`

## 影響範囲

- `mapoi_webui/web/js/app.js` のみ (frontend、追加 1 箇所、9 行)
- 既存の visibility / dirty handler はそのまま、editing handler だけ揃える形で side effect なし
- PR #107 の robot connector 機能は本修正で `_activeRouteIdx` が正しく追従するようになる

## 動作確認

\`\`\`bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
\`\`\`

ブラウザ http://localhost:8765 で:
- [ ] route A 選択 → A 太線 + A の先頭 POI へ connector
- [ ] route B Edit → B 太線 + B の先頭 POI へ connector に切替
- [ ] Cancel → B のまま (sidebar も B selected)
- [ ] route copy → 新 route 太線 + 新 route 先頭 POI へ connector
- [ ] save / discard 後にも highlight が sidebar 選択と一致 (既存挙動が壊れていないこと)

## 関連
- PR #107 (#106) — robot to first POI connector、本 PR は同 PR Codex review 残課題への対応