### PR TITLE
fix(nav_server): mapoi_route_cb の std::bind を lambda に変更し compile error 解消

### DIFF
--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -210,10 +210,15 @@ void MapoiNavServer::mapoi_route_cb(const std_msgs::msg::String::SharedPtr msg)
   auto route_request = std::make_shared<mapoi_interfaces::srv::GetRoutePois::Request>();
   route_request->route_name = msg->data;
 
-  // route_name を bind で渡し、send_goal 直前に target 更新できるようにする。
+  // route_name を lambda capture で渡す。std::bind は rclcpp Jazzy の
+  // function_traits::same_arguments テンプレート制約をパスせず compile error
+  // になるので lambda を使う (PR #119 regression fix)。
   this->route_client_->async_send_request(
     route_request,
-    std::bind(&MapoiNavServer::on_route_received, this, msg->data, _1));
+    [this, route_name = msg->data](
+      rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture future) {
+        this->on_route_received(route_name, future);
+    });
 }
 
 void MapoiNavServer::on_pois_info_received(rclcpp::Client<mapoi_interfaces::srv::GetPoisInfo>::SharedFuture future)


### PR DESCRIPTION
## 概要

PR #119 (#104) の regression 修正。`mapoi_route_cb` で `route_client_->async_send_request` に `std::bind` を渡していたが、rclcpp Jazzy / Humble の `Client::async_send_request` の `function_traits::same_arguments` テンプレート制約が `std::bind` の結果型シグネチャを推論できず、compile error になる。

## 再現エラー

\`\`\`
error: no matching function for call to ‘rclcpp::Client<...>::async_send_request(
  std::shared_ptr<...::Request>&,
  std::_Bind_helper<false, void (MapoiNavServer::*)(std::string, std::shared_future<...>),
                    MapoiNavServer*, std::string&, const std::_Placeholder<1>&>::type)’
\`\`\`

`std::enable_if<rclcpp::function_traits::same_arguments<...>>` が `std::bind` 結果型と `std::function<void(SharedFuture)>` を一致と判定できないのが原因。

## 修正

`std::bind(&MapoiNavServer::on_route_received, this, msg->data, _1)` → lambda capture に置き換え:

\`\`\`cpp
this->route_client_->async_send_request(
  route_request,
  [this, route_name = msg->data](
    rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture future) {
      this->on_route_received(route_name, future);
  });
\`\`\`

PR #119 で action callback の send options は既に lambda capture pattern に揃えていたが、service request 側の修正が漏れていた。

## ビルド検証

`mapoi_server` を Docker で **Humble / Jazzy 両方で colcon build 通過確認**:

| Distro | Image | Result |
|---|---|---|
| Humble | `mapoi:dev-humble` | ✅ `Finished <<< mapoi_server [19.2s]` |
| Jazzy | `mapoi:dev-jazzy` | ✅ `Finished <<< mapoi_server [22.1s]` |

\`\`\`bash
ROS_DISTRO=jazzy docker compose run --rm dev bash -ic 'cd /ros2_ws && colcon build --packages-up-to mapoi_server'
ROS_DISTRO=humble docker compose run --rm dev bash -ic 'cd /ros2_ws && colcon build --packages-up-to mapoi_server'
\`\`\`

## 関連
- PR #119 (#104) — nav_status payload `status:target` 拡張、本 PR で同 PR の compile error を hotfix