### PR TITLE
feat(webui): vitest 単体テスト基盤と geometry pure helper の切り出し (#129)

### DIFF
--- a/.github/workflows/consistency-check.yml
+++ b/.github/workflows/consistency-check.yml
@@ -24,3 +24,22 @@ jobs:
 
       - name: Check robot_radius drift between WebUI launch and Nav2 yaml
         run: python3 scripts/check_robot_radius_drift.py
+
+  webui_js_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: mapoi_webui/tests/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: mapoi_webui/tests/web
+
+      - name: Run vitest
+        run: npm test
+        working-directory: mapoi_webui/tests/web

--- a/mapoi_webui/tests/web/.gitignore
+++ b/mapoi_webui/tests/web/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/mapoi_webui/tests/web/geometry.test.js
+++ b/mapoi_webui/tests/web/geometry.test.js
@@ -103,16 +103,23 @@ describe('offsetPointsPx', () => {
   });
 
   it('caps the offset magnitude at 4 * |offsetPx| for sharp corners', () => {
-    // 鋭角な V 字: (0,0) → (10, 0.01) → (0, 0.02)
-    // 入射と射出の角度が極端に近い → bisector が短くなり factor が blow up
-    const pts = [{ x: 0, y: 0 }, { x: 10, y: 0.01 }, { x: 0, y: 0.02 }];
+    // canonical 法線が大きく異なる入力で bisector を短くする V 字: 縦長の山
+    // (0,0) → (1,1000) → (2,0)。
+    // canonical seg0: (0,0)→(1,1000) で normal ≈ (1, -1e-3)
+    // canonical seg1: (1,1000)→(2,0)   で normal ≈ (-1, -1e-3) (canonical は lex order で
+    //   (1,1000) → (2,0)、direction (1,-1000)/|·| → normal (-1000,-1)/|·| ≈ (-1, -1e-3))
+    // bisector ≈ (0, -2e-3) → bLen ≈ 2e-3、uncapped factor = 2*offsetPx/bLen² ≈ 1.5e6
+    // → uncapped offset 距離は ~3000、これを 4*|offsetPx|=12 にキャップする branch が走る。
+    const pts = [{ x: 0, y: 0 }, { x: 1, y: 1000 }, { x: 2, y: 0 }];
     const offsetPx = 3;
     const out = offsetPointsPx(pts, offsetPx);
-    // corner vertex (i=1) の offset 距離 (元 vertex からの距離) が cap 内に収まる
     const dx = out[1].x - pts[1].x;
     const dy = out[1].y - pts[1].y;
     const cornerOffset = Math.hypot(dx, dy);
-    expect(cornerOffset).toBeLessThanOrEqual(4 * Math.abs(offsetPx) + 1e-6);
+    const cap = 4 * Math.abs(offsetPx);
+    // cap が無いと ~3000 になる。cap=12 に張り付く (epsilon は数値誤差用)
+    expect(cornerOffset).toBeLessThanOrEqual(cap + 1e-6);
+    expect(cornerOffset).toBeGreaterThan(cap - 1e-6);
   });
 
   it('falls back to neighbor normal when a segment is degenerate', () => {
@@ -138,6 +145,32 @@ describe('offsetPointsPx', () => {
     out.forEach((p) => {
       expect(nearlyEqual(p.x, 1)).toBe(true);
       expect(nearlyEqual(p.y, 1)).toBe(true);
+    });
+  });
+
+  it('treats segments shorter than epsilon (1e-3) as degenerate, not above', () => {
+    // epsilon = 1e-3 は内部 const。境界条件を仕様として固定する。
+    //
+    // (a) 1e-4 の超短い segment を中央に挟む: (0,0) → (5,0) → (5+1e-4, 0) → (10,0)
+    //   pts[1]→pts[2] は length=1e-4 で degenerate 扱いになるため、中央 vertex の
+    //   normal は隣接 (有効) normal にフォールバックして、全体は直線として offset
+    //   される (前後の segment はどちらも y=0 軸の水平線で同じ canonical normal)。
+    const ptsDegen = [
+      { x: 0, y: 0 }, { x: 5, y: 0 }, { x: 5 + 1e-4, y: 0 }, { x: 10, y: 0 },
+    ];
+    const outDegen = offsetPointsPx(ptsDegen, 4);
+    outDegen.forEach((p) => {
+      expect(nearlyEqual(p.y, -4, 1e-3)).toBe(true);
+    });
+
+    // (b) 1e-2 の segment は通常の normal として扱われる (epsilon = 1e-3 を超える)。
+    //   3 vertex が collinear 水平 → 直線扱いで offset。
+    const ptsAbove = [
+      { x: 0, y: 0 }, { x: 5, y: 0 }, { x: 5 + 1e-2, y: 0 }, { x: 10, y: 0 },
+    ];
+    const outAbove = offsetPointsPx(ptsAbove, 4);
+    outAbove.forEach((p) => {
+      expect(nearlyEqual(p.y, -4, 1e-3)).toBe(true);
     });
   });
 

--- a/mapoi_webui/tests/web/geometry.test.js
+++ b/mapoi_webui/tests/web/geometry.test.js
@@ -149,29 +149,44 @@ describe('offsetPointsPx', () => {
   });
 
   it('treats segments shorter than epsilon (1e-3) as degenerate, not above', () => {
-    // epsilon = 1e-3 は内部 const。境界条件を仕様として固定する。
+    // epsilon = 1e-3 は内部 const。境界条件を仕様として固定するために、短い
+    // segment が **非共線 (kink)** な配置で、degenerate 扱いか normal 計算かで
+    // 出力位置が観測できる差になるよう設計する (Codex round 2 low 対応)。
     //
-    // (a) 1e-4 の超短い segment を中央に挟む: (0,0) → (5,0) → (5+1e-4, 0) → (10,0)
-    //   pts[1]→pts[2] は length=1e-4 で degenerate 扱いになるため、中央 vertex の
-    //   normal は隣接 (有効) normal にフォールバックして、全体は直線として offset
-    //   される (前後の segment はどちらも y=0 軸の水平線で同じ canonical normal)。
-    const ptsDegen = [
-      { x: 0, y: 0 }, { x: 5, y: 0 }, { x: 5 + 1e-4, y: 0 }, { x: 10, y: 0 },
-    ];
-    const outDegen = offsetPointsPx(ptsDegen, 4);
-    outDegen.forEach((p) => {
-      expect(nearlyEqual(p.y, -4, 1e-3)).toBe(true);
-    });
+    // 共通形状: 水平 → 短い垂直 → 水平 (L 字の小さい段差)。
+    //
+    // (a) 1e-4 の vertical segment: epsilon 未満で **degenerate**。中央 vertex は
+    //   隣接 (水平 segment、normal=(0,-1)) にフォールバックする。
+    //   水平 segment が両側で支配的なため offset 後 x は不変、y のみ offsetPx 分シフト。
+    {
+      const offsetPx = 4;
+      const pts = [
+        { x: 0, y: 0 }, { x: 5, y: 0 }, { x: 5, y: 1e-4 }, { x: 10, y: 1e-4 },
+      ];
+      const out = offsetPointsPx(pts, offsetPx);
+      // 全 vertex が x 不変、y は元値 - offsetPx
+      expect(nearlyEqual(out[1].x, 5)).toBe(true);
+      expect(nearlyEqual(out[1].y, -4)).toBe(true);
+      expect(nearlyEqual(out[2].x, 5)).toBe(true);
+      expect(nearlyEqual(out[2].y, 1e-4 - 4)).toBe(true);
+    }
 
-    // (b) 1e-2 の segment は通常の normal として扱われる (epsilon = 1e-3 を超える)。
-    //   3 vertex が collinear 水平 → 直線扱いで offset。
-    const ptsAbove = [
-      { x: 0, y: 0 }, { x: 5, y: 0 }, { x: 5 + 1e-2, y: 0 }, { x: 10, y: 0 },
-    ];
-    const outAbove = offsetPointsPx(ptsAbove, 4);
-    outAbove.forEach((p) => {
-      expect(nearlyEqual(p.y, -4, 1e-3)).toBe(true);
-    });
+    // (b) 1e-2 の vertical segment: epsilon 超で **通常 normal**。中央 vertex は
+    //   nIn=(0,-1) (水平) + nOut=(1,0) (垂直、canonical 方向 lex order で y 増加方向)
+    //   の bisector を使う → factor=2*offsetPx/bLen²=2*4/2=4、offset=(4,-4)。
+    //   結果として x が +4 動く ((a) と観測可能な差になる)。
+    {
+      const offsetPx = 4;
+      const pts = [
+        { x: 0, y: 0 }, { x: 5, y: 0 }, { x: 5, y: 1e-2 }, { x: 10, y: 1e-2 },
+      ];
+      const out = offsetPointsPx(pts, offsetPx);
+      // vertex 1, 2 とも x が +4 動く (degenerate 扱いなら x は変わらないはず)
+      expect(nearlyEqual(out[1].x, 9, 1e-3)).toBe(true);
+      expect(nearlyEqual(out[1].y, -4, 1e-3)).toBe(true);
+      expect(nearlyEqual(out[2].x, 9, 1e-3)).toBe(true);
+      expect(nearlyEqual(out[2].y, 1e-2 - 4, 1e-3)).toBe(true);
+    }
   });
 
   it('handles vertical segment (lex tie on x, ordered by y)', () => {

--- a/mapoi_webui/tests/web/geometry.test.js
+++ b/mapoi_webui/tests/web/geometry.test.js
@@ -1,0 +1,155 @@
+// vitest unit tests for the pure geometry helpers in
+// mapoi_webui/web/js/geometry.js (#129).
+//
+// 対象: MapoiGeometry.offsetPointsPx (parallel-offset polyline in pixel space)
+//
+// テスト方針:
+// - ロジックの幾何的不変条件 (perpendicular 距離、canonical 法線、cap、退化、
+//   no-op) を確認することで、map-viewer.js の `_offsetLatLngs` が将来 regress
+//   しても CI で検出できるようにする。
+// - Leaflet / DOM / window への依存はゼロで pure JS のみ。
+
+import { describe, it, expect } from 'vitest';
+import * as geom from '../../web/js/geometry.js';
+
+const { offsetPointsPx } = geom;
+
+const EPS = 1e-9;
+
+function nearlyEqual(a, b, tol = 1e-6) {
+  return Math.abs(a - b) < tol;
+}
+
+function distancePointToLine(p, a, b) {
+  // |(b-a) x (a-p)| / |b-a|
+  const ax = a.x;
+  const ay = a.y;
+  const bx = b.x;
+  const by = b.y;
+  const numer = Math.abs((bx - ax) * (ay - p.y) - (ax - p.x) * (by - ay));
+  const denom = Math.hypot(bx - ax, by - ay);
+  if (denom < EPS) return Number.NaN;
+  return numer / denom;
+}
+
+describe('offsetPointsPx', () => {
+  it('returns the same reference when offsetPx === 0 (no-op)', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 0 }];
+    expect(offsetPointsPx(pts, 0)).toBe(pts);
+  });
+
+  it('returns the same reference for fewer than 2 points', () => {
+    const empty = [];
+    expect(offsetPointsPx(empty, 5)).toBe(empty);
+    const single = [{ x: 1, y: 1 }];
+    expect(offsetPointsPx(single, 5)).toBe(single);
+  });
+
+  it('returns the same reference for null / undefined input', () => {
+    expect(offsetPointsPx(null, 5)).toBeNull();
+    expect(offsetPointsPx(undefined, 5)).toBeUndefined();
+  });
+
+  it('produces perpendicular distance offsetPx for a horizontal segment', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 0 }];
+    const out = offsetPointsPx(pts, 5);
+    expect(out).toHaveLength(2);
+    // canonical direction: (0,0) → (10,0) (lex order先頭は (0,0))。
+    // 90° CW rotation = (0, -1) なので offsetPx=+5 で y が -5 に動く。
+    expect(nearlyEqual(out[0].x, 0)).toBe(true);
+    expect(nearlyEqual(out[0].y, -5)).toBe(true);
+    expect(nearlyEqual(out[1].x, 10)).toBe(true);
+    expect(nearlyEqual(out[1].y, -5)).toBe(true);
+  });
+
+  it('reverses offset direction for negative offsetPx', () => {
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 0 }];
+    const out = offsetPointsPx(pts, -5);
+    expect(nearlyEqual(out[0].y, 5)).toBe(true);
+    expect(nearlyEqual(out[1].y, 5)).toBe(true);
+  });
+
+  it('uses canonical (lex-order) normal so reversed routes share the same offset axis', () => {
+    // A→B route と B→A route で同じ offsetPx を渡したとき、両者は同じ方向に offset される
+    // (canonical 法線が同じため)。これにより呼び出し側 (showRoutes) が offsetPx の符号で
+    // 分けるだけで両 route が反対側に並行配置される。
+    const forward = [{ x: 0, y: 0 }, { x: 10, y: 0 }];
+    const reverse = [{ x: 10, y: 0 }, { x: 0, y: 0 }];
+    const forwardOut = offsetPointsPx(forward, 5);
+    const reverseOut = offsetPointsPx(reverse, 5);
+    // 両者の y はどちらも -5 (canonical normal が同じ)
+    expect(nearlyEqual(forwardOut[0].y, -5)).toBe(true);
+    expect(nearlyEqual(forwardOut[1].y, -5)).toBe(true);
+    expect(nearlyEqual(reverseOut[0].y, -5)).toBe(true);
+    expect(nearlyEqual(reverseOut[1].y, -5)).toBe(true);
+    // 逆向き route 側の符号を反転すると反対側に配置される
+    const reverseOpp = offsetPointsPx(reverse, -5);
+    expect(nearlyEqual(reverseOpp[0].y, 5)).toBe(true);
+    expect(nearlyEqual(reverseOpp[1].y, 5)).toBe(true);
+  });
+
+  it('keeps perpendicular distance offsetPx from each segment at 90° corners', () => {
+    // L 字: (0,0) → (10,0) → (10,10)
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }];
+    const offsetPx = 5;
+    const out = offsetPointsPx(pts, offsetPx);
+    // 端点 0 (segment 0 のみ): perpendicular 距離が segment(pts[0]→pts[1]) で offsetPx
+    expect(nearlyEqual(distancePointToLine(out[0], pts[0], pts[1]), offsetPx)).toBe(true);
+    // 端点 2 (segment 1 のみ): perpendicular 距離が segment(pts[1]→pts[2]) で offsetPx
+    expect(nearlyEqual(distancePointToLine(out[2], pts[1], pts[2]), offsetPx)).toBe(true);
+    // 中点 (corner): bisector 計算により両 segment との perpendicular 距離が両方 offsetPx
+    expect(nearlyEqual(distancePointToLine(out[1], pts[0], pts[1]), offsetPx)).toBe(true);
+    expect(nearlyEqual(distancePointToLine(out[1], pts[1], pts[2]), offsetPx)).toBe(true);
+  });
+
+  it('caps the offset magnitude at 4 * |offsetPx| for sharp corners', () => {
+    // 鋭角な V 字: (0,0) → (10, 0.01) → (0, 0.02)
+    // 入射と射出の角度が極端に近い → bisector が短くなり factor が blow up
+    const pts = [{ x: 0, y: 0 }, { x: 10, y: 0.01 }, { x: 0, y: 0.02 }];
+    const offsetPx = 3;
+    const out = offsetPointsPx(pts, offsetPx);
+    // corner vertex (i=1) の offset 距離 (元 vertex からの距離) が cap 内に収まる
+    const dx = out[1].x - pts[1].x;
+    const dy = out[1].y - pts[1].y;
+    const cornerOffset = Math.hypot(dx, dy);
+    expect(cornerOffset).toBeLessThanOrEqual(4 * Math.abs(offsetPx) + 1e-6);
+  });
+
+  it('falls back to neighbor normal when a segment is degenerate', () => {
+    // 退化セグメント (length≈0) を中央に挟む: (0,0) → (5,0) → (5,0) → (10,0)
+    // pts[1]==pts[2] の segment 1 は length≈0 → segNormal[1] = null
+    // 結果として中央 vertex は隣接 normal を使う。全体は直線として offset される。
+    const pts = [
+      { x: 0, y: 0 }, { x: 5, y: 0 }, { x: 5, y: 0 }, { x: 10, y: 0 },
+    ];
+    const out = offsetPointsPx(pts, 4);
+    // 全 vertex が y=-4 (canonical normal (0,-1)) に近いことを確認
+    out.forEach((p) => {
+      expect(nearlyEqual(p.y, -4, 1e-3)).toBe(true);
+    });
+  });
+
+  it('returns input position for fully degenerate segment pair (no valid normal)', () => {
+    // 全ての隣接 segment が degenerate な極端ケース: 同点 3 つ
+    const pts = [{ x: 1, y: 1 }, { x: 1, y: 1 }, { x: 1, y: 1 }];
+    const out = offsetPointsPx(pts, 5);
+    // どの vertex も normal が null → 原点 (元位置) 維持
+    expect(out).toHaveLength(3);
+    out.forEach((p) => {
+      expect(nearlyEqual(p.x, 1)).toBe(true);
+      expect(nearlyEqual(p.y, 1)).toBe(true);
+    });
+  });
+
+  it('handles vertical segment (lex tie on x, ordered by y)', () => {
+    // 同 x の縦線: (5, 0) → (5, 10)
+    // canonical: (5,0) → (5,10) (y で lex 比較)、direction (0, 10)、normal (10, 0)/10 = (1, 0)
+    // offsetPx=+3 で x が +3 に動く
+    const pts = [{ x: 5, y: 0 }, { x: 5, y: 10 }];
+    const out = offsetPointsPx(pts, 3);
+    expect(nearlyEqual(out[0].x, 8)).toBe(true);
+    expect(nearlyEqual(out[0].y, 0)).toBe(true);
+    expect(nearlyEqual(out[1].x, 8)).toBe(true);
+    expect(nearlyEqual(out[1].y, 10)).toBe(true);
+  });
+});

