### PR TITLE
feat(webui): サイドパネルを drag-resize 可能化 + 幅を localStorage に永続化 (#122 PR-2)

### DIFF
--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -75,6 +75,24 @@ main {
   pointer-events: none;
 }
 
+/* Sidebar drag-resize handle (#122 PR-2)。
+   #map-container と #poi-panel の間に置く 6px 幅のスプリッタ。drag で
+   #poi-panel 幅を変更し、localStorage に永続化する (sidebar-resizer.js)。
+   mobile (<768px) では panel が full-width column になるため非表示。 */
+#sidebar-resizer {
+  width: 6px;
+  flex-shrink: 0;
+  cursor: ew-resize;
+  background: #ddd;
+  user-select: none;
+  transition: background 0.15s;
+}
+
+#sidebar-resizer:hover,
+#sidebar-resizer.dragging {
+  background: #3498db;
+}
+
 /* POI Panel */
 #poi-panel {
   width: 350px;
@@ -1085,6 +1103,12 @@ main {
     border-left: none;
     border-top: 1px solid #ddd;
     padding: 8px;
+  }
+
+  /* Mobile では panel が full-width column 配置になり drag-resize の意味が
+     無いので handle を非表示にする (#122 PR-2)。 */
+  #sidebar-resizer {
+    display: none;
   }
 
   header {

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -22,6 +22,8 @@
       <div id="map-status"></div>
     </div>
 
+    <div id="sidebar-resizer" title="Drag to resize sidebar"></div>
+
     <div id="poi-panel">
       <div id="nav-section" class="panel-section">
         <div class="section-header">
@@ -190,6 +192,7 @@
   <script src="/js/map-viewer.js"></script>
   <script src="/js/poi-editor.js"></script>
   <script src="/js/route-editor.js"></script>
+  <script src="/js/sidebar-resizer.js"></script>
   <script src="/js/app.js"></script>
 </body>
 </html>

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -22,7 +22,7 @@
       <div id="map-status"></div>
     </div>
 
-    <div id="sidebar-resizer" title="Drag to resize sidebar"></div>
+    <div id="sidebar-resizer" role="separator" aria-orientation="vertical" title="Drag to resize sidebar"></div>
 
     <div id="poi-panel">
       <div id="nav-section" class="panel-section">

--- a/mapoi_webui/web/js/sidebar-resizer.js
+++ b/mapoi_webui/web/js/sidebar-resizer.js
@@ -6,36 +6,67 @@
  * に復元する。
  *
  * 制約:
- * - 幅は MIN_WIDTH / MAX_WIDTH で clamp (panel 中身が崩れない範囲)
+ * - 幅は MIN_WIDTH / 動的 maxAllowedWidth() で clamp
+ *   maxAllowedWidth は MAX_WIDTH と「viewport から map 用の最低幅 (MAP_RESERVE_PX)
+ *   を確保した値」のうち小さい方。viewport 縮小で 800px 上限が viewport を
+ *   超えないようにする (Codex PR #124 round 1 medium)。
  * - mobile (max-width: 768px) では handle が CSS で非表示なので何もしない
  * - drag 中は document 全体で text 選択を抑止し ew-resize cursor を強制
+ * - window blur / mouseleave で drag を確実に cancel し stuck を防ぐ
  *
  * リサイズ後に Leaflet マップが新サイズを認識できるよう `window` の
  * `resize` event を dispatch する (Leaflet が listen して invalidateSize 相当
- * を内部で行う)。
+ * を内部で行う)。復元直後にも 1 回 dispatch して初期化タイミングずれを防ぐ。
+ *
+ * localStorage 読み書きは private mode 等で SecurityError が出るため try/catch
+ * で囲み、失敗時は default 350px のまま drag は引き続き使えるようにする。
  */
 (function () {
   const STORAGE_KEY = 'mapoi_sidebar_width_px';
   const MIN_WIDTH = 280;
   const MAX_WIDTH = 800;
+  const MAP_RESERVE_PX = 200; // viewport 縮小時に map 側に確保する最低幅
+
+  function maxAllowedWidth() {
+    return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, window.innerWidth - MAP_RESERVE_PX));
+  }
+
+  function clamp(width) {
+    return Math.max(MIN_WIDTH, Math.min(maxAllowedWidth(), width));
+  }
 
   document.addEventListener('DOMContentLoaded', () => {
     const resizer = document.getElementById('sidebar-resizer');
     const panel = document.getElementById('poi-panel');
     if (!resizer || !panel) return;
 
-    // 初期化: 保存幅を復元 (範囲外 / NaN は無視して default 350px のまま)
-    const savedRaw = localStorage.getItem(STORAGE_KEY);
+    // 初期化: 保存幅を復元 (範囲外 / NaN / storage 例外は無視して default のまま)
+    let savedRaw = null;
+    try {
+      savedRaw = localStorage.getItem(STORAGE_KEY);
+    } catch (_) {
+      // private mode / cookies blocked など。default 350px で続行
+    }
     if (savedRaw !== null) {
       const saved = parseInt(savedRaw, 10);
-      if (!Number.isNaN(saved) && saved >= MIN_WIDTH && saved <= MAX_WIDTH) {
-        panel.style.width = saved + 'px';
+      if (!Number.isNaN(saved)) {
+        panel.style.width = clamp(saved) + 'px';
+        // 復元直後に Leaflet にサイズ通知 (map 初期化タイミング次第のずれを防ぐ)
+        window.dispatchEvent(new Event('resize'));
       }
     }
 
     let dragging = false;
     let startX = 0;
     let startWidth = 0;
+
+    function cancelDrag() {
+      if (!dragging) return;
+      dragging = false;
+      resizer.classList.remove('dragging');
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    }
 
     resizer.addEventListener('mousedown', (e) => {
       e.preventDefault();
@@ -52,25 +83,34 @@
       // resizer の右側に panel があるので、左へドラッグ (clientX 減少) すると
       // panel 幅が増える。
       const delta = startX - e.clientX;
-      let newWidth = startWidth + delta;
-      newWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, newWidth));
-      panel.style.width = newWidth + 'px';
+      panel.style.width = clamp(startWidth + delta) + 'px';
     });
 
     document.addEventListener('mouseup', () => {
       if (!dragging) return;
-      dragging = false;
-      resizer.classList.remove('dragging');
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
+      cancelDrag();
       const finalWidth = Math.round(panel.getBoundingClientRect().width);
       try {
         localStorage.setItem(STORAGE_KEY, String(finalWidth));
       } catch (_) {
-        // localStorage が使えない環境 (private mode 等) では永続化を skip
+        // localStorage が使えない環境では永続化を skip
       }
       // Leaflet マップに新サイズを通知 (`resize` event を listen している)。
       window.dispatchEvent(new Event('resize'));
+    });
+
+    // ブラウザ外 mouseup や window が blur した時に drag が stuck するのを防ぐ。
+    window.addEventListener('blur', cancelDrag);
+
+    // viewport 縮小で現在幅が maxAllowedWidth() を超えた場合は再 clamp。
+    // drag 中は startWidth 基準で計算しているので無視 (drag 終了後に補正される)。
+    window.addEventListener('resize', () => {
+      if (dragging) return;
+      const current = Math.round(panel.getBoundingClientRect().width);
+      const clamped = clamp(current);
+      if (clamped !== current) {
+        panel.style.width = clamped + 'px';
+      }
     });
   });
 })();

