### PR TITLE
feat(webui): POI / route 名の文字溢れを ellipsis + hover tooltip で制御 (#122 PR-3)

### DIFF
--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -217,6 +217,12 @@ main {
 .poi-card-name {
   font-weight: 600;
   font-size: 0.95rem;
+  /* 長い POI 名は 1 行 ellipsis、JS 側で title 属性に full name を入れて
+     hover tooltip で確認可能 (#122 PR-3)。親 .poi-card-info に min-width: 0
+     が設定済なので flex 内で縮む。 */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .poi-card-detail {
@@ -514,6 +520,12 @@ main {
 .route-item-name {
   font-weight: 600;
   font-size: 0.85rem;
+  /* 長い route 名は 1 行 ellipsis、JS 側で title 属性に full name を入れて
+     hover tooltip で確認可能 (#122 PR-3)。親 .route-item-text に
+     min-width: 0 が設定済なので flex 内で縮む。 */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .route-item-detail {

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -89,7 +89,10 @@ class PoiEditor {
 
       const name = document.createElement('div');
       name.className = 'poi-card-name';
-      name.textContent = poi.name || '(unnamed)';
+      const nameText = poi.name || '(unnamed)';
+      name.textContent = nameText;
+      // ellipsis 切り捨てに備え hover tooltip で full text 確認可能に (#122 PR-3)。
+      name.title = nameText;
       info.appendChild(name);
 
       const detail = document.createElement('div');
@@ -97,7 +100,9 @@ class PoiEditor {
       const pose = poi.pose || {};
       const tags = (poi.tags || []).join(', ');
       const desc = poi.description || '';
-      detail.textContent = `(${(pose.x||0).toFixed(2)}, ${(pose.y||0).toFixed(2)}) yaw=${(pose.yaw||0).toFixed(2)} ${tags} ${desc}`;
+      const detailText = `(${(pose.x||0).toFixed(2)}, ${(pose.y||0).toFixed(2)}) yaw=${(pose.yaw||0).toFixed(2)} ${tags} ${desc}`;
+      detail.textContent = detailText;
+      detail.title = detailText;
       info.appendChild(detail);
 
       card.appendChild(info);

--- a/mapoi_webui/web/js/route-editor.js
+++ b/mapoi_webui/web/js/route-editor.js
@@ -103,10 +103,14 @@ class RouteEditor {
       const nameSpan = document.createElement('span');
       nameSpan.className = 'route-item-name';
       nameSpan.textContent = route.name;
+      // ellipsis 切り捨てに備え hover tooltip で full text 確認可能に (#122 PR-3)。
+      nameSpan.title = route.name || '';
 
       const wpSpan = document.createElement('span');
       wpSpan.className = 'route-item-detail';
-      wpSpan.textContent = (route.waypoints || []).join(' \u2192 ');
+      const wpText = (route.waypoints || []).join(' \u2192 ');
+      wpSpan.textContent = wpText;
+      wpSpan.title = wpText;
 
       textWrap.appendChild(nameSpan);
       textWrap.appendChild(wpSpan);

--- a/mapoi_webui/web/js/route-editor.js
+++ b/mapoi_webui/web/js/route-editor.js
@@ -102,9 +102,12 @@ class RouteEditor {
 
       const nameSpan = document.createElement('span');
       nameSpan.className = 'route-item-name';
-      nameSpan.textContent = route.name;
-      // ellipsis 切り捨てに備え hover tooltip で full text 確認可能に (#122 PR-3)。
-      nameSpan.title = route.name || '';
+      // textContent と title を同じ正規化値で揃える (POI 側 pattern と一貫、
+      // Codex PR #125 round 1 medium 対応)。空 / undefined の route 名は
+      // "(unnamed)" として表示され tooltip も同値、ずれを防ぐ。
+      const nameText = route.name || '(unnamed)';
+      nameSpan.textContent = nameText;
+      nameSpan.title = nameText;
 
       const wpSpan = document.createElement('span');
       wpSpan.className = 'route-item-detail';


### PR DESCRIPTION
## 概要

Issue #122 PR-3 対応。長い POI 名 / route 名で表示が崩れる問題を **ellipsis 1 行切り捨て + hover tooltip で full text 確認可能** な形に統一する。

#122 で議論した文字幅制御の方針 (A: ellipsis、B: wrap、C: ellipsis + tooltip) のうち、**name は A** を採用。tooltip も合わせて添えることで C 相当の挙動も得られる。

#122 を close する最後の PR。PR-1 (form-actions sticky)、PR-2 (drag-resize) と合わせて sidebar UX 改善が完成。

Close #122

## 変更内容

### CSS (`mapoi_webui/web/css/style.css`)
- `.poi-card-name` / `.route-item-name` に `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;` を追加
- 親 (`.poi-card-info` / `.route-item-text`) は既に `min-width: 0` 設定済なので flex 内縮みが効く

### JS
- `mapoi_webui/web/js/poi-editor.js` `renderList`: `.poi-card-name` / `.poi-card-detail` に `title` 属性 (full text)
- `mapoi_webui/web/js/route-editor.js` `renderList`: `.route-item-name` / `.route-item-detail` に同様

### スコープ外
- 説明文 (description) や tag 列の **wrap (B 案)** は input フォーム自体の構造変更が必要なため別 PR / 別 issue
- tag chip の ellipsis: 通常 tag は短いため必要性低、保留
- 検索 / フィルタ機能: スコープ外

## 動作確認

\`\`\`bash
ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml \
  rviz:=false gazebo_gui:=false
\`\`\`

ブラウザ http://localhost:8765 で:
- [ ] POI 名を長い名前 (例: "very_long_poi_name_that_does_not_fit_in_panel") にして save
- [ ] panel 上で名前末尾が "..." で切れている、hover で full name の tooltip 表示
- [ ] route 名も同様
- [ ] 短い名前は影響なし (regression なし)
- [ ] sidebar drag-resize (PR-2) で panel を狭めても ellipsis が動的に追従
- [ ] mobile (<768px) でも崩れない

## 関連

- #122 — UX 改善親 issue。本 PR で close
- PR #123 (#122 PR-1, merged) — form-actions sticky
- PR #124 (#122 PR-2, merged) — sidebar drag-resize
- 本 PR (#122 PR-3) — 文字幅制御