### PR TITLE
feat(webui): robot marker の色を active route と揃える (#110)

### DIFF
--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -546,6 +546,11 @@ class MapViewer {
     });
     this._activeRouteIdx = routeIdx;
     this._updateRobotConnector();
+    // route 切替で marker 色も追従させる (pose 未受信時は updateRobotMarker が
+    // early return するので safe)。
+    if (this._lastRobotPose) {
+      this.updateRobotMarker(this._lastRobotPose);
+    }
   }
 
   _setMarkersOpacity(markers, opacity) {
@@ -643,12 +648,14 @@ class MapViewer {
   }
 
   /**
-   * Create an SVG icon for the robot marker (red circle with direction arrow).
+   * Create an SVG icon for the robot marker (colored circle with direction arrow).
+   * @param {number} yaw - heading in radians
+   * @param {string} color - circle fill color (default cyan); 内側の方向矢印は白固定
    */
-  createRobotIcon(yaw) {
+  createRobotIcon(yaw, color = '#00bcd4') {
     const rotDeg = 90 - (yaw * 180 / Math.PI);
     const svg = `<svg width="36" height="36" viewBox="0 0 36 36" style="transform: rotate(${rotDeg}deg);">` +
-      `<circle cx="18" cy="18" r="12" fill="#00bcd4" fill-opacity="0.7" stroke="#fff" stroke-width="2"/>` +
+      `<circle cx="18" cy="18" r="12" fill="${color}" fill-opacity="0.7" stroke="#fff" stroke-width="2"/>` +
       `<path d="M18 8 L24 24 L18 19 L12 24 Z" fill="#fff" fill-opacity="0.9" stroke="none"/>` +
       `</svg>`;
     return L.divIcon({
@@ -657,6 +664,21 @@ class MapViewer {
       iconSize: [36, 36],
       iconAnchor: [18, 18],
     });
+  }
+
+  /**
+   * Resolve the marker color to use based on the current active route selection.
+   * - active route が選択されていてかつ entry が `_routePolylines` に実在する場合は
+   *   その色 (route 色と marker 色を揃える)
+   * - 未選択 / entry 不在 (waypoint <2 / 非表示等) は default cyan
+   *   PR #105 の `activeExists` ガードと同じ趣旨
+   */
+  _resolveRobotMarkerColor() {
+    if (this._activeRouteIdx < 0) return '#00bcd4';
+    const item = this._routePolylines.find(
+      (it) => it.routeIdx === this._activeRouteIdx,
+    );
+    return item ? item.color : '#00bcd4';
   }
 
   /**
@@ -674,7 +696,7 @@ class MapViewer {
       return;
     }
     const latlng = this.worldToLatLng(pose.x, pose.y);
-    const icon = this.createRobotIcon(pose.yaw || 0);
+    const icon = this.createRobotIcon(pose.yaw || 0, this._resolveRobotMarkerColor());
     if (this.robotMarker) {
       this.robotMarker.setLatLng(latlng);
       this.robotMarker.setIcon(icon);


### PR DESCRIPTION
## 概要

Issue #110 対応。WebUI のロボット自己位置 marker (中央の cyan 円) の色を、active route と同色に揃えて視覚的一貫性を強化する。

PR #107 (#106) で robot → 先頭 POI connector を route 色で描画する仕組みを入れた延長で、marker 自体も route 色に追従させる。

Close #110

## 変更内容

`mapoi_webui/web/js/map-viewer.js` のみ (frontend-only)。

### `createRobotIcon(yaw, color = '#00bcd4')`
- color 引数を追加し、SVG circle の `fill` をパラメタライズ
- 内側の方向矢印 (白い path) は方向視認性のため**白固定**

### `_resolveRobotMarkerColor()`
- active route 選択時 + `_routePolylines` に entry 実在 → route 色
- それ以外 (未選択 / entry 不在) → default cyan
- PR #105 の `activeExists` ガードと同じ趣旨

### `updateRobotMarker(pose)`
- 末尾で resolved color を渡して icon 再生成

### `highlightRoute(routeIdx)`
- 末尾で `updateRobotMarker(_lastRobotPose)` を呼び、route 切替で色が即追従
- pose 未受信時は updateRobotMarker が early return して safe

## 設計判断

- **(a) 円のみ route 色 / SVG 全体着色**: 円のみ採用。内側矢印 (heading) は白で方向視認性を確保
- **(b) entry 不在時の挙動**: PR #105 の `activeExists` 同様 default cyan に倒す。route が選ばれていても polyline が描けない (waypoint <2) 時は color 確定不可なので
- **(c) dim 状態 (他 route が active のとき自分は別 route)**: marker は単一なので concept N/A

## 動作確認

\`\`\`bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
\`\`\`

ブラウザ http://localhost:8765 で:
- [x] route 未選択時 → marker が cyan
- [x] route_1 選択 → marker が route_1 色
- [x] route_2 に切替 → marker が route_2 色 (即追従)
- [x] 選択解除 (-1) → marker が cyan に戻る
- [x] active route の visibility off → marker は cyan に戻る (entry 不在)
- [x] amcl_pose 未受信 → marker 描画されず影響なし

## 関連
- #69 — route 視認性親
- #106 / PR #107 (merged) — robot → first POI connector、本 PR は marker 自体の追従を追加