--- a/mapoi_webui/web/js/sidebar-resizer.js
+++ b/mapoi_webui/web/js/sidebar-resizer.js
@@ -1,0 +1,76 @@
+/**
+ * Sidebar drag-resize (#122 PR-2)。
+ *
+ * #sidebar-resizer (6px のスプリッタ) を mousedown でつかんで左右に動かすと
+ * #poi-panel の幅が変わる。リリース時に localStorage に永続化、次回ロード時
+ * に復元する。
+ *
+ * 制約:
+ * - 幅は MIN_WIDTH / MAX_WIDTH で clamp (panel 中身が崩れない範囲)
+ * - mobile (max-width: 768px) では handle が CSS で非表示なので何もしない
+ * - drag 中は document 全体で text 選択を抑止し ew-resize cursor を強制
+ *
+ * リサイズ後に Leaflet マップが新サイズを認識できるよう `window` の
+ * `resize` event を dispatch する (Leaflet が listen して invalidateSize 相当
+ * を内部で行う)。
+ */
+(function () {
+  const STORAGE_KEY = 'mapoi_sidebar_width_px';
+  const MIN_WIDTH = 280;
+  const MAX_WIDTH = 800;
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const resizer = document.getElementById('sidebar-resizer');
+    const panel = document.getElementById('poi-panel');
+    if (!resizer || !panel) return;
+
+    // 初期化: 保存幅を復元 (範囲外 / NaN は無視して default 350px のまま)
+    const savedRaw = localStorage.getItem(STORAGE_KEY);
+    if (savedRaw !== null) {
+      const saved = parseInt(savedRaw, 10);
+      if (!Number.isNaN(saved) && saved >= MIN_WIDTH && saved <= MAX_WIDTH) {
+        panel.style.width = saved + 'px';
+      }
+    }
+
+    let dragging = false;
+    let startX = 0;
+    let startWidth = 0;
+
+    resizer.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      dragging = true;
+      startX = e.clientX;
+      startWidth = panel.getBoundingClientRect().width;
+      resizer.classList.add('dragging');
+      document.body.style.cursor = 'ew-resize';
+      document.body.style.userSelect = 'none';
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!dragging) return;
+      // resizer の右側に panel があるので、左へドラッグ (clientX 減少) すると
+      // panel 幅が増える。
+      const delta = startX - e.clientX;
+      let newWidth = startWidth + delta;
+      newWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, newWidth));
+      panel.style.width = newWidth + 'px';
+    });
+
+    document.addEventListener('mouseup', () => {
+      if (!dragging) return;
+      dragging = false;
+      resizer.classList.remove('dragging');
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      const finalWidth = Math.round(panel.getBoundingClientRect().width);
+      try {
+        localStorage.setItem(STORAGE_KEY, String(finalWidth));
+      } catch (_) {
+        // localStorage が使えない環境 (private mode 等) では永続化を skip
+      }
+      // Leaflet マップに新サイズを通知 (`resize` event を listen している)。
+      window.dispatchEvent(new Event('resize'));
+    });
+  });
+})();

