### PR TITLE
feat(webui): POI / route 名の uniqueness を save 時に弾く (#109)

### DIFF
--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -21,6 +21,25 @@ from mapoi_webui.yaml_handler import load_config, save_pois, save_routes, save_c
 from mapoi_webui.map_image import get_map_metadata, get_map_png
 
 
+def _validate_unique_names(items, label):
+    """POI / route の name list が空 / 重複を含まないか検査する (#109)。
+
+    frontend (poi-editor / route-editor) は formOk で同じ check を持つが、
+    yaml 直編集や別 client からの POST に対する保険として backend でも reject。
+    return: エラーメッセージ文字列 (issue あり) または None (OK)。case-sensitive 判定。
+    """
+    seen = set()
+    for i, it in enumerate(items or []):
+        name = (it.get('name') if isinstance(it, dict) else None)
+        if not name or not isinstance(name, str) or not name.strip():
+            return f'{label} #{i} has empty name'
+        name = name.strip()
+        if name in seen:
+            return f'{label} name "{name}" is duplicated'
+        seen.add(name)
+    return None
+
+
 class MapoiWebNode(Node):
     def __init__(self):
         super().__init__('mapoi_webui_node')
@@ -319,6 +338,12 @@ class MapoiWebNode(Node):
             data = request.get_json()
             if data is None or 'pois' not in data:
                 return jsonify({'error': 'Invalid request body'}), 400
+            # name の uniqueness / 空 を backend でも validate (#109)。
+            # frontend 経由なら poi-editor が reject 済みだが、yaml 直編集や
+            # 別 client からの POST に対する保険として 400 で reject する。
+            err = _validate_unique_names(data['pois'], 'POI')
+            if err:
+                return jsonify({'error': err}), 400
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
                 return jsonify({'error': 'Config not found'}), 404
@@ -383,6 +408,9 @@ class MapoiWebNode(Node):
             data = request.get_json()
             if data is None or 'routes' not in data:
                 return jsonify({'error': 'Invalid request body'}), 400
+            err = _validate_unique_names(data['routes'], 'Route')
+            if err:
+                return jsonify({'error': err}), 400
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
                 return jsonify({'error': 'Config not found'}), 404

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -28,8 +28,12 @@ def _validate_unique_names(items, label):
     yaml 直編集や別 client からの POST に対する保険として backend でも reject。
     return: エラーメッセージ文字列 (issue あり) または None (OK)。case-sensitive 判定。
     """
+    # Top-level 型 check: list でないと {"pois": null} や数値が validate を
+    # 素通りして save_* で 500 になる (Codex PR #120 round 1 medium)。
+    if not isinstance(items, list):
+        return f'{label} list must be an array'
     seen = set()
-    for i, it in enumerate(items or []):
+    for i, it in enumerate(items):
         name = (it.get('name') if isinstance(it, dict) else None)
         if not name or not isinstance(name, str) or not name.strip():
             return f'{label} #{i} has empty name'

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -339,6 +339,20 @@ class PoiEditor {
    */
   formOk() {
     const poi = this.readForm();
+    // name required + uniqueness check (#109)。route-editor の formOk と同 pattern。
+    // editingIndex === -2 (new POI) は全 POI と比較、editingIndex >= 0 (edit) は
+    // 自分以外と比較する。trim 済 (readForm 内) を前提、case-sensitive 判定。
+    if (!poi.name) {
+      alert('POI name is required.');
+      return;
+    }
+    const dupIndex = this.pois.findIndex(
+      (p, i) => p.name === poi.name && i !== this.editingIndex,
+    );
+    if (dupIndex >= 0) {
+      alert('POI name "' + poi.name + '" already exists.');
+      return;
+    }
     if (this.editingIndex === -2) {
       // New POI
       this.pois.push(poi);


### PR DESCRIPTION
## 概要

Issue #109 対応。PR #107 round 4 で挙がった「同名 route で stale 状態が残る」「`|` 区切り key 衝突」等の root cause として、**POI / route 名の uniqueness を save 時に invariant 化**する。

frontend の formOk と backend の REST endpoint の両方で reject することで、yaml 直編集や別 client からの POST 経路にも保険をかける。

Close #109

## 変更内容

### Frontend (`mapoi_webui/web/js/poi-editor.js`)
- `formOk()` に name required + duplicate check を追加
- route-editor の同 pattern (`formOk:347-356`) に揃える
- `editingIndex === -2` (new POI) は全 POI と比較、`>= 0` (edit) は自分以外と比較
- 大文字小文字区別、trim は既存の `readForm()` 内で完結
- route-editor は既に check 済みのため変更なし

### Backend (`mapoi_webui/mapoi_webui/mapoi_webui_node.py`)
- 共通 helper `_validate_unique_names(items, label)` をモジュールレベルで追加
- `api_save_pois` / `api_save_routes` で受信 name list を validate
  - empty / 重複なら 400 + error message
- frontend bypass (yaml 直編集 / 別 client からの POST) への防御

## スコープ外

- **Map 名 uniqueness**: webui に map 作成 / rename UI が無いため対象外
- **yaml 直編集の起動時 warning**: `mapoi_server` の起動時 (`load_mapoi_config`) で警告するのは scope 拡大、別 issue 候補
- **大文字小文字無視 / Unicode 正規化**: 現状は case-sensitive、NFC/NFD 正規化なし。ROS / yaml 慣習に倣う

## 設計判断

- **(a) Frontend + Backend 二重 check**: frontend で UX 良く reject、backend で invariant 担保。冗長だが層を分けて防御
- **(b) Case-sensitive**: ROS topic / param 名と同じ慣習。"foo" と "Foo" は別物として通す
- **(c) trim**: 前後空白のみ trim、内部空白は保持。ユーザの意図的な空白入力 (例: "Goal 1") を尊重
- **(d) error message format**: 「`<label> name "<name>" is duplicated`」など英語、debug 用。frontend は alert で日本語表示にこだわらず英語で OK

## 動作確認

\`\`\`bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
\`\`\`

ブラウザ http://localhost:8765 で:
- [ ] POI 編集 → 既存名を入れて Save → alert で reject
- [ ] POI 編集 → 空名を入れて Save → alert で reject
- [ ] POI 編集 → 既存単一名で Save → 通る (regression なし)
- [ ] route 編集も同様に既存挙動が維持される (regression なし)

別 client (curl 等) で:
\`\`\`
curl -X POST -H 'Content-Type: application/json' \
  -d '{"pois":[{"name":"a"},{"name":"a"}]}' \
  http://localhost:8765/api/pois
\`\`\`
- [ ] 400 + error message が返る
- [ ] 重複 name が無い list は通る

## 関連
- #69 — route 視認性親
- #106 / PR #107 — robot to first POI connector、本 PR で同名 route 想定の signature 暴発が原理的に消える
- #105 (merged) — route active highlight、route 名 uniqueness の前提を共有