### PR TITLE
feat(webui): connector の到達閾値を先頭 POI radius に置き換え (#108)

### DIFF
--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -401,13 +401,17 @@ class MapViewer {
       const latlngs = [];
       const resolved = []; // { latlng, order }
       let firstWaypointName = '';
+      let firstPoiRadius = 0;
       waypoints.forEach((wpName, i) => {
         const poi = poiByName[wpName];
         if (poi && poi.pose) {
           const ll = this.worldToLatLng(poi.pose.x, poi.pose.y);
           latlngs.push(ll);
           resolved.push({ latlng: ll, order: i + 1 });
-          if (!firstWaypointName) firstWaypointName = wpName;
+          if (!firstWaypointName) {
+            firstWaypointName = wpName;
+            firstPoiRadius = (typeof poi.radius === 'number') ? poi.radius : 0;
+          }
         }
       });
 
@@ -490,7 +494,7 @@ class MapViewer {
       this._routePolylines.push({
         line, hitLine, arrowMarkers, labelMarkers,
         routeIdx, routeName: route.name || '', firstWaypointName,
-        color, latlngs,
+        firstPoiRadius, color, latlngs,
       });
     });
   }
@@ -728,16 +732,19 @@ class MapViewer {
    *     再生成された等のケースは signature が変わるため fresh 評価される
    *     (Codex round 3 medium 対応)
    *
-   * 距離が ARRIVAL_THRESHOLD_M 未満になった瞬間に signature を Set に登録し、
+   * 距離が `arrivalThreshold` (先頭 POI radius、#108) 未満になった瞬間に
+   * signature を Set に登録し、
    * 以降同 signature の間は描画しない (page 内 sticky)。
    *
    * polyline は active route と同色 + dashed (本線 polyline と差別化) で、
    * 中点に既存の route 矢印 SVG を再利用して方向を示す。
    */
   _updateRobotConnector() {
-    // 先頭 POI に「到達」と見なす世界距離 (m)。MVP として hardcoded。
-    // TODO(#108): 先頭 POI radius または Nav2 xy_goal_tolerance に置き換え検討。
-    const ARRIVAL_THRESHOLD_M = 0.1;
+    // 先頭 POI radius を到達閾値として使う (#108 対応)。mapoi の PoiEvent
+    // (mapoi_nav_server::PoiEventDetector) と同じ意味論で「この POI に
+    // 到達」を判定し、connector の sticky-hide タイミングを揃える。
+    // POI に radius が設定されていない / 値が 0 や負の場合は fallback default。
+    const FALLBACK_THRESHOLD_M = 0.1;
 
     this._clearRobotConnector();
     if (this._activeRouteIdx < 0) return;
@@ -748,6 +755,8 @@ class MapViewer {
     if (!item || !item.latlngs || item.latlngs.length === 0) return;
     const signature = this._routeSignature(item);
     if (signature && this._reachedRouteSignatures.has(signature)) return;
+    const arrivalThreshold = (item.firstPoiRadius > 0)
+      ? item.firstPoiRadius : FALLBACK_THRESHOLD_M;
 
     const robotLatLng = this.worldToLatLng(
       this._lastRobotPose.x, this._lastRobotPose.y,
@@ -758,7 +767,7 @@ class MapViewer {
     const firstWorld = this.latLngToWorld(firstLatLng);
     const dx = this._lastRobotPose.x - firstWorld.x;
     const dy = this._lastRobotPose.y - firstWorld.y;
-    if (Math.hypot(dx, dy) < ARRIVAL_THRESHOLD_M) {
+    if (Math.hypot(dx, dy) < arrivalThreshold) {
       if (signature) {
         this._reachedRouteSignatures.add(signature);
       }


### PR DESCRIPTION
## 概要

Issue #108 対応。PR #107 (#106) で hardcoded していた connector 非表示の到達閾値 (`ARRIVAL_THRESHOLD_M = 0.1m`) を、active route の先頭 POI の `radius` field に置き換える。

mapoi の `PoiEvent` (`mapoi_nav_server::PoiEventDetector`) と同じ意味論で「この POI に到達」を判定するため、connector の sticky-hide タイミングが PoiEvent 発火と揃う。

backend 改修不要、frontend のみで完結。

Close #108

## 変更内容

`mapoi_webui/web/js/map-viewer.js` のみ。

### `showRoutes()`
- `_routePolylines.push` 時に `firstPoiRadius` を追加
- 先頭 valid waypoint の `poi.radius` を保存（数値でない場合は 0）

### `_updateRobotConnector()`
- hardcoded `ARRIVAL_THRESHOLD_M = 0.1` を撤廃
- `arrivalThreshold = item.firstPoiRadius > 0 ? item.firstPoiRadius : 0.1` (fallback default)
- POI に radius 未設定 / 0 / 負値の場合は fallback で挙動維持

## Edge case

- POI が radius を持たない (mapoi_config.yaml に書かれていない) → `typeof poi.radius !== 'number'` で 0 → fallback 0.1m
- POI radius を編集した場合 (poi-editor) → save 時 `poiEditor.onDirtyChange(false)` → `loadRoutes()` → `redrawRoutes()` で `_routePolylines` 再構築 → 新 radius が反映
- 先頭 POI が削除済み (signature 不在) → 既存の activeExists ガードで早期 return、threshold まで到達せず
- _routeSignature には radius を含めない: 先頭 POI 名が同じなら identity 同一と扱い、radius 変更だけで到達履歴を ride させない (semantically: 同 POI への到達 = sticky)

## 動作確認

\`\`\`bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
\`\`\`

ブラウザ http://localhost:8765 で:
- [ ] route 選択 → connector 表示 (先頭 POI radius が大きい route ほど早めに hide)
- [ ] route 選択 + 先頭 POI radius を 0.5 に変更 → save → 0.5m 以内に近づくと connector 消える
- [ ] radius 未設定の sample POI でも fallback 0.1m で従来挙動維持
- [ ] sticky 性 (再描画暴発防止) は radius 変更後も働く

## 関連
- #69 — route 視認性親
- #106 / PR #107 — robot → first POI connector、本 PR は閾値の動的化
- #108 (本 issue) で挙げた候補 A (frontend のみ) を採用、B (Nav2 xy_goal_tolerance pull) は将来余地として残す