--- a/mapoi_webui/web/js/sidebar-resizer.js
+++ b/mapoi_webui/web/js/sidebar-resizer.js
@@ -10,22 +10,29 @@
  *   maxAllowedWidth は MAX_WIDTH と「viewport から map 用の最低幅 (MAP_RESERVE_PX)
  *   を確保した値」のうち小さい方。viewport 縮小で 800px 上限が viewport を
  *   超えないようにする (Codex PR #124 round 1 medium)。
- * - mobile (max-width: 768px) では handle が CSS で非表示なので何もしない
+ * - mobile (max-width: 768px) では handle が CSS で非表示、かつ panel は
+ *   width: auto の column 配置になるため inline width を入れない / クリア
+ *   する (Codex PR #124 round 2 medium 対応)
  * - drag 中は document 全体で text 選択を抑止し ew-resize cursor を強制
- * - window blur / mouseleave で drag を確実に cancel し stuck を防ぐ
+ * - window blur で drag を確実に cancel し stuck を防ぐ
  *
  * リサイズ後に Leaflet マップが新サイズを認識できるよう `window` の
  * `resize` event を dispatch する (Leaflet が listen して invalidateSize 相当
  * を内部で行う)。復元直後にも 1 回 dispatch して初期化タイミングずれを防ぐ。
  *
  * localStorage 読み書きは private mode 等で SecurityError が出るため try/catch
- * で囲み、失敗時は default 350px のまま drag は引き続き使えるようにする。
+ * で囲み、失敗時は default のまま drag は引き続き使えるようにする。
  */
 (function () {
   const STORAGE_KEY = 'mapoi_sidebar_width_px';
   const MIN_WIDTH = 280;
   const MAX_WIDTH = 800;
   const MAP_RESERVE_PX = 200; // viewport 縮小時に map 側に確保する最低幅
+  const MOBILE_MAX_WIDTH = 768; // CSS @media (max-width: 768px) と一致
+
+  function isMobile() {
+    return window.innerWidth <= MOBILE_MAX_WIDTH;
+  }
 
   function maxAllowedWidth() {
     return Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, window.innerWidth - MAP_RESERVE_PX));
@@ -40,21 +47,40 @@
     const panel = document.getElementById('poi-panel');
     if (!resizer || !panel) return;
 
-    // 初期化: 保存幅を復元 (範囲外 / NaN / storage 例外は無視して default のまま)
-    let savedRaw = null;
+    // localStorage から保存幅を 1 回読み in-memory cache する。private mode 等の
+    // 例外は無視。null のまま保たれた場合は CSS default (350px) で運用。
+    let savedDesktopWidth = null;
     try {
-      savedRaw = localStorage.getItem(STORAGE_KEY);
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw !== null) {
+        const n = parseInt(raw, 10);
+        if (!Number.isNaN(n)) savedDesktopWidth = n;
+      }
     } catch (_) {
-      // private mode / cookies blocked など。default 350px で続行
+      // private mode / cookies blocked など
     }
-    if (savedRaw !== null) {
-      const saved = parseInt(savedRaw, 10);
-      if (!Number.isNaN(saved)) {
-        panel.style.width = clamp(saved) + 'px';
-        // 復元直後に Leaflet にサイズ通知 (map 初期化タイミング次第のずれを防ぐ)
-        window.dispatchEvent(new Event('resize'));
+
+    /**
+     * 現 breakpoint に応じて panel の inline width を設定 / クリア:
+     * - mobile: inline width をクリアし CSS @media (width: auto) に任せる
+     * - desktop: 保存幅があれば clamp して適用、無ければ inline をクリアして
+     *   CSS default (350px) に戻す
+     */
+    function applyForCurrentBreakpoint() {
+      if (isMobile()) {
+        panel.style.width = '';
+        return;
+      }
+      if (savedDesktopWidth !== null) {
+        panel.style.width = clamp(savedDesktopWidth) + 'px';
+      } else {
+        panel.style.width = '';
       }
     }
+
+    applyForCurrentBreakpoint();
+    // 初期化直後に Leaflet にサイズ通知 (map 初期化タイミング次第のずれを防ぐ)
+    window.dispatchEvent(new Event('resize'));
 
     let dragging = false;
     let startX = 0;
@@ -69,6 +95,7 @@
     }
 
     resizer.addEventListener('mousedown', (e) => {
+      if (isMobile()) return; // mobile では resizer 自体が非表示だが念のため
       e.preventDefault();
       dragging = true;
       startX = e.clientX;
@@ -90,6 +117,7 @@
       if (!dragging) return;
       cancelDrag();
       const finalWidth = Math.round(panel.getBoundingClientRect().width);
+      savedDesktopWidth = finalWidth;
       try {
         localStorage.setItem(STORAGE_KEY, String(finalWidth));
       } catch (_) {
@@ -102,15 +130,11 @@
     // ブラウザ外 mouseup や window が blur した時に drag が stuck するのを防ぐ。
     window.addEventListener('blur', cancelDrag);
 
-    // viewport 縮小で現在幅が maxAllowedWidth() を超えた場合は再 clamp。
-    // drag 中は startWidth 基準で計算しているので無視 (drag 終了後に補正される)。
+    // viewport 変化 (mobile/desktop 切替 + desktop での viewport 縮小) に追従。
+    // drag 中は startWidth 基準計算と衝突するので skip (drag 終了後に補正される)。
     window.addEventListener('resize', () => {
       if (dragging) return;
-      const current = Math.round(panel.getBoundingClientRect().width);
-      const clamped = clamp(current);
-      if (clamped !== current) {
-        panel.style.width = clamped + 'px';
-      }
+      applyForCurrentBreakpoint();
     });
   });
 })();


### PR DESCRIPTION
## 概要

Issue #122 PR-2 対応。固定幅 350px だった `#poi-panel` を、左境界に置いたスプリッタ (drag handle) でユーザが任意の幅に調整できるようにする。リロード後も localStorage で幅を復元。

#122 PR-1 (form-actions sticky、merged) の続きで、サイドパネル UX 改善の本丸。

Refs #122

## 変更内容

| ファイル | 変更 |
|---|---|
| `mapoi_webui/web/index.html` | `<div id="sidebar-resizer">` を `#map-container` ↔ `#poi-panel` 間に挿入、`sidebar-resizer.js` を読み込み |
| `mapoi_webui/web/css/style.css` | `#sidebar-resizer` の見た目 (6px 幅、ew-resize cursor、hover/dragging 時に色変化)、mobile 非表示 |
| `mapoi_webui/web/js/sidebar-resizer.js` (新規) | mousedown→move→up を listen して panel 幅を更新、localStorage に永続化 |

`CMakeLists.txt` は既に `web/` 全体を install 対象にしているため、新 JS ファイルも自動で含まれる。

## 設計判断

### (a) 制約: MIN_WIDTH = 280px / MAX_WIDTH = 800px
- 280px は操作系が崩れない最小値（route name input + ボタン 2 個が並ぶ）
- 800px はマップを完全に覆い隠さない上限。画面解像度によらず実用範囲

### (b) Leaflet 対応
リサイズ後に `window.dispatchEvent(new Event('resize'))` を発火し、Leaflet 側で内部的に invalidateSize 相当の処理が走るのに任せる。`mapViewer` インスタンスに直接アクセスせず疎結合を保つ。

### (c) localStorage キー
`mapoi_sidebar_width_px` で衝突回避。範囲外 / NaN は無視して default 350px に戻る。

### (d) Mobile (<768px) は無効化
panel が full-width column 配置になるため drag-resize の意味がない。CSS で `#sidebar-resizer { display: none; }`。

### (e) Touch event 非対応 (MVP)
mousedown/move/up のみ。タブレット運用が出てきたら touchstart/touchmove/touchend を追加する別 PR で対応予定。

## 動作確認

\`\`\`bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
\`\`\`

ブラウザ http://localhost:8765 で:
- [ ] 左境界 (panel と map の境目) に 6px のグレースプリッタが表示される
- [ ] hover で青色に変わる
- [ ] mousedown → ドラッグで panel 幅が変わる、map もリサイズされる
- [ ] mouseup でリリース、リロードしても同じ幅で復元される
- [ ] 280px 未満 / 800px 超には伸びない (clamp)
- [ ] mobile (< 768px window) では handle が消える、panel は full-width
- [ ] PR-1 の form-actions sticky 動作と組み合わせても問題なし

## 関連
- #122 — UX 改善親 issue
- PR #123 (#122 PR-1, merged) — form-actions sticky 化、本 PR は同 issue の続編
- PR-3 (文字幅制御) は別 PR で