--- a/mapoi_webui/tests/web/package-lock.json
+++ b/mapoi_webui/tests/web/package-lock.json
@@ -1,0 +1,1422 @@
+{
+  "name": "mapoi-webui-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mapoi-webui-tests",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "vitest": "^2.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/mapoi_webui/tests/web/package.json
+++ b/mapoi_webui/tests/web/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mapoi-webui-tests",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Vitest unit tests for mapoi_webui frontend pure helpers (#129).",
+  "license": "MIT",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
+  }
+}

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -189,6 +189,9 @@
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="/js/api.js"></script>
+  <!-- geometry.js は MapoiGeometry を window に attach する pure helper 群。
+       map-viewer.js より前に読み込む必要がある (showRoutes 経由で参照される) -->
+  <script src="/js/geometry.js"></script>
   <script src="/js/map-viewer.js"></script>
   <script src="/js/poi-editor.js"></script>
   <script src="/js/route-editor.js"></script>

--- a/mapoi_webui/web/js/geometry.js
+++ b/mapoi_webui/web/js/geometry.js
@@ -1,0 +1,90 @@
+/**
+ * Pure geometry helpers for mapoi WebUI.
+ *
+ * Browser からは `MapoiGeometry.offsetPointsPx` 等のグローバルとして使い、
+ * Node (vitest) からは `module.exports` 経由で import する dual export 形式。
+ * 依存ゼロの pure 関数で、Leaflet / DOM / window 等を参照しない。
+ *
+ * 単体テスト想定: mapoi_webui/tests/web/ 配下の vitest テストから直接呼び出す。
+ */
+(function () {
+  'use strict';
+
+  /**
+   * Compute parallel-offset polyline in pixel space.
+   *
+   * **Direction-independent (canonical) normal**: 各 segment の 2 端点を lex-order
+   * (x, y 辞書順) で並べ、その方向の 90° 時計回り回転を法線とする。これにより
+   * A→B route と B→A route が同じ segment を共有しても法線方向が一致し、
+   * `offsetPx` を符号付きで分けるだけで両 route が同じ canonical 軸の反対側に
+   * 並行配置される (#69 PR-2)。
+   *
+   * 各 vertex で前後 segment 法線 (nIn / nOut) の和 = bisector を取り、
+   * `bisector × (2*offsetPx / |bisector|^2)` で位置を求める。直線・浅い角度では
+   * perpendicular 距離 `offsetPx` を保つが、鋭角で `|bisector|` が小さくなると
+   * factor が blow up するため offset 距離を `4*|offsetPx|` でキャップ。**キャップ
+   * 域では「`offsetPx` の perpendicular 距離」保証は崩れる**点に注意: 視覚分離の
+   * 優先度を「コーナーで線同士が刺さらない」 > 「厳密な等距離」と割り切った設計。
+   *
+   * 端点 (i=0 / i=last) は片側 segment のみで normal を直接使う。退化 segment
+   * (length < epsilon) は normal を null とし、隣接 normal にフォールバック。
+   *
+   * **anti-parallel fallback** (`bLen < epsilon`): canonical normal 化後では
+   * 通常の vertex で nIn = -nOut になる組み合わせは構築できない (lex-order
+   * canonical 方向は両 segment で一致するため)。fallback コードは degenerate な
+   * 数値誤差や将来の normal 計算仕様変更に対する保険として残す。
+   *
+   * @param {Array<{x: number, y: number}>} points - 入力経路 (pixel 空間)
+   * @param {number} offsetPx - 正負で canonical 法線に対する offset 方向、
+   *                            0 なら no-op で同じ参照を返す
+   * @returns {Array<{x: number, y: number}>}
+   */
+  function offsetPointsPx(points, offsetPx) {
+    if (!points || points.length < 2 || offsetPx === 0) return points;
+    const epsilon = 1e-3;
+    const segNormals = [];
+    for (let i = 0; i < points.length - 1; i++) {
+      const a = points[i];
+      const b = points[i + 1];
+      const aFirst = a.x < b.x || (a.x === b.x && a.y < b.y);
+      const dx = aFirst ? b.x - a.x : a.x - b.x;
+      const dy = aFirst ? b.y - a.y : a.y - b.y;
+      const len = Math.hypot(dx, dy);
+      // canonical 方向の 90° 時計回り回転 = (dy, -dx) / len
+      segNormals.push(len < epsilon ? null : { x: dy / len, y: -dx / len });
+    }
+    const maxOffset = 4 * Math.abs(offsetPx);
+    return points.map((p, i) => {
+      const nIn = i > 0 ? segNormals[i - 1] : null;
+      const nOut = i < points.length - 1 ? segNormals[i] : null;
+      if (nIn && nOut) {
+        const bx = nIn.x + nOut.x;
+        const by = nIn.y + nOut.y;
+        const bLen = Math.hypot(bx, by);
+        if (bLen < epsilon) {
+          // anti-parallel fallback (canonical normal 化後では通常到達しない)
+          return { x: p.x + nOut.x * offsetPx, y: p.y + nOut.y * offsetPx };
+        }
+        let factor = (2 * offsetPx) / (bLen * bLen);
+        const offMag = Math.abs(factor) * bLen;
+        if (offMag > maxOffset) {
+          factor *= maxOffset / offMag;
+        }
+        return { x: p.x + bx * factor, y: p.y + by * factor };
+      }
+      const single = nIn || nOut;
+      if (!single) return { x: p.x, y: p.y }; // 完全退化
+      return { x: p.x + single.x * offsetPx, y: p.y + single.y * offsetPx };
+    });
+  }
+
+  const api = { offsetPointsPx };
+
+  if (typeof window !== 'undefined') {
+    window.MapoiGeometry = window.MapoiGeometry || {};
+    Object.assign(window.MapoiGeometry, api);
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+}());

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -435,30 +435,11 @@ class MapViewer {
   /**
    * Offset a polyline by `offsetPx` pixels perpendicular to each segment.
    *
-   * **Direction-independent (canonical) normal**: 各 segment の 2 端点を
-   * lex-order (x, y 辞書順) で並べ、その方向の 90° 時計回り回転を法線とする。
-   * これにより A→B route と B→A route が同じ segment を共有しても法線方向が
-   * 一致し、`offsetPx` を符号付きで分けるだけで両 route が同じ canonical 軸の
-   * 反対側に並行配置される (#69 PR-2 round 1 medium 対応、Codex review)。
-   *
-   * 各 vertex で前後 segment 法線 (nIn / nOut) の和 = bisector を取り、
-   * `bisector × (2*offsetPx / |bisector|^2)` で位置を求める。直線・浅い角度で
-   * は perpendicular 距離 `offsetPx` を保つが、鋭角で `|bisector|` が小さく
-   * なると factor が blow up するため offset 距離を `4*|offsetPx|` でキャップ。
-   * **キャップ域では「`offsetPx` の perpendicular 距離」保証は崩れる**点に注意:
-   * 視覚分離の優先度を「コーナーで線同士が刺さらない」 > 「厳密な等距離」と
-   * 割り切った設計。
-   *
-   * 端点 (i=0 / i=last) は片側 segment のみで normal を直接使う。退化 segment
-   * (length < epsilon) は normal を null とし、隣接 normal にフォールバック。
-   *
-   * **anti-parallel fallback** (`bLen < epsilon`): canonical normal 化以降は
-   * 両 segment が共通端点を持つ通常の vertex で nIn = -nOut になる組み合わせは
-   * 構築できない (lex-order canonical 方向は片方の端点を起点にするため、両
-   * segment の canonical 方向が完全反転する case は collinear-foldback 含めて
-   * 発生しない)。fallback コードは degenerate な数値誤差や将来の normal 計算
-   * 仕様変更に対する保険として残すのみで、現実装では実質到達しない (#69 round 2
-   * low 対応、Codex review)。
+   * Leaflet `latLngToContainerPoint` で pixel 空間に変換し、純粋幾何関数
+   * `MapoiGeometry.offsetPointsPx` (mapoi_webui/web/js/geometry.js) に委譲、
+   * 結果を `containerPointToLatLng` で latlng に戻す。pure helper 側で
+   * canonical normal / bisector / cap / 退化 fallback 等の幾何ロジックを担当
+   * (#129 で単体テストの対象として切り出し)。
    *
    * pixel 計算なので zoom 変化で再計算が必要 → showRoutes は zoomend で cached
    * args を使って呼び直す (#69 PR-2)。
@@ -470,45 +451,7 @@ class MapViewer {
   _offsetLatLngs(latlngs, offsetPx) {
     if (!latlngs || latlngs.length < 2 || offsetPx === 0) return latlngs;
     const points = latlngs.map((ll) => this.map.latLngToContainerPoint(ll));
-    const epsilon = 1e-3;
-    const segNormals = [];
-    for (let i = 0; i < points.length - 1; i++) {
-      const a = points[i];
-      const b = points[i + 1];
-      // canonical direction: 端点を (x, y) lex 順で並べた最小 → 最大。
-      // A→B route と B→A route の両方で同じ法線方向になるための鍵。
-      const aFirst = a.x < b.x || (a.x === b.x && a.y < b.y);
-      const dx = aFirst ? b.x - a.x : a.x - b.x;
-      const dy = aFirst ? b.y - a.y : a.y - b.y;
-      const len = Math.hypot(dx, dy);
-      // canonical 方向の 90° 時計回り回転 = (dy, -dx) / len。
-      segNormals.push(len < epsilon ? null : { x: dy / len, y: -dx / len });
-    }
-    const maxOffset = 4 * Math.abs(offsetPx);
-    const offsetPoints = points.map((p, i) => {
-      const nIn = i > 0 ? segNormals[i - 1] : null;
-      const nOut = i < points.length - 1 ? segNormals[i] : null;
-      if (nIn && nOut) {
-        const bx = nIn.x + nOut.x;
-        const by = nIn.y + nOut.y;
-        const bLen = Math.hypot(bx, by);
-        if (bLen < epsilon) {
-          // anti-parallel fallback: canonical normal 化後では通常到達しない
-          // (上段 JSDoc 参照)。数値誤差や将来の normal 計算仕様変更に対する保険
-          // として nOut 単独で offset するに留める。
-          return { x: p.x + nOut.x * offsetPx, y: p.y + nOut.y * offsetPx };
-        }
-        let factor = (2 * offsetPx) / (bLen * bLen);
-        const offMag = Math.abs(factor) * bLen;
-        if (offMag > maxOffset) {
-          factor *= maxOffset / offMag;
-        }
-        return { x: p.x + bx * factor, y: p.y + by * factor };
-      }
-      const single = nIn || nOut;
-      if (!single) return { x: p.x, y: p.y }; // 完全退化
-      return { x: p.x + single.x * offsetPx, y: p.y + single.y * offsetPx };
-    });
+    const offsetPoints = MapoiGeometry.offsetPointsPx(points, offsetPx);
     return offsetPoints.map((pt) => this.map.containerPointToLatLng(L.point(pt.x, pt.y)));
   }
 


### PR DESCRIPTION
## Summary

PR #128 (#69 PR-2) の Codex review で round 4 まで掛かった一因が、\`_offsetLatLngs\` の幾何ロジックを map-viewer.js (Leaflet 依存) の中に抱えていて単体テストできないことだった。pure helper として切り出し、vitest で幾何不変条件を機械化する。

- \`mapoi_webui/web/js/geometry.js\`: \`MapoiGeometry.offsetPointsPx\` を切り出し。入力/出力は plain \`{x, y}\` で Leaflet / DOM 非依存。browser 用 window attach + Node 用 \`module.exports\` の dual export
- \`mapoi_webui/web/js/map-viewer.js\` \`_offsetLatLngs\`: 幾何ロジックを上記 pure helper に委譲。latLng↔containerPoint 変換のみ残す
- \`mapoi_webui/web/index.html\`: \`geometry.js\` を \`map-viewer.js\` より前に load
- \`mapoi_webui/tests/web/\`: vitest セットアップ (package.json, package-lock.json, geometry.test.js)
- \`.github/workflows/consistency-check.yml\`: \`webui_js_tests\` job を追加 (Node 20 + npm ci + npm test)

Close #129

## テストケース (11)

\`geometry.test.js\` でカバー:

- offsetPx === 0 で同じ参照を返す (no-op)
- length < 2 / null / undefined で同じ参照を返す
- 直線 segment で perpendicular 距離が \`offsetPx\` ぴったり (符号反転含む)
- canonical (lex-order) normal で A→B / B→A route が同じ法線軸を使う
- 90° corner で bisector 計算が両側 segment と \`offsetPx\` 距離を保つ
- 鋭角コーナーで cap が効き offset 距離 ≤ \`4*|offsetPx|\`
- 退化 segment (length≈0) で隣接 normal にフォールバック
- 完全退化 (3 同点) で原点維持
- 縦線 (lex tie on x) で y 順 canonical 化が動く

## 設計メモ

### 切り出し方針
- pure helper (\`offsetPointsPx\`) は **window への attach + module.exports の dual export** で、browser script tag と Node (vitest) の両方から使える形
- map-viewer.js は \`MapoiGeometry.offsetPointsPx\` を呼ぶだけ。Leaflet 依存の latLng↔pixel 変換と Map 連携 (zoomend redraw 等) は MapViewer に残す
- index.html では \`geometry.js\` を \`map-viewer.js\` の前に load。\`MapoiGeometry\` がまだ undefined のまま MapViewer constructor が走っても問題ない (offsetLatLngs は showRoutes 経由でのみ呼ばれる、それは async API fetch 後)

### 配置
- テスト本体は \`mapoi_webui/tests/web/\` に置き、CMakeLists の \`install(DIRECTORY web launch ...)\` の対象外にすることで colcon build 成果物に node_modules / package.json を含めない

### CI
- \`webui_js_tests\` job を既存の Consistency Check workflow に追加。robot_radius drift と並列実行
- \`npm ci\` で package-lock.json から再現性ある install。Node 20 を pin (LTS)
- \`actions/setup-node\` の cache: npm を有効化、cache-dependency-path で lock ファイル指定

## Test plan

- [x] \`npm test\` でローカルで 11 件全 pass
- [x] \`yaml.safe_load\` で workflow yaml syntax 確認
- [x] map-viewer.js \`node --check\` 通過
- [ ] PR 上で GitHub Actions の \`webui_js_tests\` job が緑になる
- [ ] (実機) ブラウザで route 表示・active highlight・connector が以前同様に動作 (regression なし)

⚠️ **ローカルで動作確認する場合**: \`mapoi_webui/web/js/geometry.js\` は新規ファイルのため、\`install(DIRECTORY) + --symlink-install\` の前回 build から差分検出できず、再 \`colcon build --symlink-install --packages-select mapoi_webui\` が必要 (lessons 既知パターン)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)