### PR TITLE
feat(webui): 複数 route polyline の parallel offset 描画 (#69 PR-2)

### DIFF
--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -555,21 +555,27 @@ class MapViewer {
     routes.forEach((route, routeIdx) => {
       if (visibleNames && !visibleNames.has(route.name)) return;
       const rawLatlngs = [];
+      // orders は rawLatlngs と並行配列。各 vertex に「元 waypoint 配列での
+      // 1-based index」を保持する。missing POI が途中にある場合 (例: 2 番目が
+      // 未解決で skip) でも、地図上のラベルが route editor 側の waypoint 順番
+      // (1, 3, 4 等) を保つ (#69 round 4 low 対応、Codex review)。
+      const orders = [];
       let firstWaypointName = '';
-      (route.waypoints || []).forEach((wpName) => {
+      (route.waypoints || []).forEach((wpName, i) => {
         const poi = poiByName[wpName];
         if (poi && poi.pose) {
           rawLatlngs.push(this.worldToLatLng(poi.pose.x, poi.pose.y));
+          orders.push(i + 1);
           if (!firstWaypointName) firstWaypointName = wpName;
         }
       });
       if (rawLatlngs.length < 2) return;
-      drawableEntries.push({ route, routeIdx, rawLatlngs, firstWaypointName });
+      drawableEntries.push({ route, routeIdx, rawLatlngs, orders, firstWaypointName });
     });
     const totalDrawable = drawableEntries.length;
     const OFFSET_STEP_PX = 6;
 
-    drawableEntries.forEach(({ route, routeIdx, rawLatlngs, firstWaypointName }, visibleIdx) => {
+    drawableEntries.forEach(({ route, routeIdx, rawLatlngs, orders, firstWaypointName }, visibleIdx) => {
       const offsetPx = (visibleIdx - (totalDrawable - 1) / 2) * OFFSET_STEP_PX;
       const color = this.getRouteColor(routeIdx);
 
@@ -634,11 +640,14 @@ class MapViewer {
         arrowMarkers.push(arrowMarker);
       }
 
-      // Draw order labels at each waypoint (offset 後位置でラベル重なりも軽減)
+      // Draw order labels at each waypoint (offset 後位置でラベル重なりも軽減)。
+      // 番号は元 waypoint 配列の 1-based index (orders[i]) を使い、missing POI
+      // が skip されても route editor 側の順番と整合する (#69 round 4 low 対応)。
       displayLatlngs.forEach((latlng, i) => {
+        const order = orders[i];
         const icon = L.divIcon({
           className: 'route-order-label',
-          html: `<span style="background: ${color};">${i + 1}</span>`,
+          html: `<span style="background: ${color};">${order}</span>`,
           iconSize: [22, 22],
           iconAnchor: [-6, 28],
         });

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -65,17 +65,16 @@ class MapViewer {
     // _activeRouteIdx に基づいて highlight も再適用する (clearRoutes は active
     // index を保持するので、新規 _routePolylines に対して再 paint すれば良い)。
     //
-    // perf 最適化: 表示中 route が 1 本以下なら offsetPx は必ず 0 で displayLatlngs
-    // === latlngs (世界座標) なので、Leaflet が zoom 変換を自前でやれば足りる。
-    // この場合は redraw skip して DOM/SVG layer の全削除→全作成コストを避ける
-    // (#69 round 1 low 対応)。
+    // perf 最適化: 直近の showRoutes で実際に描画された route 数 (= drawable 数) が
+    // 1 本以下なら offsetPx は必ず 0 で displayLatlngs === latlngs (世界座標)。
+    // Leaflet の zoom 変換に任せれば足りるので redraw skip して DOM/SVG layer
+    // の全削除→全作成コストを避ける (#69 round 2 low 対応)。
+    // visibleNames で filter された結果でも、POI 未解決で drawable=0/1 になる
+    // ケースに正しく対応する。
     this.map.on('zoomend', () => {
       if (!this._cachedRoutesArgs) return;
+      if (this._routePolylines.length <= 1) return;
       const { routes, pois, visibleNames } = this._cachedRoutesArgs;
-      const visibleCount = visibleNames
-        ? routes.reduce((acc, r) => acc + (visibleNames.has(r.name) ? 1 : 0), 0)
-        : routes.length;
-      if (visibleCount <= 1) return;
       const prevActive = this._activeRouteIdx;
       this.showRoutes(routes, pois, visibleNames);
       if (prevActive >= 0) {
@@ -453,11 +452,13 @@ class MapViewer {
    * 端点 (i=0 / i=last) は片側 segment のみで normal を直接使う。退化 segment
    * (length < epsilon) は normal を null とし、隣接 normal にフォールバック。
    *
-   * **180° 折り返し** (A→B→A 等で nIn と nOut が anti-parallel、|bisector|≈0):
-   * 折り返し vertex で `nOut` 単独に fallback するため、incoming 側 segment の
-   * offset polyline が元 segment を斜めに横切る視覚アーティファクトが残る。
-   * 厳密に対応するなら vertex 複製 + cap 描画が必要だが、route が同 POI で
-   * 折り返すケースは稀なため許容している (#69 round 1 medium 認知済み)。
+   * **anti-parallel fallback** (`bLen < epsilon`): canonical normal 化以降は
+   * 両 segment が共通端点を持つ通常の vertex で nIn = -nOut になる組み合わせは
+   * 構築できない (lex-order canonical 方向は片方の端点を起点にするため、両
+   * segment の canonical 方向が完全反転する case は collinear-foldback 含めて
+   * 発生しない)。fallback コードは degenerate な数値誤差や将来の normal 計算
+   * 仕様変更に対する保険として残すのみで、現実装では実質到達しない (#69 round 2
+   * low 対応、Codex review)。
    *
    * pixel 計算なので zoom 変化で再計算が必要 → showRoutes は zoomend で cached
    * args を使って呼び直す (#69 PR-2)。
@@ -539,34 +540,36 @@ class MapViewer {
     });
 
     // 共通区間で polyline が完全重複する視認性問題への (b) parallel offset 対策 (#69 PR-2)。
-    // 表示対象 route 数を先に数えて、各 route に中心揃えの offset index を付与する。
-    // 例: 表示中 3 route → offset index は -1, 0, +1 → offsetPx は -STEP, 0, +STEP。
-    // route 数 1 のみだと offset 0 で _offsetLatLngs は no-op、原点描画と完全一致。
-    const visibleEntries = [];
+    //
+    // 1) drawable な route (rawLatlngs.length >= 2、つまり POI 2 点以上に解決でき
+    //    実際に描画される route) を先に列挙する。
+    //    visible だが waypoint 不足 / POI 未解決で描画されない route を offset lane
+    //    数に含めると、画面上の route 数 1 でも offsetPx > 0 で route が中心から
+    //    ずれる + zoomend skip 条件が崩れる (Codex round 2 low 対応)。
+    // 2) drawable 数で中心揃え offset index を付与し、各 route に offsetPx を割り当てる。
+    //    表示中 3 route → offset index は -1, 0, +1 → offsetPx は -STEP, 0, +STEP。
+    //    route 数 1 のみだと offset 0 で _offsetLatLngs は no-op、原点描画と完全一致。
+    const drawableEntries = [];
     routes.forEach((route, routeIdx) => {
       if (visibleNames && !visibleNames.has(route.name)) return;
-      visibleEntries.push({ route, routeIdx });
-    });
-    const totalVisible = visibleEntries.length;
-    const OFFSET_STEP_PX = 6;
-
-    visibleEntries.forEach(({ route, routeIdx }, visibleIdx) => {
-      const offsetPx = (visibleIdx - (totalVisible - 1) / 2) * OFFSET_STEP_PX;
-      const color = this.getRouteColor(routeIdx);
-      const waypoints = route.waypoints || [];
-
-      // Resolve waypoint names to LatLng positions (raw, POI 物理座標)
       const rawLatlngs = [];
       let firstWaypointName = '';
-      waypoints.forEach((wpName) => {
+      (route.waypoints || []).forEach((wpName) => {
         const poi = poiByName[wpName];
         if (poi && poi.pose) {
           rawLatlngs.push(this.worldToLatLng(poi.pose.x, poi.pose.y));
           if (!firstWaypointName) firstWaypointName = wpName;
         }
       });
-
       if (rawLatlngs.length < 2) return;
+      drawableEntries.push({ route, routeIdx, rawLatlngs, firstWaypointName });
+    });
+    const totalDrawable = drawableEntries.length;
+    const OFFSET_STEP_PX = 6;
+
+    drawableEntries.forEach(({ route, routeIdx, rawLatlngs, firstWaypointName }, visibleIdx) => {
+      const offsetPx = (visibleIdx - (totalDrawable - 1) / 2) * OFFSET_STEP_PX;
+      const color = this.getRouteColor(routeIdx);
 
       // 表示用に offset を適用 (offsetPx === 0 なら同じ配列参照が返る)
       const displayLatlngs = this._offsetLatLngs(rawLatlngs, offsetPx);

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -64,10 +64,19 @@ class MapViewer {
     // (#69 PR-2)。最後の showRoutes 引数を保持して再描画する。再描画後は
     // _activeRouteIdx に基づいて highlight も再適用する (clearRoutes は active
     // index を保持するので、新規 _routePolylines に対して再 paint すれば良い)。
+    //
+    // perf 最適化: 表示中 route が 1 本以下なら offsetPx は必ず 0 で displayLatlngs
+    // === latlngs (世界座標) なので、Leaflet が zoom 変換を自前でやれば足りる。
+    // この場合は redraw skip して DOM/SVG layer の全削除→全作成コストを避ける
+    // (#69 round 1 low 対応)。
     this.map.on('zoomend', () => {
       if (!this._cachedRoutesArgs) return;
-      const prevActive = this._activeRouteIdx;
       const { routes, pois, visibleNames } = this._cachedRoutesArgs;
+      const visibleCount = visibleNames
+        ? routes.reduce((acc, r) => acc + (visibleNames.has(r.name) ? 1 : 0), 0)
+        : routes.length;
+      if (visibleCount <= 1) return;
+      const prevActive = this._activeRouteIdx;
       this.showRoutes(routes, pois, visibleNames);
       if (prevActive >= 0) {
         this.highlightRoute(prevActive);
@@ -119,17 +128,21 @@ class MapViewer {
     // updateRobotMarker / _updateRobotConnector が実行されると、新 map 側で
     // 誤座標描画 + 旧 signature の sticky 引継ぎが起こる (Codex PR #118 round 1
     // medium)。同様に _cachedRoutesArgs に旧 map の pois が残っていると、
-    // fitBounds → zoomend → showRoutes (旧 pois) で stale 描画 (#69 PR-2)。
-    // app.js が新 map の pois で showRoutes を呼び直すまで何も描かないよう null 化。
+    // fitBounds → zoomend → showRoutes (旧 pois) で stale 描画する (#69 PR-2)。
     this._lastRobotPose = null;
     this._reachedRouteSignatures.clear();
     this._activeRouteIdx = -1;
-    this._cachedRoutesArgs = null;
     if (this.robotMarker) {
       this.map.removeLayer(this.robotMarker);
       this.robotMarker = null;
     }
     this._clearRobotConnector();
+    // 旧 map の route layer (line / hitLine / arrow / label) も新 overlay に
+    // 重なるため明示的に物理削除。app.js の loadRoutes が遅い・失敗する・
+    // map 切替が連続するケースで stale polyline が見えないように同期 reset
+    // (#69 PR-2 round 1 medium 対応)。clearRoutes 内で _cachedRoutesArgs = null
+    // も実施されるため、再度の null 代入は冗長だが副作用は無い。
+    this.clearRoutes();
 
     // Remove old overlay
     if (this.imageOverlay) {
@@ -421,23 +434,36 @@ class MapViewer {
   }
 
   /**
-   * Offset a polyline by `offsetPx` pixels perpendicular to its tangent
-   * direction (positive offsetPx = right side of motion, i.e. 90° clockwise rotation).
+   * Offset a polyline by `offsetPx` pixels perpendicular to each segment.
    *
-   * 各 vertex で前後セグメントの perpendicular 単位ベクトル (nIn / nOut) の
-   * 和 (= bisector) を計算し、`bisector × (2*offsetPx / |bisector|^2)` で
-   * 並べる。これにより各 segment との perpendicular 距離が `offsetPx` になる。
-   * 鋭角コーナーで blowup しないよう offset 距離を `4*|offsetPx|` でキャップ。
+   * **Direction-independent (canonical) normal**: 各 segment の 2 端点を
+   * lex-order (x, y 辞書順) で並べ、その方向の 90° 時計回り回転を法線とする。
+   * これにより A→B route と B→A route が同じ segment を共有しても法線方向が
+   * 一致し、`offsetPx` を符号付きで分けるだけで両 route が同じ canonical 軸の
+   * 反対側に並行配置される (#69 PR-2 round 1 medium 対応、Codex review)。
    *
-   * 端点 (i=0 / i=last) は片側 segment のみで normal を直接使う。退化セグメント
-   * (length < epsilon) があるとその vertex の normal は無視し、有効な隣の
-   * normal にフォールバック。両側無効なら offset 0 で原点維持。
+   * 各 vertex で前後 segment 法線 (nIn / nOut) の和 = bisector を取り、
+   * `bisector × (2*offsetPx / |bisector|^2)` で位置を求める。直線・浅い角度で
+   * は perpendicular 距離 `offsetPx` を保つが、鋭角で `|bisector|` が小さく
+   * なると factor が blow up するため offset 距離を `4*|offsetPx|` でキャップ。
+   * **キャップ域では「`offsetPx` の perpendicular 距離」保証は崩れる**点に注意:
+   * 視覚分離の優先度を「コーナーで線同士が刺さらない」 > 「厳密な等距離」と
+   * 割り切った設計。
    *
-   * pixel 計算なので zoom が変わるたびに再計算が必要 → showRoutes は zoomend
-   * で cached args を使って呼び直す (#69 PR-2)。
+   * 端点 (i=0 / i=last) は片側 segment のみで normal を直接使う。退化 segment
+   * (length < epsilon) は normal を null とし、隣接 normal にフォールバック。
+   *
+   * **180° 折り返し** (A→B→A 等で nIn と nOut が anti-parallel、|bisector|≈0):
+   * 折り返し vertex で `nOut` 単独に fallback するため、incoming 側 segment の
+   * offset polyline が元 segment を斜めに横切る視覚アーティファクトが残る。
+   * 厳密に対応するなら vertex 複製 + cap 描画が必要だが、route が同 POI で
+   * 折り返すケースは稀なため許容している (#69 round 1 medium 認知済み)。
+   *
+   * pixel 計算なので zoom 変化で再計算が必要 → showRoutes は zoomend で cached
+   * args を使って呼び直す (#69 PR-2)。
    *
    * @param {Array<L.LatLng>} latlngs - 入力経路 (raw)
-   * @param {number} offsetPx - 正負で offset 方向、0 なら no-op で同じ参照
+   * @param {number} offsetPx - 正負で canonical 法線に対する offset 方向、0 なら no-op
    * @returns {Array<L.LatLng>}
    */
   _offsetLatLngs(latlngs, offsetPx) {
@@ -446,11 +472,15 @@ class MapViewer {
     const epsilon = 1e-3;
     const segNormals = [];
     for (let i = 0; i < points.length - 1; i++) {
-      const dx = points[i + 1].x - points[i].x;
-      const dy = points[i + 1].y - points[i].y;
+      const a = points[i];
+      const b = points[i + 1];
+      // canonical direction: 端点を (x, y) lex 順で並べた最小 → 最大。
+      // A→B route と B→A route の両方で同じ法線方向になるための鍵。
+      const aFirst = a.x < b.x || (a.x === b.x && a.y < b.y);
+      const dx = aFirst ? b.x - a.x : a.x - b.x;
+      const dy = aFirst ? b.y - a.y : a.y - b.y;
       const len = Math.hypot(dx, dy);
-      // 90° clockwise rotation: (dx, dy) → (dy, -dx) (Leaflet container y は下向きで
-      // CRS と揃うため、画面上で「進行方向の右側」を正と扱う)
+      // canonical 方向の 90° 時計回り回転 = (dy, -dx) / len。
       segNormals.push(len < epsilon ? null : { x: dy / len, y: -dx / len });
     }
     const maxOffset = 4 * Math.abs(offsetPx);
@@ -462,7 +492,7 @@ class MapViewer {
         const by = nIn.y + nOut.y;
         const bLen = Math.hypot(bx, by);
         if (bLen < epsilon) {
-          // nIn と nOut が anti-parallel (180° turn): nOut 方向を使う
+          // 180° 折り返し: nOut 単独で offset (incoming 側の精度は犠牲、上記 doc 参照)
           return { x: p.x + nOut.x * offsetPx, y: p.y + nOut.y * offsetPx };
         }
         let factor = (2 * offsetPx) / (bLen * bLen);
@@ -489,10 +519,18 @@ class MapViewer {
     this.clearRoutes();
     if (!this.metadata || !routes || !pois) return;
 
-    // zoomend で再描画するため最後の引数を保持。配列/Set は呼び出し側 (app.js) が
-    // showRoutes 後に in-place 変更しない前提で参照を保持する (現状そう運用、変更時は
-    // copy を取る方針に切り替える)。
-    this._cachedRoutesArgs = { routes, pois, visibleNames };
+    // zoomend で再描画するため最後の引数を保持。
+    // - visibleNames: 軽量なので `new Set` で snapshot し、呼び出し側の Set 変更が
+    //   redraw に漏れない (#69 round 1 low 対応)。
+    // - routes / pois: 配列が大きくなり得る (POI 多数) ため deep copy しない。代わりに
+    //   呼び出し側 (app.js) は showRoutes 後に in-place mutation しない前提を取る。
+    //   in-place 更新ではなく新配列で再 showRoutes する運用 (現状そう)。仕様変更で
+    //   in-place mutation が出てきた場合は、ここを snapshot に切り替える。
+    this._cachedRoutesArgs = {
+      routes,
+      pois,
+      visibleNames: visibleNames ? new Set(visibleNames) : null,
+    };
 
     // Build name -> poi lookup
     const poiByName = {};

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -58,6 +58,21 @@ class MapViewer {
     this.map.on('zoomend', () => {
       if (this._lastRobotPose) this.updateRobotMarker(this._lastRobotPose);
     });
+
+    // route polyline は parallel offset を pixel 単位で計算するため、zoom 変化で
+    // 各 vertex の世界座標が同じでも画面表示用 displayLatlngs の位置が変わる
+    // (#69 PR-2)。最後の showRoutes 引数を保持して再描画する。再描画後は
+    // _activeRouteIdx に基づいて highlight も再適用する (clearRoutes は active
+    // index を保持するので、新規 _routePolylines に対して再 paint すれば良い)。
+    this.map.on('zoomend', () => {
+      if (!this._cachedRoutesArgs) return;
+      const prevActive = this._activeRouteIdx;
+      const { routes, pois, visibleNames } = this._cachedRoutesArgs;
+      this.showRoutes(routes, pois, visibleNames);
+      if (prevActive >= 0) {
+        this.highlightRoute(prevActive);
+      }
+    });
   }
 
   /**
@@ -103,10 +118,13 @@ class MapViewer {
     // 直後の fitBounds() で zoomend hook が走るため、旧 map の latlng 基準で
     // updateRobotMarker / _updateRobotConnector が実行されると、新 map 側で
     // 誤座標描画 + 旧 signature の sticky 引継ぎが起こる (Codex PR #118 round 1
-    // medium)。
+    // medium)。同様に _cachedRoutesArgs に旧 map の pois が残っていると、
+    // fitBounds → zoomend → showRoutes (旧 pois) で stale 描画 (#69 PR-2)。
+    // app.js が新 map の pois で showRoutes を呼び直すまで何も描かないよう null 化。
     this._lastRobotPose = null;
     this._reachedRouteSignatures.clear();
     this._activeRouteIdx = -1;
+    this._cachedRoutesArgs = null;
     if (this.robotMarker) {
       this.map.removeLayer(this.robotMarker);
       this.robotMarker = null;
@@ -403,6 +421,65 @@ class MapViewer {
   }
 
   /**
+   * Offset a polyline by `offsetPx` pixels perpendicular to its tangent
+   * direction (positive offsetPx = right side of motion, i.e. 90° clockwise rotation).
+   *
+   * 各 vertex で前後セグメントの perpendicular 単位ベクトル (nIn / nOut) の
+   * 和 (= bisector) を計算し、`bisector × (2*offsetPx / |bisector|^2)` で
+   * 並べる。これにより各 segment との perpendicular 距離が `offsetPx` になる。
+   * 鋭角コーナーで blowup しないよう offset 距離を `4*|offsetPx|` でキャップ。
+   *
+   * 端点 (i=0 / i=last) は片側 segment のみで normal を直接使う。退化セグメント
+   * (length < epsilon) があるとその vertex の normal は無視し、有効な隣の
+   * normal にフォールバック。両側無効なら offset 0 で原点維持。
+   *
+   * pixel 計算なので zoom が変わるたびに再計算が必要 → showRoutes は zoomend
+   * で cached args を使って呼び直す (#69 PR-2)。
+   *
+   * @param {Array<L.LatLng>} latlngs - 入力経路 (raw)
+   * @param {number} offsetPx - 正負で offset 方向、0 なら no-op で同じ参照
+   * @returns {Array<L.LatLng>}
+   */
+  _offsetLatLngs(latlngs, offsetPx) {
+    if (!latlngs || latlngs.length < 2 || offsetPx === 0) return latlngs;
+    const points = latlngs.map((ll) => this.map.latLngToContainerPoint(ll));
+    const epsilon = 1e-3;
+    const segNormals = [];
+    for (let i = 0; i < points.length - 1; i++) {
+      const dx = points[i + 1].x - points[i].x;
+      const dy = points[i + 1].y - points[i].y;
+      const len = Math.hypot(dx, dy);
+      // 90° clockwise rotation: (dx, dy) → (dy, -dx) (Leaflet container y は下向きで
+      // CRS と揃うため、画面上で「進行方向の右側」を正と扱う)
+      segNormals.push(len < epsilon ? null : { x: dy / len, y: -dx / len });
+    }
+    const maxOffset = 4 * Math.abs(offsetPx);
+    const offsetPoints = points.map((p, i) => {
+      const nIn = i > 0 ? segNormals[i - 1] : null;
+      const nOut = i < points.length - 1 ? segNormals[i] : null;
+      if (nIn && nOut) {
+        const bx = nIn.x + nOut.x;
+        const by = nIn.y + nOut.y;
+        const bLen = Math.hypot(bx, by);
+        if (bLen < epsilon) {
+          // nIn と nOut が anti-parallel (180° turn): nOut 方向を使う
+          return { x: p.x + nOut.x * offsetPx, y: p.y + nOut.y * offsetPx };
+        }
+        let factor = (2 * offsetPx) / (bLen * bLen);
+        const offMag = Math.abs(factor) * bLen;
+        if (offMag > maxOffset) {
+          factor *= maxOffset / offMag;
+        }
+        return { x: p.x + bx * factor, y: p.y + by * factor };
+      }
+      const single = nIn || nOut;
+      if (!single) return { x: p.x, y: p.y }; // 完全退化
+      return { x: p.x + single.x * offsetPx, y: p.y + single.y * offsetPx };
+    });
+    return offsetPoints.map((pt) => this.map.containerPointToLatLng(L.point(pt.x, pt.y)));
+  }
+
+  /**
    * Display routes on the map as polylines with waypoint order labels.
    * @param {Array} routes - [{name, waypoints: [poiName, ...]}, ...]
    * @param {Array} pois - POI array to resolve waypoint names to coordinates
@@ -412,37 +489,52 @@ class MapViewer {
     this.clearRoutes();
     if (!this.metadata || !routes || !pois) return;
 
+    // zoomend で再描画するため最後の引数を保持。配列/Set は呼び出し側 (app.js) が
+    // showRoutes 後に in-place 変更しない前提で参照を保持する (現状そう運用、変更時は
+    // copy を取る方針に切り替える)。
+    this._cachedRoutesArgs = { routes, pois, visibleNames };
+
     // Build name -> poi lookup
     const poiByName = {};
     pois.forEach((poi) => {
       if (poi.name) poiByName[poi.name] = poi;
     });
 
+    // 共通区間で polyline が完全重複する視認性問題への (b) parallel offset 対策 (#69 PR-2)。
+    // 表示対象 route 数を先に数えて、各 route に中心揃えの offset index を付与する。
+    // 例: 表示中 3 route → offset index は -1, 0, +1 → offsetPx は -STEP, 0, +STEP。
+    // route 数 1 のみだと offset 0 で _offsetLatLngs は no-op、原点描画と完全一致。
+    const visibleEntries = [];
     routes.forEach((route, routeIdx) => {
-      // Filter by visible set
       if (visibleNames && !visibleNames.has(route.name)) return;
+      visibleEntries.push({ route, routeIdx });
+    });
+    const totalVisible = visibleEntries.length;
+    const OFFSET_STEP_PX = 6;
 
+    visibleEntries.forEach(({ route, routeIdx }, visibleIdx) => {
+      const offsetPx = (visibleIdx - (totalVisible - 1) / 2) * OFFSET_STEP_PX;
       const color = this.getRouteColor(routeIdx);
       const waypoints = route.waypoints || [];
 
-      // Resolve waypoint names to LatLng positions
-      const latlngs = [];
-      const resolved = []; // { latlng, order }
+      // Resolve waypoint names to LatLng positions (raw, POI 物理座標)
+      const rawLatlngs = [];
       let firstWaypointName = '';
-      waypoints.forEach((wpName, i) => {
+      waypoints.forEach((wpName) => {
         const poi = poiByName[wpName];
         if (poi && poi.pose) {
-          const ll = this.worldToLatLng(poi.pose.x, poi.pose.y);
-          latlngs.push(ll);
-          resolved.push({ latlng: ll, order: i + 1 });
+          rawLatlngs.push(this.worldToLatLng(poi.pose.x, poi.pose.y));
           if (!firstWaypointName) firstWaypointName = wpName;
         }
       });
 
-      if (latlngs.length < 2) return;
+      if (rawLatlngs.length < 2) return;
+
+      // 表示用に offset を適用 (offsetPx === 0 なら同じ配列参照が返る)
+      const displayLatlngs = this._offsetLatLngs(rawLatlngs, offsetPx);
 
       // Draw polyline (dashed)
-      const line = L.polyline(latlngs, {
+      const line = L.polyline(displayLatlngs, {
         color: color,
         weight: 3,
         opacity: 0.7,
@@ -459,7 +551,7 @@ class MapViewer {
       this.routeLayers.push(line);
 
       // Invisible wider hit area for easier clicking
-      const hitLine = L.polyline(latlngs, {
+      const hitLine = L.polyline(displayLatlngs, {
         color: '#000',
         weight: 16,
         opacity: 0,
@@ -477,10 +569,10 @@ class MapViewer {
       const arrowMarkers = [];
       const labelMarkers = [];
 
-      // Draw teardrop direction markers along segments
-      for (let i = 0; i < latlngs.length - 1; i++) {
-        const from = latlngs[i];
-        const to = latlngs[i + 1];
+      // Draw teardrop direction markers along segments (offset 後の座標で配置)
+      for (let i = 0; i < displayLatlngs.length - 1; i++) {
+        const from = displayLatlngs[i];
+        const to = displayLatlngs[i + 1];
         const midLat = (from.lat + to.lat) / 2;
         const midLng = (from.lng + to.lng) / 2;
         const rotDeg = this.routeDirectionDeg(from, to);
@@ -499,11 +591,11 @@ class MapViewer {
         arrowMarkers.push(arrowMarker);
       }
 
-      // Draw order labels at each waypoint
-      resolved.forEach(({ latlng, order }) => {
+      // Draw order labels at each waypoint (offset 後位置でラベル重なりも軽減)
+      displayLatlngs.forEach((latlng, i) => {
         const icon = L.divIcon({
           className: 'route-order-label',
-          html: `<span style="background: ${color};">${order}</span>`,
+          html: `<span style="background: ${color};">${i + 1}</span>`,
           iconSize: [22, 22],
           iconAnchor: [-6, 28],
         });
@@ -518,7 +610,12 @@ class MapViewer {
       this._routePolylines.push({
         line, hitLine, arrowMarkers, labelMarkers,
         routeIdx, routeName: route.name || '', firstWaypointName,
-        color, latlngs,
+        color,
+        // latlngs: raw (POI 物理座標)。robot connector の到達判定など物理距離を
+        //   評価する用途で使う
+        // displayLatlngs: offset 後 (画面表示用)。connector の視覚端点や zoom
+        //   再描画時の再計算で使う
+        latlngs: rawLatlngs, displayLatlngs,
       });
     });
   }
@@ -532,6 +629,12 @@ class MapViewer {
     });
     this.routeLayers = [];
     this._routePolylines = [];
+    // cached args は次回 showRoutes で上書きされるので残しても害は無いが、
+    // route データが本当に空 (cleared) のとき zoom した瞬間に古い args で
+    // 再描画されないよう、clearRoutes が「外から明示的に空にされた」ケースで
+    // 初期化することにした。showRoutes 内部から clearRoutes を呼ぶ場合は直後に
+    // _cachedRoutesArgs が再設定されるので race にはならない。
+    this._cachedRoutesArgs = null;
     this.clearEditingRoutePreview();
     this._clearRobotConnector();
     // 到達履歴 (_reachedRouteSignatures) は clearRoutes では reset しない。
@@ -836,10 +939,17 @@ class MapViewer {
     const robotLatLng = this.worldToLatLng(
       this._lastRobotPose.x, this._lastRobotPose.y,
     );
-    const firstLatLng = item.latlngs[0];
+    // 視覚端点は offset 後 (displayLatlngs) を使い、parallel offset で動いた
+    // polyline 始点に矢印が刺さるようにする (#69 PR-2)。displayLatlngs が無い
+    // 古い entry / no-offset 時は latlngs にフォールバック。
+    const firstLatLngVisual = (item.displayLatlngs && item.displayLatlngs[0])
+      || item.latlngs[0];
 
     // 先頭 POI に到達済みなら Set に登録して以降描かない。
-    const firstWorld = this.latLngToWorld(firstLatLng);
+    // 到達判定は offset で動かない物理座標 (latlngs[0] = POI 実位置) で評価する
+    // (offset 後位置で判定すると同じ POI に到達しているのに route ごとに到達タイ
+    //  ミングがずれる)。
+    const firstWorld = this.latLngToWorld(item.latlngs[0]);
     const dx = this._lastRobotPose.x - firstWorld.x;
     const dy = this._lastRobotPose.y - firstWorld.y;
     if (Math.hypot(dx, dy) < this.robotRadiusM) {
@@ -849,7 +959,7 @@ class MapViewer {
       return;
     }
 
-    const line = L.polyline([robotLatLng, firstLatLng], {
+    const line = L.polyline([robotLatLng, firstLatLngVisual], {
       color: item.color,
       weight: 3,
       opacity: 0.8,
@@ -859,9 +969,9 @@ class MapViewer {
     line.bringToBack();
     this._robotConnectorLayers.push(line);
 
-    const midLat = (robotLatLng.lat + firstLatLng.lat) / 2;
-    const midLng = (robotLatLng.lng + firstLatLng.lng) / 2;
-    const rotDeg = this.routeDirectionDeg(robotLatLng, firstLatLng);
+    const midLat = (robotLatLng.lat + firstLatLngVisual.lat) / 2;
+    const midLng = (robotLatLng.lng + firstLatLngVisual.lng) / 2;
+    const rotDeg = this.routeDirectionDeg(robotLatLng, firstLatLngVisual);
     const arrowIcon = L.divIcon({
       className: 'route-arrow',
       html: this.createRouteDirectionSvg(item.color, rotDeg, 18),

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -493,7 +493,9 @@ class MapViewer {
         const by = nIn.y + nOut.y;
         const bLen = Math.hypot(bx, by);
         if (bLen < epsilon) {
-          // 180° 折り返し: nOut 単独で offset (incoming 側の精度は犠牲、上記 doc 参照)
+          // anti-parallel fallback: canonical normal 化後では通常到達しない
+          // (上段 JSDoc 参照)。数値誤差や将来の normal 計算仕様変更に対する保険
+          // として nOut 単独で offset するに留める。
           return { x: p.x + nOut.x * offsetPx, y: p.y + nOut.y * offsetPx };
         }
         let factor = (2 * offsetPx) / (bLen * bLen);


### PR DESCRIPTION
## Summary

#69 の採用案 (b) parallel offset を実装。前段 PR #105 の (d) active highlight と組み合わせ、複数 route が同 POI を経由した時の視覚的識別を確保する。

- `_offsetLatLngs` helper を追加。各 vertex で前後 segment 法線の bisector を使い perpendicular 距離 `offsetPx` を維持
- `showRoutes` は表示中 route 数を先に数え、中心揃え offset index (`-N/2 〜 +N/2`) を付与。`OFFSET_STEP_PX=6`
- `_routePolylines` に `displayLatlngs` (offset 後) を追加し `latlngs` (POI 物理座標) と分離
- `zoomend` で `_cachedRoutesArgs` 経由 redraw、pixel offset を zoom-aware に再計算

Close #69

## 設計詳細

### offset 計算 (_offsetLatLngs)

各 vertex \`i\` で前後 segment の perpendicular 単位ベクトル \`nIn\`, \`nOut\` を計算 (Leaflet container point 上で 90° 時計回り回転)。\`bisector = nIn + nOut\` と置き、最終 offset を \`bisector × (2*offsetPx / |bisector|^2)\` で算出。これにより各 segment との perpendicular 距離が \`offsetPx\` になる。

- **鋭角コーナー対策**: \`|bisector|\` が小さい (≈0) と factor が blowup するため offset 距離を \`4*|offsetPx|\` でキャップ
- **180° 折り返し** (\`|bisector|≈0\`): \`nOut\` 単独で offset
- **退化セグメント** (length≈0): segNormal を null とし、隣接 normal にフォールバック

### connector の物理 / 視覚分離

- 視覚端点: \`displayLatlngs[0]\` (offset 後の polyline 始点へ矢印が刺さる)
- 到達判定: \`latLngToWorld(latlngs[0])\` (POI 実位置で評価、offset で route ごとに到達タイミングがずれない)

### zoomend redraw

pixel-based offset は zoom 変化で位置が動くため、\`_cachedRoutesArgs\` を保持し \`zoomend\` で \`showRoutes\` を呼び直す。直後に \`prevActive\` を \`highlightRoute\` で再適用 (再描画で style が default に戻るため)。

map 切替 (\`loadMap\`) では旧 pois の stale 描画を防ぐため \`_cachedRoutesArgs = null\` で無効化、app.js が新 pois で \`showRoutes\` を呼ぶまで何も描かない。

## Test plan

- [x] node --check で JS syntax 通過
- [x] (実機 / sim) 同 POI を経由する 2 route で polyline が並行に並んで識別可能
- [x] zoom in/out で offset が再計算され、解像度に応じた pixel 距離を維持
- [x] active route の highlight (PR #105) が parallel offset と両立 (太線 + 不透明、他 dim)
- [ ] connector が active route の offset 後始点に正しく刺さる、到達判定は POI 実位置で発火
- [ ] map 切替直後に zoomend が発火しても旧 pois で stale route が描画されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)