### PR TITLE
feat(webui): connector 閾値とロボットマーカーサイズを robot_radius に揃える (#116)

### DIFF
--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -97,6 +97,20 @@ class MapViewer {
 
     const m = this.metadata;
 
+    // Map 切替時は robot pose / connector / 到達履歴 / active 選択を全 reset。
+    // 直後の fitBounds() で zoomend hook が走るため、旧 map の latlng 基準で
+    // updateRobotMarker / _updateRobotConnector が実行されると、新 map 側で
+    // 誤座標描画 + 旧 signature の sticky 引継ぎが起こる (Codex PR #118 round 1
+    // medium)。
+    this._lastRobotPose = null;
+    this._reachedRouteSignatures.clear();
+    this._activeRouteIdx = -1;
+    if (this.robotMarker) {
+      this.map.removeLayer(this.robotMarker);
+      this.robotMarker = null;
+    }
+    this._clearRobotConnector();
+
     // Remove old overlay
     if (this.imageOverlay) {
       this.map.removeLayer(this.imageOverlay);
@@ -688,6 +702,14 @@ class MapViewer {
    * `worldToLatLng` + `latLngToContainerPoint` で 1m が今の zoom で何 pixel
    * になるかを実測する。CRS / resolution に依存せず robust。低 zoom で
    * marker が点になるのを防ぐため下限 16px を入れる。
+   *
+   * Note: 戻り値は icon の **outer width/height (= bounding box)** で、
+   * 内部の見える circle は viewBox の `r=12 / 36 ≒ 2/3` の比率になる
+   * (矢印 path 含む余白のため)。outer = robot diameter として扱うので
+   * 見える円自体は実 robot より少し小さく描かれるが、heading 矢印を含めた
+   * 総占有面積として robot 実寸に揃う設計 (Codex PR #118 round 1 low の
+   * 意図明示)。見える円を robot 実寸に厳密に合わせる場合は別 PR で sizePx
+   * を 1.5 倍するか、SVG 内部を r=18 に書き換える。
    *
    * pose / metadata 未受信時は default 36px (constructor 時 marker のため)。
    */

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -28,6 +28,11 @@ class MapViewer {
     this._robotConnectorLayers = []; // 現在のロボット位置 → active route 先頭 POI への connector
     this._reachedRouteSignatures = new Set(); // 到達済み route の "name|firstWaypoint" signature 集合 (page 内 sticky)
 
+    // ロボットの実寸 (m)。connector 到達閾値とロボットマーカーサイズの両方に
+    // 使う共通定数 (#116)。MVP として hardcoded、将来 launch param / Nav2 pull
+    // へ移行 (#117)。値は TurtleBot3 burger (~0.105m) に余裕を持たせた一般値。
+    this.robotRadiusM = 0.15;
+
     this.map.on('click', (e) => {
       if (this._poseTool) {
         this._handlePoseToolClick(e.latlng);
@@ -43,6 +48,13 @@ class MapViewer {
       if (this._poseTool && this._poseTool.phase === 'yaw') {
         this._updatePoseToolArrow(e.latlng);
       }
+    });
+
+    // zoom が変わると 1m あたりの pixel が変わるので、robot marker のピクセル
+    // サイズを再計算するために再描画する (#116)。pose 未受信時は updateRobotMarker
+    // が early return するので safe。
+    this.map.on('zoomend', () => {
+      if (this._lastRobotPose) this.updateRobotMarker(this._lastRobotPose);
     });
   }
 
@@ -651,19 +663,46 @@ class MapViewer {
    * Create an SVG icon for the robot marker (colored circle with direction arrow).
    * @param {number} yaw - heading in radians
    * @param {string} color - circle fill color (default cyan); 内側の方向矢印は白固定
+   * @param {number} sizePx - icon の outer width/height (px)。viewBox は固定 36 のままで
+   *   内部 path / circle 座標は変えず、outer サイズだけリスケールする
    */
-  createRobotIcon(yaw, color = '#00bcd4') {
+  createRobotIcon(yaw, color = '#00bcd4', sizePx = 36) {
     const rotDeg = 90 - (yaw * 180 / Math.PI);
-    const svg = `<svg width="36" height="36" viewBox="0 0 36 36" style="transform: rotate(${rotDeg}deg);">` +
+    const half = sizePx / 2;
+    const svg = `<svg width="${sizePx}" height="${sizePx}" viewBox="0 0 36 36" style="transform: rotate(${rotDeg}deg);">` +
       `<circle cx="18" cy="18" r="12" fill="${color}" fill-opacity="0.7" stroke="#fff" stroke-width="2"/>` +
       `<path d="M18 8 L24 24 L18 19 L12 24 Z" fill="#fff" fill-opacity="0.9" stroke="none"/>` +
       `</svg>`;
     return L.divIcon({
       className: 'robot-icon',
       html: svg,
-      iconSize: [36, 36],
-      iconAnchor: [18, 18],
+      iconSize: [sizePx, sizePx],
+      iconAnchor: [half, half],
     });
+  }
+
+  /**
+   * Compute the marker icon size (pixels) so it reflects the robot's real
+   * world radius at the current map zoom level (#116).
+   *
+   * `worldToLatLng` + `latLngToContainerPoint` で 1m が今の zoom で何 pixel
+   * になるかを実測する。CRS / resolution に依存せず robust。低 zoom で
+   * marker が点になるのを防ぐため下限 16px を入れる。
+   *
+   * pose / metadata 未受信時は default 36px (constructor 時 marker のため)。
+   */
+  _resolveRobotMarkerSizePx() {
+    const MIN_PX = 16;
+    const DEFAULT_PX = 36;
+    if (!this.metadata || !this._lastRobotPose) return DEFAULT_PX;
+    const center = this.worldToLatLng(this._lastRobotPose.x, this._lastRobotPose.y);
+    const edge = this.worldToLatLng(
+      this._lastRobotPose.x + this.robotRadiusM, this._lastRobotPose.y,
+    );
+    const pxRadius = this.map.latLngToContainerPoint(center)
+      .distanceTo(this.map.latLngToContainerPoint(edge));
+    const diameterPx = pxRadius * 2;
+    return Math.max(MIN_PX, diameterPx);
   }
 
   /**
@@ -695,8 +734,15 @@ class MapViewer {
       this._updateRobotConnector();
       return;
     }
+    // _resolveRobotMarkerSizePx は this._lastRobotPose を読むため、
+    // metadata / pose を使う前に最新値を保存しておく。
+    this._lastRobotPose = pose;
     const latlng = this.worldToLatLng(pose.x, pose.y);
-    const icon = this.createRobotIcon(pose.yaw || 0, this._resolveRobotMarkerColor());
+    const icon = this.createRobotIcon(
+      pose.yaw || 0,
+      this._resolveRobotMarkerColor(),
+      this._resolveRobotMarkerSizePx(),
+    );
     if (this.robotMarker) {
       this.robotMarker.setLatLng(latlng);
       this.robotMarker.setIcon(icon);
@@ -707,7 +753,6 @@ class MapViewer {
         zIndexOffset: 2000,
       }).addTo(this.map);
     }
-    this._lastRobotPose = pose;
     this._updateRobotConnector();
   }
 
@@ -728,17 +773,13 @@ class MapViewer {
    *     再生成された等のケースは signature が変わるため fresh 評価される
    *     (Codex round 3 medium 対応)
    *
-   * 距離が ARRIVAL_THRESHOLD_M 未満になった瞬間に signature を Set に登録し、
-   * 以降同 signature の間は描画しない (page 内 sticky)。
+   * 距離が `this.robotRadiusM` (#116) 未満になった瞬間に signature を Set に
+   * 登録し、以降同 signature の間は描画しない (page 内 sticky)。
    *
    * polyline は active route と同色 + dashed (本線 polyline と差別化) で、
    * 中点に既存の route 矢印 SVG を再利用して方向を示す。
    */
   _updateRobotConnector() {
-    // 先頭 POI に「到達」と見なす世界距離 (m)。MVP として hardcoded。
-    // TODO(#108): 先頭 POI radius または Nav2 xy_goal_tolerance に置き換え検討。
-    const ARRIVAL_THRESHOLD_M = 0.1;
-
     this._clearRobotConnector();
     if (this._activeRouteIdx < 0) return;
     if (!this._lastRobotPose || !this.metadata) return;
@@ -758,7 +799,7 @@ class MapViewer {
     const firstWorld = this.latLngToWorld(firstLatLng);
     const dx = this._lastRobotPose.x - firstWorld.x;
     const dy = this._lastRobotPose.y - firstWorld.y;
-    if (Math.hypot(dx, dy) < ARRIVAL_THRESHOLD_M) {
+    if (Math.hypot(dx, dy) < this.robotRadiusM) {
       if (signature) {
         this._reachedRouteSignatures.add(signature);
       }


### PR DESCRIPTION
## 概要

Issue #116 対応。WebUI の以下 2 要素を **ロボットの実寸 (robot_radius)** に揃えて視覚と実装意味を統一する。

1. **connector 到達閾値**: 従来 hardcoded 0.1m → `robot_radius`
2. **ロボットマーカーサイズ**: 従来固定 36px → world radius を pixel に変換して zoom 追従

#108 / #115 で POI radius を採用しようとしたが、意味論的に「ロボットの占有サイズ」とは別軸なので方針転換した結果。

Close #116
Refs #117 (将来 launch param / Nav2 pull に移行)

## 変更内容

`mapoi_webui/web/js/map-viewer.js` のみ。

### 共通定数
- `this.robotRadiusM = 0.15` (TurtleBot3 burger ~0.105m に余裕)
- 連動要素は connector 閾値 + marker サイズの 2 箇所

### marker サイズ動的化
- `createRobotIcon(yaw, color, sizePx)` に sizePx 追加
  - viewBox 36 固定で内部 cx/r 等は触らず、outer width/height のみリスケール
- `_resolveRobotMarkerSizePx()` 新規
  - `worldToLatLng` + `latLngToContainerPoint` で 1m が今の zoom で何 px になるかを実測
  - CRS / resolution / zoom 非依存で robust
  - 低 zoom 時は下限 16px で潰れ防止
- `map.on('zoomend')` hook で `updateRobotMarker(_lastRobotPose)` を呼び再描画

### connector 閾値
- `_updateRobotConnector` の hardcoded `ARRIVAL_THRESHOLD_M = 0.1` を撤廃
- `< this.robotRadiusM` で sticky-hide

## 設計判断

- **(a) viewBox 固定 + outer リスケール**: SVG 内部座標 (cx=18, r=12 等) を変えず outer width/height だけ変えることで、内部 path / circle 比率が崩れない
- **(b) 下限 16px**: 低 zoom + 小 robot で marker が点になるのを防ぐ。要実機調整
- **(c) zoomend 時の re-render コスト**: 1Hz polling と同等の更新負荷で実用上問題なし
- **(d) hardcoded 0.15m**: 将来 #117 (launch param / Nav2 pull) で動的化、本 PR は MVP

## 動作確認

\`\`\`bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
\`\`\`

ブラウザ http://localhost:8765 で:
- [ ] marker が概ね robot 実寸で表示される (低 zoom 時は 16px 下限)
- [ ] zoom in/out で marker サイズが追従する
- [ ] route 選択 → connector が robot_radius (0.15m) 以内で sticky-hide
- [ ] sticky 性 (PR #107 の振舞い) は維持
- [ ] route 切替で marker 色も追従 (PR #113 維持)

## 関連
- #69 — route 視認性親
- #106 / PR #107 (merged) — connector 本体
- #108 (closed) / PR #115 (closed) — POI radius 採用案、本 PR で代替
- #117 — launch param / Nav2 pull で robot_radius を動的化する follow-up