### PR TITLE
feat(webui): robot_radius を ROS param 化 + /api/nav/status payload に注入 (#117)

### DIFF
--- a/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
@@ -80,6 +80,9 @@ launch:
       - {name: robot_sdf_path, value: "$(find-pkg-share turtlebot3_gazebo)/models/turtlebot3_$(env TURTLEBOT3_MODEL)/model.sdf"}
 
 # Mapoi Web UI
+# robot_radius は Nav2 param (param/$(ROS_DISTRO)/burger.yaml の `robot_radius: 0.1`)
+# と意図的に揃える。両者がずれると「marker は当たっていないのに Nav2 は当たり判定」
+# のような UX の不整合になる (#117)。
 - include:
     file: "$(find-pkg-share mapoi_webui)/launch/mapoi_webui.launch.yaml"
     arg:
@@ -88,3 +91,4 @@ launch:
       - {name: config_file, value: "mapoi_config.yaml"}
       - {name: web_port, value: "8765"}
       - {name: web_host, value: "0.0.0.0"}
+      - {name: robot_radius, value: "0.1"}

--- a/mapoi_webui/README.md
+++ b/mapoi_webui/README.md
@@ -31,6 +31,7 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 | `web_host` | `string` | `0.0.0.0` | HTTP サーバーのバインドアドレス |
 | `map_frame` | `string` | `map` | TF の親フレーム |
 | `base_frame` | `string` | `base_link` | TF の子フレーム |
+| `robot_radius` | `double` | `0.15` | ロボットの実寸 (m)。frontend の robot marker サイズ・active route connector の到達閾値に使う。Nav2 の `robot_radius` と意味は同じだが本 node は Nav2 非依存運用も想定するため独立 param とした。Nav2 を併用する場合は両者の値を一致させる (#117) |
 
 #### パブリッシャー
 
@@ -67,7 +68,7 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 | POST | `/api/pois` | POI の保存 |
 | GET | `/api/routes` | ルート一覧 |
 | GET | `/api/tag_definitions` | タグ定義一覧 |
-| GET | `/api/nav/status` | ナビゲーション状態・ロボット位置 |
+| GET | `/api/nav/status` | ナビゲーション状態・ロボット位置・`robot_radius` (m) |
 | POST | `/api/nav/goal` | POI へのゴール走行 |
 | POST | `/api/nav/route` | ルート走行の開始 |
 | POST | `/api/nav/pause` | ナビゲーションの一時停止 |

--- a/mapoi_webui/launch/mapoi_editor.launch.yaml
+++ b/mapoi_webui/launch/mapoi_editor.launch.yaml
@@ -36,6 +36,11 @@ launch:
     default: "0.0.0.0"
     description: "HTTP server bind address"
 
+- arg:
+    name: robot_radius
+    default: "0.15"
+    description: "Robot radius in meters (frontend connector / marker size; default tuned for TurtleBot3)"
+
 # mapoi_server を minimal で起動 (nav_server / rviz_publisher / sim bridge は起動しない)。
 - include:
     file: "$(find-pkg-share mapoi_server)/launch/mapoi_bringup.launch.yaml"
@@ -56,3 +61,4 @@ launch:
       - {name: config_file, value: "$(var config_file)"}
       - {name: web_port, value: "$(var web_port)"}
       - {name: web_host, value: "$(var web_host)"}
+      - {name: robot_radius, value: "$(var robot_radius)"}

--- a/mapoi_webui/launch/mapoi_webui.launch.yaml
+++ b/mapoi_webui/launch/mapoi_webui.launch.yaml
@@ -25,6 +25,11 @@ launch:
     default: "0.0.0.0"
     description: "HTTP server bind address"
 
+- arg:
+    name: robot_radius
+    default: "0.15"
+    description: "Robot radius in meters (frontend connector / marker size; default tuned for TurtleBot3)"
+
 - node:
     pkg: mapoi_webui
     exec: mapoi_webui_node.py
@@ -34,4 +39,5 @@ launch:
       - {name: config_file, value: "$(var config_file)"}
       - {name: web_port, value: "$(var web_port)"}
       - {name: web_host, value: "$(var web_host)"}
+      - {name: robot_radius, value: "$(var robot_radius)"}
     output: "screen"

--- a/mapoi_webui/launch/mapoi_webui.launch.yaml
+++ b/mapoi_webui/launch/mapoi_webui.launch.yaml
@@ -39,5 +39,8 @@ launch:
       - {name: config_file, value: "$(var config_file)"}
       - {name: web_port, value: "$(var web_port)"}
       - {name: web_host, value: "$(var web_host)"}
-      - {name: robot_radius, value: "$(var robot_radius)"}
+      # type: double を明示。CLI override `robot_radius:=1` のような整数表記が
+      # int として coerce されると declare_parameter (DOUBLE) と型不一致になる
+      # (Codex PR #126 round 1 medium)。double 指定で launch_ros が float coercion する。
+      - {name: robot_radius, value: "$(var robot_radius)", type: "double"}
     output: "screen"

--- a/mapoi_webui/launch/mapoi_webui.launch.yaml
+++ b/mapoi_webui/launch/mapoi_webui.launch.yaml
@@ -39,8 +39,11 @@ launch:
       - {name: config_file, value: "$(var config_file)"}
       - {name: web_port, value: "$(var web_port)"}
       - {name: web_host, value: "$(var web_host)"}
-      # type: double を明示。CLI override `robot_radius:=1` のような整数表記が
+      # type: float を明示。CLI override `robot_radius:=1` のような整数表記が
       # int として coerce されると declare_parameter (DOUBLE) と型不一致になる
-      # (Codex PR #126 round 1 medium)。double 指定で launch_ros が float coercion する。
-      - {name: robot_radius, value: "$(var robot_radius)", type: "double"}
+      # (Codex PR #126 round 1 medium → round 2 high で identifier 修正)。
+      # launch frontend (humble/jazzy 共通) の有効識別子は "float" のみで
+      # "double" は ValueError で parse 失敗する点に注意。Python float = C++ double
+      # で ROS parameter 上は double param として渡る。
+      - {name: robot_radius, value: "$(var robot_radius)", type: "float"}
     output: "screen"

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -56,6 +56,12 @@ class MapoiWebNode(Node):
         self.declare_parameter('web_host', '0.0.0.0')
         self.declare_parameter('map_frame', 'map')
         self.declare_parameter('base_frame', 'base_link')
+        # ロボットの実寸 (m)。frontend が connector 到達閾値 / robot marker サイズ
+        # に使う (#116, #117)。Nav2 の `robot_radius` と意味は同じだが、本 node
+        # は Nav2 非依存運用 (Editor mode 等) も想定するため、launch param で
+        # 個別に渡す。Nav2 と必ずセットで使う場合は controller_server 側を
+        # 直接 pull する案 (#117 案 B) を別途検討。
+        self.declare_parameter('robot_radius', 0.15)
 
         self.maps_path_ = self.get_parameter('maps_path').get_parameter_value().string_value
         self.map_name_ = self.get_parameter('map_name').get_parameter_value().string_value
@@ -64,6 +70,8 @@ class MapoiWebNode(Node):
         self.web_host_ = self.get_parameter('web_host').get_parameter_value().string_value
         self.map_frame_ = self.get_parameter('map_frame').get_parameter_value().string_value
         self.base_frame_ = self.get_parameter('base_frame').get_parameter_value().string_value
+        self.robot_radius_ = float(
+            self.get_parameter('robot_radius').get_parameter_value().double_value)
 
         # ROS2 service clients
         self.reload_client_ = self.create_client(Trigger, 'reload_map_info')
@@ -494,6 +502,10 @@ class MapoiWebNode(Node):
                 'status': node.nav_status_,
                 'target': node.nav_status_target_,
                 'robot_pose': node.robot_pose_,
+                # robot_radius は launch 起動時固定だが、frontend が boot 時に
+                # 別 endpoint を叩かなくて済むよう poll 結果に相乗りさせる。
+                # 値は float (m)、payload size 影響は無視できる (#117)。
+                'robot_radius': node.robot_radius_,
             })
 
         @app.route('/api/nav/initialpose', methods=['POST'])

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -70,8 +70,19 @@ class MapoiWebNode(Node):
         self.web_host_ = self.get_parameter('web_host').get_parameter_value().string_value
         self.map_frame_ = self.get_parameter('map_frame').get_parameter_value().string_value
         self.base_frame_ = self.get_parameter('base_frame').get_parameter_value().string_value
