### PR TITLE
fix(webui): 編集フォームの form-actions を sticky 化し小さいウィンドウでも到達可能に (#122 PR-1)

### DIFF
--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -247,7 +247,13 @@ main {
   padding: 12px;
   margin: 0 16px 8px;
   border: 2px solid #3498db;
-  flex-shrink: 0;
+  /* form 自体に内部スクロールを持たせ、ウィンドウが小さい時も form-actions
+     (OK / Cancel) に到達できるようにする (#122 PR-1)。flex-shrink: 1 +
+     min-height: 0 は flex column 内で flex item を実際にシュリンクさせるため
+     (デフォルトの min-height: auto は content size 未満に縮まらない)。 */
+  flex-shrink: 1;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 #poi-edit-form.hidden {
@@ -285,6 +291,15 @@ main {
   display: flex;
   gap: 8px;
   margin-top: 8px;
+  /* form の内部スクロール時に常に見える位置に sticky 固定 (#122 PR-1)。
+     parent の form は #fff 背景なので合わせて #fff を敷き、scroll up 時に
+     form-row の文字が下から透けて見えないようにする。z-index で同レイヤ
+     重なりに上から表示。 */
+  position: sticky;
+  bottom: 0;
+  background: #fff;
+  z-index: 1;
+  padding-top: 8px;
 }
 
 .form-actions button {
@@ -514,7 +529,11 @@ main {
   padding: 12px;
   margin: 4px 16px 4px;
   border: 2px solid #8e44ad;
-  flex-shrink: 0;
+  /* POI form と同じく、ウィンドウが小さい時も form-actions に到達できる
+     よう内部スクロール可能化 (#122 PR-1)。 */
+  flex-shrink: 1;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 #route-edit-form.hidden {

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -377,14 +377,16 @@ main {
   border-bottom: 1px solid #ddd;
 }
 
-#poi-section {
+#poi-section,
+#route-section {
   flex-shrink: 1;
   overflow: hidden;
   display: flex;
   flex-direction: column;
 }
 
-#poi-body {
+#poi-body,
+#route-body {
   flex: 1;
   overflow: hidden;
   display: flex;


### PR DESCRIPTION
## 概要

Issue #122 で挙げた 3 改善のうち **PR-1 (form-actions sticky 化、bug fix)** に対応。ブラウザウィンドウが小さい / 縦に短い時に、POI / route 編集フォームの **OK / Cancel ボタンが押せず保存不可になる bug** を修正する。

#122 PR-1 のスコープのみで、サイドパネル drag-resize や文字幅制御は別 PR (#122 PR-2 / PR-3) に残す。

Refs #122

## 背景

`#poi-edit-form` / `#route-edit-form` は `flex-shrink: 0` で、親 `#poi-body` は `overflow: hidden`。フォームが viewport より大きい時:
- form は縮まず、bottom (`.form-actions`) が画面外にはみ出す
- 親が overflow hidden なのでスクロールも不可
- → 保存できない

## 修正

`mapoi_webui/web/css/style.css` のみ (HTML / JS 無変更)。

### 1. `#poi-edit-form` / `#route-edit-form` を内部スクロール可能化
\`\`\`css
flex-shrink: 1;
overflow-y: auto;
min-height: 0;  /* flex column 内のシュリンクを有効化 (default min-height: auto を override) */
\`\`\`

### 2. `.form-actions` を sticky 固定
\`\`\`css
position: sticky;
bottom: 0;
background: #fff;
z-index: 1;
padding-top: 8px;
\`\`\`

両 form は背景 `#fff` なので sticky 領域も `#fff` で seamless。scroll up 時に form-row 文字が下から透けないように `z-index: 1` で重なりを保証。

## 動作確認

\`\`\`bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
\`\`\`

ブラウザ http://localhost:8765 で:
- [ ] ウィンドウを縦に小さく (高さ 500px 程度) → POI Edit を開く → form 内でスクロールできる
- [ ] form 内でスクロールしても OK / Cancel ボタンが常に画面下部に表示される
- [ ] route Edit でも同様
- [ ] 通常サイズ (高さ 1000px 以上) ではこれまで通りの見た目 (regression なし)
- [ ] form-actions の sticky 背景が form-row 文字と重なって見やすい

## 関連

- #122 — サイドパネル UX 改善親 issue (PR-2 = drag-resize、PR-3 = 文字幅制御は別 PR)