### PR TITLE
feat(webui): POI / route 選択時に Navigation dropdown を自動入力 (#111)

### DIFF
--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -239,6 +239,7 @@
     } else {
       mapViewer.disablePoseTool();
     }
+    syncNavGoalSelect();
   };
 
   // POI visibility toggle
@@ -268,6 +269,7 @@
   // Route selection change — highlight on map
   routeEditor.onSelectionChange = (index) => {
     mapViewer.highlightRoute(index);
+    syncNavRouteSelect();
   };
 
   // Route editing state change — redraw routes with editing preview
@@ -282,6 +284,7 @@
     if (routeEditor.selectedIndex >= 0) {
       mapViewer.highlightRoute(routeEditor.selectedIndex);
     }
+    syncNavRouteSelect();
   };
 
   // Route visibility toggle
@@ -300,6 +303,9 @@
     }
     if (!isDirty) {
       populateNavRouteSelect(routeEditor.routes);
+      // populate で options が rebuild されるが、選択中なら value を再同期して
+      // ユーザーの選択 state を保持する。
+      syncNavRouteSelect();
     }
   };
 
@@ -361,6 +367,26 @@
       opt.textContent = r.name;
       navRouteSelect.appendChild(opt);
     });
+  }
+
+  // Nav dropdowns auto-fill from POI/route selection (#111)。
+  // 選択中の route 名 / POI 名を Navigation グループの dropdown に反映し、
+  // 「選択 → 再選択 → Run/Go」の重複操作を 1 ステップ減らす。
+  // 選択解除 (-1) では dropdown を維持する (再 nav 時の再利用性のため)。
+  // 該当 name が dropdown options に無い場合 (例: goal タグ無し POI) は
+  // .value の代入が silent no-op になり、dropdown は前値を保持する。
+  function syncNavRouteSelect() {
+    const idx = routeEditor.selectedIndex;
+    if (idx < 0) return;
+    const name = routeEditor.routes[idx]?.name;
+    if (name) navRouteSelect.value = name;
+  }
+
+  function syncNavGoalSelect() {
+    const idx = poiEditor.selectedIndex;
+    if (idx < 0) return;
+    const name = poiEditor.pois[idx]?.name;
+    if (name) navGoalSelect.value = name;
   }
 
   function populateInitialPoseSelect(pois) {

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -373,20 +373,30 @@
   // 選択中の route 名 / POI 名を Navigation グループの dropdown に反映し、
   // 「選択 → 再選択 → Run/Go」の重複操作を 1 ステップ減らす。
   // 選択解除 (-1) では dropdown を維持する (再 nav 時の再利用性のため)。
-  // 該当 name が dropdown options に無い場合 (例: goal タグ無し POI) は
-  // .value の代入が silent no-op になり、dropdown は前値を保持する。
+  //
+  // 重要: 該当 name が dropdown options に無い場合 (例: goal タグ無し POI、
+  // 未保存の Copy 直後の route 等)、`select.value = missingName` は silent
+  // no-op ではなく value を空 ("") に落とし前値を消してしまう。前値維持を
+  // 守るため options 存在チェックしてから代入する (PR #114 Codex round 1
+  // medium 対応)。
+  function _hasOption(selectEl, name) {
+    return Array.from(selectEl.options).some((o) => o.value === name);
+  }
+
   function syncNavRouteSelect() {
     const idx = routeEditor.selectedIndex;
     if (idx < 0) return;
     const name = routeEditor.routes[idx]?.name;
-    if (name) navRouteSelect.value = name;
+    if (!name) return;
+    if (_hasOption(navRouteSelect, name)) navRouteSelect.value = name;
   }
 
   function syncNavGoalSelect() {
     const idx = poiEditor.selectedIndex;
     if (idx < 0) return;
     const name = poiEditor.pois[idx]?.name;
-    if (name) navGoalSelect.value = name;
+    if (!name) return;
+    if (_hasOption(navGoalSelect, name)) navGoalSelect.value = name;
   }
 
   function populateInitialPoseSelect(pois) {


### PR DESCRIPTION
## 概要

Issue #111 対応。POI / route を map クリック / list クリックで選択したとき、Navigation グループの「Goal POI」/「Route」dropdown を自動で同期する。

「選択 → Run / Go」の重複操作を 1 ステップ減らす UX 改善。

Close #111

## 変更内容

`mapoi_webui/web/js/app.js` のみ (frontend-only)。

### 追加: helper 2 つ
\`\`\`js
function syncNavRouteSelect() {
  const idx = routeEditor.selectedIndex;
  if (idx < 0) return;
  const name = routeEditor.routes[idx]?.name;
  if (name) navRouteSelect.value = name;
}

function syncNavGoalSelect() {
  const idx = poiEditor.selectedIndex;
  if (idx < 0) return;
  const name = poiEditor.pois[idx]?.name;
  if (name) navGoalSelect.value = name;
}
\`\`\`

### 既存 hook への呼び出し追加
- `routeEditor.onSelectionChange` — sync after highlight
- `routeEditor.onEditingChange` — Edit/copy で `selectedIndex` が直接変わるパスもカバー (PR #112 と同パターン)
- `routeEditor.onDirtyChange` (`!isDirty` 時) — `populateNavRouteSelect` で options 再構築後に value を復元
- `poiEditor.onSelectionChange` — sync after highlight

## 設計判断

- **(a) 選択解除 (-1) で dropdown 維持**: 再 nav 時の再利用性のため。Issue #111 の方針に従う
- **(b) name が options に無い場合**: `.value` 代入が silent no-op になるので、特別な処理不要
  - 例: goal タグ無し POI を選択 → navGoalSelect は前値を保持
- **(c) edit lifecycle**: PR #112 で `_activeRouteIdx` を `onEditingChange` で同期したのと同じパターンで dropdown も同期
- **(d) 走行中の自動同期**: 現状は走行 status を見ずに常時 sync。Issue #111 の検討点 ("走行中の自動同期" 案 A/B) は今後 nav status との連動を入れる際に再評価
- **(e) 手動 dropdown 変更との関係**: 「最後の操作が勝つ」シンプル原則。user が手動で dropdown を変えた直後に map で別 selection されたら上書き

## 動作確認

\`\`\`bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
\`\`\`

ブラウザ http://localhost:8765 で:
- [ ] route_1 をクリック → navRouteSelect が `route_1` に
- [ ] route_2 に切替 → navRouteSelect が `route_2` に
- [ ] route 解除 → navRouteSelect は `route_2` のまま (維持)
- [ ] goal タグ付き POI をクリック → navGoalSelect が POI 名に
- [ ] goal タグ無し POI をクリック → navGoalSelect は前値のまま
- [ ] route Edit → Cancel → navRouteSelect が編集対象 route 名に同期 (PR #112 + 本 PR の連携)
- [ ] route save 後 → dropdown 再構築されても選択 route 名が保持される

## 関連
- #69 — route 視認性親
- #106 / PR #107 (merged) — selection と connector 描画の連動
- #110 / PR #113 (merged) — selection と marker 色の連動
- 本 PR は selection と nav dropdown の連動を追加し、selection event の triple sync (highlight / connector / marker / dropdown) が完成