-        self.robot_radius_ = float(
+        # 値検証: 設定ミス (typo / yaml で `0` / 負値) を silent に飲み込まないよう
+        # finite かつ正値を要求する。invalid なら warn して default 0.15 に fallback
+        # (frontend 側 `setRobotRadius` ガードと defense in depth、
+        #  Codex PR #126 round 1 low)。
+        raw_radius = float(
             self.get_parameter('robot_radius').get_parameter_value().double_value)
+        if not math.isfinite(raw_radius) or raw_radius <= 0.0:
+            self.get_logger().warn(
+                f'robot_radius={raw_radius!r} は不正値です。default 0.15m を使います。'
+                ' (連動する Nav2 robot_radius と一致するように launch param を見直してください)')
+            self.robot_radius_ = 0.15
+        else:
+            self.robot_radius_ = raw_radius
 
         # ROS2 service clients
         self.reload_client_ = self.create_client(Trigger, 'reload_map_info')

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -435,6 +435,11 @@
       try {
         const data = await MapoiApi.navStatus();
         updateNavStatus(data.status, data.target);
+        // robot_radius は launch param 由来 (#117)。古い backend では key
+        // 不在になるが setRobotRadius が型 check で no-op にする。値が来る
+        // 前に updateRobotMarker が走っても map-viewer の default 0.15 で
+        // 描画されるので safe。
+        mapViewer.setRobotRadius(data.robot_radius);
         mapViewer.updateRobotMarker(data.robot_pose);
       } catch (e) {
         // ignore fetch errors

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -29,8 +29,10 @@ class MapViewer {
     this._reachedRouteSignatures = new Set(); // 到達済み route の "name|firstWaypoint" signature 集合 (page 内 sticky)
 
     // ロボットの実寸 (m)。connector 到達閾値とロボットマーカーサイズの両方に
-    // 使う共通定数 (#116)。MVP として hardcoded、将来 launch param / Nav2 pull
-    // へ移行 (#117)。値は TurtleBot3 burger (~0.105m) に余裕を持たせた一般値。
+    // 使う (#116)。default は TurtleBot3 burger (~0.105m) に余裕を持たせた値。
+    // backend (`/api/nav/status` payload の `robot_radius`) が起動時 launch
+    // param 由来の値を返すので、app.js が `setRobotRadius` で上書きする (#117)。
+    // backend が古い (key 不在) 場合や上書き前の初回描画はこの default を使う。
     this.robotRadiusM = 0.15;
 
     this.map.on('click', (e) => {
@@ -693,6 +695,25 @@ class MapViewer {
       iconSize: [sizePx, sizePx],
       iconAnchor: [half, half],
     });
+  }
+
+  /**
+   * Update `robotRadiusM` from backend (`/api/nav/status` の `robot_radius`)。
+   *
+   * 値は launch param `robot_radius` 由来で起動後は変わらない想定だが、
+   * polling 経路で来るので idempotent に書く。次の `updateRobotMarker` で
+   * marker サイズと connector 閾値が新値で再計算される。
+   *
+   * 不正値 (NaN / 非有限 / 0以下) は ignore して default / 前回値を維持する。
+   * connector 到達判定で `< robotRadiusM` を使うため 0 以下を許すと到達認識が
+   * 永久に立たない。
+   */
+  setRobotRadius(meters) {
+    if (typeof meters !== 'number' || !Number.isFinite(meters) || meters <= 0) {
+      return;
+    }
+    if (this.robotRadiusM === meters) return;
+    this.robotRadiusM = meters;
   }
 
   /**


### PR DESCRIPTION
## Summary

- `mapoi_webui_node` に `robot_radius` param (default 0.15) を追加し、`/api/nav/status` の payload に相乗りで配信。frontend は `MapViewer.setRobotRadius()` で polling 経由に取得、connector 到達閾値 / robot marker サイズに反映する
- launch arg `robot_radius` を `mapoi_webui.launch.yaml` / `mapoi_editor.launch.yaml` に追加。turtlebot3 example では Nav2 `burger.yaml` の `robot_radius: 0.1` と揃えるため明示的に `0.1` を渡す
- 既存の hardcoded `ROBOT_RADIUS_M = 0.15` (#116) を MVP から正式 param 化、別 robot 構成への対応路を確保

Close #117

## 設計メモ

- **case A (採用)**: `robot_radius` を webui_node 自身の launch param として宣言。Nav2 非依存運用 (Editor mode 等) でも値を渡せる。Issue #117 の方針通り
- **case B (採用見送り)**: Nav2 `controller_server` から `AsyncParameterClient` で pull する案。Operator mode (#61) で Nav2 と必ずセット運用するときに検討
- payload 配信先: 既存の `/api/nav/status` (1Hz polling) に相乗り。値はほぼ静的で別 endpoint を新設するメリットが薄い
- frontend default: backend 古い (key 不在) 場合や初回描画時は `MapViewer` 側 default 0.15 を使う。`setRobotRadius` は NaN / 非有限 / 0以下を ignore する (connector 到達判定の `< robotRadiusM` を絶対 0 にしないガード)

## Test plan

- [x] `colcon build --symlink-install --packages-up-to mapoi_webui mapoi_turtlebot3_example` (humble) clean pass
- [x] `colcon build --symlink-install --packages-up-to mapoi_webui mapoi_turtlebot3_example` (jazzy) clean pass
- [x] launch yaml 3 ファイルの YAML syntax check
- [x] mapoi_webui_node.py の python ast.parse
- [x] app.js / map-viewer.js の `node --check`
- [x] (実機 / sim) `ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml` 起動 → `curl http://localhost:8765/api/nav/status` の payload に `robot_radius: 0.1` が乗る
- [x] ブラウザで marker 直径と connector 到達閾値が `0.1m` 相当 (前 0.15m との差) で動く
- [ ] launch override (`ros2 launch ... robot_radius:=0.30`) で frontend にも 0.30 が反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)