### PR TITLE
feat: system tag landmark を追加 (#85)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 
 # docker compose 環境変数 (host UID/GID は user 環境固有、.env.example をテンプレート参照)
 .env
+
+# Codex CLI 作業ディレクトリ印 (各セッションで自動生成される空ファイル)
+.codex

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -296,13 +296,13 @@ void MapoiPanel::SetNav2GoalComboBox()
 
     for(const auto & p : pois_all){
       bool is_goal = false;
+      bool is_landmark = false;
       for(const auto & tag : p.tags){
-        if(tag == "goal"){
-          is_goal = true;
-          break;
-        }
+        if(tag == "goal") is_goal = true;
+        else if(tag == "landmark") is_landmark = true;
       }
-      if(is_goal){
+      // goal+landmark 併用は意味矛盾だが万一 config に混入しても candidate には載せない (#85)。
+      if(is_goal && !is_landmark){
         pois_.push_back(p);
         ui_->Nav2GoalComboBox->addItem(QString::fromStdString(p.name));
       }

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -723,6 +723,37 @@ bool PoiEditorPanel::ValidatePois()
     return false;
   }
 
+  // Hard validation: landmark の排他 (#85)。
+  // goal+landmark は意味矛盾 (Nav2 goal にできない reference 点)、
+  // initial_pose+landmark は到達不可な POI を起点に置く矛盾。
+  QStringList exclusivity_warnings;
+  for (int row = 0; row < numRows; row++) {
+    int logical_row = ui_->PoiTable->verticalHeader()->logicalIndex(row);
+    auto* tags_item = ui_->PoiTable->item(logical_row, 4);
+    std::string tags_str = tags_item ? tags_item->text().toStdString() : "";
+    if (tags_str.empty()) continue;
+
+    auto tags = this->SplitSentence(tags_str, ", ");
+    bool has_goal = false, has_landmark = false, has_initial_pose = false;
+    for (const auto& t : tags) {
+      if (t == "goal") has_goal = true;
+      else if (t == "landmark") has_landmark = true;
+      else if (t == "initial_pose") has_initial_pose = true;
+    }
+    if (has_goal && has_landmark) {
+      exclusivity_warnings.append(
+        tr("Row %1: \"goal\" と \"landmark\" は併用できません (landmark は Nav2 goal 不可)").arg(row + 1));
+    }
+    if (has_initial_pose && has_landmark) {
+      exclusivity_warnings.append(
+        tr("Row %1: \"initial_pose\" と \"landmark\" は併用できません").arg(row + 1));
+    }
+  }
+  if (!exclusivity_warnings.isEmpty()) {
+    QMessageBox::warning(this, tr("Tag Exclusivity Errors"), exclusivity_warnings.join("\n"));
+    return false;
+  }
+
   // Soft validation: warn about undefined tags (non-blocking)
   QStringList tag_warnings;
   for (int row = 0; row < numRows; row++) {

--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -162,8 +162,13 @@ private:
 
   // POI リストから initial_pose タグ付き候補を返す純関数（test 容易化のため分離）。
   // 複数あれば WARN を出し先頭、0 個なら空ベクタ。
+  // landmark タグ併用 POI は initial_pose 排他のため候補から除外する (#85)。
   std::vector<mapoi_interfaces::msg::PointOfInterest> select_initial_pose_pois(
     const std::vector<mapoi_interfaces::msg::PointOfInterest> & pois);
+
+  // landmark system tag を持つかを判定する純関数 (#85)。
+  // landmark POI は Nav2 navigation goal / initial_pose に使えない reference 専用。
+  static bool has_landmark_tag(const mapoi_interfaces::msg::PointOfInterest & poi);
 
   // /initialpose 配信の単一エントリポイント（手動経路 / 自動経路で共通化）。
   void publish_initial_pose(
@@ -187,6 +192,8 @@ private:
   FRIEND_TEST(NavServerTestFixture, SelectInitialPosePoisEmpty);
   FRIEND_TEST(NavServerTestFixture, SelectInitialPosePoisSingle);
   FRIEND_TEST(NavServerTestFixture, SelectInitialPosePoisMultiple);
+  FRIEND_TEST(NavServerTestFixture, SelectInitialPosePoisExcludesLandmark);
+  FRIEND_TEST(NavServerTestFixture, HasLandmarkTagDetection);
 #endif
 };
 

--- a/mapoi_server/maps/tag_definitions.yaml
+++ b/mapoi_server/maps/tag_definitions.yaml
@@ -4,6 +4,8 @@
 tags:
   - name: goal
     description: "Navigation goal destination"
+  - name: landmark
+    description: "Reference point on the map (excluded from Nav2 navigation goal)"
   - name: origin
     description: "Map origin reference point"
   - name: pause

--- a/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -39,10 +39,10 @@ poi:
   radius: 0.30
   tags: [goal, checkpoint]
 - name: hazard_south
-  description: 南側ハザード (回避対象)
+  description: 南側ハザード (回避対象、Nav2 goal 不可)
   pose: {x: 0.5, y: -1.3, yaw: 0.0}
   radius: 0.45
-  tags: [event, hazard]
+  tags: [event, landmark, hazard]
 - name: north_goal
   description: 北側目標地点
   pose: {x: 0.4, y: 1.7, yaw: -2.0}

--- a/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
@@ -1,7 +1,6 @@
 custom_tags:
 - {name: event, description: Event trigger area}
 - {name: destination, description: General destination point}
-- {name: landmark, description: Landmark for guidance}
 - {name: audio_info, description: Audio guide trigger}
 route:
 - name: route_1

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -122,6 +122,13 @@ void MapoiNavServer::mapoi_initialpose_poi_cb(const std_msgs::msg::String::Share
 
       for (const auto &poi : result->pois_list) {
         if (poi.name == poi_name) {
+          // landmark + initial_pose は排他 (#85)。explicit POI 指定でも reject する。
+          if (has_landmark_tag(poi)) {
+            RCLCPP_ERROR(this->get_logger(),
+              "POI '%s' has 'landmark' tag; cannot be used as initial pose.",
+              poi_name.c_str());
+            return;
+          }
           publish_initial_pose(poi.pose, "explicit POI '" + poi_name + "'");
           return;
         }
@@ -160,6 +167,14 @@ void MapoiNavServer::mapoi_goal_pose_poi_cb(const std_msgs::msg::String::SharedP
 
       for (const auto &poi : result->pois_list) {
         if (poi.name == poi_name) {
+          // landmark POI は Nav2 navigation goal にできない reference 専用 (#85)。
+          // goal+landmark 併用も同様に弾く。
+          if (has_landmark_tag(poi)) {
+            RCLCPP_ERROR(this->get_logger(),
+              "POI '%s' has 'landmark' tag; cannot be set as Nav2 goal.",
+              poi_name.c_str());
+            return;
+          }
           geometry_msgs::msg::PoseStamped goal_pose;
           goal_pose.header.frame_id = "map";
           goal_pose.header.stamp = this->now();
@@ -254,6 +269,10 @@ std::vector<mapoi_interfaces::msg::PointOfInterest> MapoiNavServer::select_initi
 {
   std::vector<mapoi_interfaces::msg::PointOfInterest> matched;
   for (const auto & poi : pois) {
+    // landmark + initial_pose は排他 (#85)。auto-publish 候補からも除外する。
+    if (has_landmark_tag(poi)) {
+      continue;
+    }
     for (const auto & tag : poi.tags) {
       if (tag == "initial_pose") {
         matched.push_back(poi);
@@ -303,6 +322,16 @@ void MapoiNavServer::auto_publish_initial_pose()
 
   publish_initial_pose(matched[0].pose, "auto from POI '" + matched[0].name + "'");
   last_initial_pose_config_path_ = last_config_path_;
+}
+
+bool MapoiNavServer::has_landmark_tag(const mapoi_interfaces::msg::PointOfInterest & poi)
+{
+  for (const auto & tag : poi.tags) {
+    if (tag == "landmark") {
+      return true;
+    }
+  }
+  return false;
 }
 
 void MapoiNavServer::publish_initial_pose(

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -416,38 +416,14 @@ void MapoiRviz2Publisher::timer_callback(){
         id += 1;
       }
       else if(tag == "landmark"){
-        // landmark POI は中抜き三角 (LINE_STRIP) で描画する (#85)。
-        // goal の塗りつぶし矢印 (ARROW) との対比で「実体 (到達目標) vs 参照点」を視覚化。
-        // pose.orientation を yaw quaternion とし、local frame で頂点を打つ。
-        // anchor は底辺中央 = pose、頂点が +x (yaw) 方向。長さは radius と arrow_size_ratio
-        // に整合させ、矢印と並べたときに違和感のないサイズになる。
-        // color は default gray、tag 別 color の整理は #70 で扱う。
-        visualization_msgs::msg::Marker m_landmark;
-        m_landmark.header.frame_id = "map";
-        m_landmark.header.stamp = rclcpp::Clock().now();
-        m_landmark.ns = "landmark_outline";
-        m_landmark.id = id;
-        m_landmark.type = visualization_msgs::msg::Marker::LINE_STRIP;
-        m_landmark.action = visualization_msgs::msg::Marker::ADD;
+        // landmark POI も矢印 + label を描画する (#85)。reference 専用なので
+        // ma_events 側に置く。color は default gray、tag 別 color の整理は #70 で扱う。
+        visualization_msgs::msg::Marker m_landmark = default_arrow_marker;
         m_landmark.pose = pose;
         m_landmark.pose.position.z = 0.1;
-        m_landmark.lifetime.sec = 2.0;
-        m_landmark.scale.x = 0.04;  // line width (m)
-        m_landmark.color.r = 0.5; m_landmark.color.g = 0.5; m_landmark.color.b = 0.5; m_landmark.color.a = 0.9;
-
-        double length = 0.3;
-        if (poi.radius > 0.0 && arrow_size_ratio > 0.0) {
-          length = poi.radius * arrow_size_ratio;
-        }
-        const double half_width = length * 0.4;
-        geometry_msgs::msg::Point p_tip, p_left, p_right;
-        p_tip.x = length;  p_tip.y = 0;             p_tip.z = 0;
-        p_left.x = 0;      p_left.y = half_width;   p_left.z = 0;
-        p_right.x = 0;     p_right.y = -half_width; p_right.z = 0;
-        m_landmark.points.push_back(p_tip);
-        m_landmark.points.push_back(p_left);
-        m_landmark.points.push_back(p_right);
-        m_landmark.points.push_back(p_tip);  // closure
+        apply_radius_scale(m_landmark, poi.radius);
+        m_landmark.color.r = 0.5; m_landmark.color.g = 0.5; m_landmark.color.b = 0.5; m_landmark.color.a = 0.7;
+        m_landmark.id = id;
         ma_events.markers.push_back(m_landmark);
         id += 1;
 

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -416,14 +416,38 @@ void MapoiRviz2Publisher::timer_callback(){
         id += 1;
       }
       else if(tag == "landmark"){
-        // landmark POI も矢印 + label を描画する (#85)。reference 専用なので
-        // ma_events 側に置く。color は default gray、tag 別 color の整理は #70 で扱う。
-        visualization_msgs::msg::Marker m_landmark = default_arrow_marker;
+        // landmark POI は中抜き三角 (LINE_STRIP) で描画する (#85)。
+        // goal の塗りつぶし矢印 (ARROW) との対比で「実体 (到達目標) vs 参照点」を視覚化。
+        // pose.orientation を yaw quaternion とし、local frame で頂点を打つ。
+        // anchor は底辺中央 = pose、頂点が +x (yaw) 方向。長さは radius と arrow_size_ratio
+        // に整合させ、矢印と並べたときに違和感のないサイズになる。
+        // color は default gray、tag 別 color の整理は #70 で扱う。
+        visualization_msgs::msg::Marker m_landmark;
+        m_landmark.header.frame_id = "map";
+        m_landmark.header.stamp = rclcpp::Clock().now();
+        m_landmark.ns = "landmark_outline";
+        m_landmark.id = id;
+        m_landmark.type = visualization_msgs::msg::Marker::LINE_STRIP;
+        m_landmark.action = visualization_msgs::msg::Marker::ADD;
         m_landmark.pose = pose;
         m_landmark.pose.position.z = 0.1;
-        apply_radius_scale(m_landmark, poi.radius);
-        m_landmark.color.r = 0.5; m_landmark.color.g = 0.5; m_landmark.color.b = 0.5; m_landmark.color.a = 0.7;
-        m_landmark.id = id;
+        m_landmark.lifetime.sec = 2.0;
+        m_landmark.scale.x = 0.04;  // line width (m)
+        m_landmark.color.r = 0.5; m_landmark.color.g = 0.5; m_landmark.color.b = 0.5; m_landmark.color.a = 0.9;
+
+        double length = 0.3;
+        if (poi.radius > 0.0 && arrow_size_ratio > 0.0) {
+          length = poi.radius * arrow_size_ratio;
+        }
+        const double half_width = length * 0.4;
+        geometry_msgs::msg::Point p_tip, p_left, p_right;
+        p_tip.x = length;  p_tip.y = 0;             p_tip.z = 0;
+        p_left.x = 0;      p_left.y = half_width;   p_left.z = 0;
+        p_right.x = 0;     p_right.y = -half_width; p_right.z = 0;
+        m_landmark.points.push_back(p_tip);
+        m_landmark.points.push_back(p_left);
+        m_landmark.points.push_back(p_right);
+        m_landmark.points.push_back(p_tip);  // closure
         ma_events.markers.push_back(m_landmark);
         id += 1;
 

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -415,6 +415,29 @@ void MapoiRviz2Publisher::timer_callback(){
         ma_events.markers.push_back(m_event);
         id += 1;
       }
+      else if(tag == "landmark"){
+        // landmark POI も矢印 + label を描画する (#85)。reference 専用なので
+        // ma_events 側に置く。color は default gray、tag 別 color の整理は #70 で扱う。
+        visualization_msgs::msg::Marker m_landmark = default_arrow_marker;
+        m_landmark.pose = pose;
+        m_landmark.pose.position.z = 0.1;
+        apply_radius_scale(m_landmark, poi.radius);
+        m_landmark.color.r = 0.5; m_landmark.color.g = 0.5; m_landmark.color.b = 0.5; m_landmark.color.a = 0.7;
+        m_landmark.id = id;
+        ma_events.markers.push_back(m_landmark);
+        id += 1;
+
+        const std::string label_text = build_label(poi_index_one_based, poi.name);
+        if (!label_text.empty()) {
+          visualization_msgs::msg::Marker m_text = default_text_marker;
+          m_text.text = label_text;
+          m_text.pose = pose;
+          m_text.pose.position.z = 0.1;
+          m_text.id = id;
+          ma_events.markers.push_back(m_text);
+          id += 1;
+        }
+      }
     }
   }
 

--- a/mapoi_server/test/test_nav_server_unit.cpp
+++ b/mapoi_server/test/test_nav_server_unit.cpp
@@ -119,6 +119,31 @@ TEST_F(NavServerTestFixture, SelectInitialPosePoisMultiple)
   EXPECT_EQ(matched[1].name, "second");
 }
 
+TEST_F(NavServerTestFixture, SelectInitialPosePoisExcludesLandmark)
+{
+  // landmark + initial_pose は排他なので auto-publish 候補から除外される (#85)。
+  std::vector<mapoi_interfaces::msg::PointOfInterest> pois;
+  pois.push_back(make_poi("ip_only", 1.0, 1.0, 0.5, {"initial_pose"}));
+  pois.push_back(make_poi("landmark_ip", 2.0, 2.0, 0.5, {"initial_pose", "landmark"}));
+  pois.push_back(make_poi("ip_with_other", 3.0, 3.0, 0.5, {"initial_pose", "goal"}));
+  auto matched = node_->select_initial_pose_pois(pois);
+  ASSERT_EQ(matched.size(), 2u);
+  EXPECT_EQ(matched[0].name, "ip_only");
+  EXPECT_EQ(matched[1].name, "ip_with_other");
+}
+
+TEST_F(NavServerTestFixture, HasLandmarkTagDetection)
+{
+  EXPECT_FALSE(MapoiNavServer::has_landmark_tag(
+    make_poi("goal_only", 0.0, 0.0, 0.5, {"goal"})));
+  EXPECT_FALSE(MapoiNavServer::has_landmark_tag(
+    make_poi("no_tags", 0.0, 0.0, 0.5, {})));
+  EXPECT_TRUE(MapoiNavServer::has_landmark_tag(
+    make_poi("landmark_only", 0.0, 0.0, 0.5, {"landmark"})));
+  EXPECT_TRUE(MapoiNavServer::has_landmark_tag(
+    make_poi("landmark_combo", 0.0, 0.0, 0.5, {"event", "landmark", "hazard"})));
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -39,10 +39,10 @@ poi:
   radius: 0.30
   tags: [goal, checkpoint]
 - name: hazard_south
-  description: 南側ハザード (回避対象)
+  description: 南側ハザード (回避対象、Nav2 goal 不可)
   pose: {x: 0.5, y: -1.3, yaw: 0.0}
   radius: 0.45
-  tags: [event, hazard]
+  tags: [event, landmark, hazard]
 - name: north_goal
   description: 北側目標地点
   pose: {x: 0.4, y: 1.7, yaw: -2.0}

--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -1,7 +1,6 @@
 custom_tags:
 - {name: event, description: Event trigger area}
 - {name: destination, description: General destination point}
-- {name: landmark, description: Landmark for guidance}
 - {name: audio_info, description: Audio guide trigger}
 route:
 - name: route_1

--- a/mapoi_webui/tests/web/poi-filter.test.js
+++ b/mapoi_webui/tests/web/poi-filter.test.js
@@ -1,0 +1,119 @@
+// vitest unit tests for the POI candidate filters in
+// mapoi_webui/web/js/poi-filter.js (#85).
+//
+// 対象: MapoiPoiFilter.{hasLandmarkTag, filterGoalCandidates,
+//   filterInitialPoseCandidates, filterRouteWaypointCandidates}
+//
+// テスト方針:
+// - landmark system tag を持つ POI が dropdown 候補から確実に除外されること
+//   を検証する (#85: landmark = Nav2 goal 不可な reference 専用)。
+// - DOM / window 依存ゼロの pure JS。
+
+import { describe, it, expect } from 'vitest';
+import * as filter from '../../web/js/poi-filter.js';
+
+const {
+  hasLandmarkTag,
+  filterGoalCandidates,
+  filterInitialPoseCandidates,
+  filterRouteWaypointCandidates,
+} = filter;
+
+const poi = (name, tags) => ({ name, tags });
+
+describe('hasLandmarkTag', () => {
+  it('returns true when tags include landmark', () => {
+    expect(hasLandmarkTag(poi('a', ['landmark']))).toBe(true);
+    expect(hasLandmarkTag(poi('b', ['event', 'landmark', 'hazard']))).toBe(true);
+  });
+
+  it('returns false when landmark is absent', () => {
+    expect(hasLandmarkTag(poi('a', ['goal']))).toBe(false);
+    expect(hasLandmarkTag(poi('b', []))).toBe(false);
+    expect(hasLandmarkTag(poi('c', ['origin', 'pause']))).toBe(false);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(hasLandmarkTag(poi('a', ['LandMark']))).toBe(true);
+    expect(hasLandmarkTag(poi('b', ['LANDMARK']))).toBe(true);
+  });
+
+  it('handles missing / null input gracefully', () => {
+    expect(hasLandmarkTag(null)).toBe(false);
+    expect(hasLandmarkTag(undefined)).toBe(false);
+    expect(hasLandmarkTag({})).toBe(false);
+    expect(hasLandmarkTag({ tags: null })).toBe(false);
+  });
+});
+
+describe('filterGoalCandidates', () => {
+  it('keeps goal POIs without landmark', () => {
+    const pois = [
+      poi('north_goal', ['goal']),
+      poi('checkpoint', ['goal', 'checkpoint']),
+    ];
+    expect(filterGoalCandidates(pois).map((p) => p.name)).toEqual(['north_goal', 'checkpoint']);
+  });
+
+  it('drops POIs that combine goal with landmark', () => {
+    // goal+landmark は仕様上排他だが万一 config に混入しても候補に載せない。
+    const pois = [
+      poi('valid', ['goal']),
+      poi('reference', ['goal', 'landmark']),
+    ];
+    expect(filterGoalCandidates(pois).map((p) => p.name)).toEqual(['valid']);
+  });
+
+  it('drops landmark-only POIs (no goal tag)', () => {
+    const pois = [
+      poi('landmark_only', ['landmark']),
+      poi('hazard_landmark', ['event', 'landmark', 'hazard']),
+    ];
+    expect(filterGoalCandidates(pois)).toEqual([]);
+  });
+
+  it('returns [] for empty / null input', () => {
+    expect(filterGoalCandidates([])).toEqual([]);
+    expect(filterGoalCandidates(null)).toEqual([]);
+    expect(filterGoalCandidates(undefined)).toEqual([]);
+  });
+});
+
+describe('filterInitialPoseCandidates', () => {
+  it('drops landmark POIs (排他: landmark + initial_pose)', () => {
+    const pois = [
+      poi('start_zone', ['goal', 'initial_pose']),
+      poi('landmark_x', ['landmark']),
+      poi('hazard', ['event', 'landmark', 'hazard']),
+      poi('north', ['goal']),
+    ];
+    expect(filterInitialPoseCandidates(pois).map((p) => p.name)).toEqual(['start_zone', 'north']);
+  });
+
+  it('keeps non-landmark POIs even without initial_pose tag', () => {
+    // initial pose dropdown は全 navigable POI を載せて user に選ばせる
+    // (manual override 用途) ため、initial_pose タグの有無で絞らない。
+    const pois = [
+      poi('a', ['goal']),
+      poi('b', ['origin']),
+    ];
+    expect(filterInitialPoseCandidates(pois).map((p) => p.name)).toEqual(['a', 'b']);
+  });
+});
+
+describe('filterRouteWaypointCandidates', () => {
+  it('drops landmark POIs from route waypoint candidate list', () => {
+    const pois = [
+      poi('start_zone', ['goal']),
+      poi('hazard', ['event', 'landmark', 'hazard']),
+      poi('north_goal', ['goal']),
+    ];
+    expect(filterRouteWaypointCandidates(pois).map((p) => p.name)).toEqual(['start_zone', 'north_goal']);
+  });
+
+  it('returns input copy for null / undefined / empty', () => {
+    expect(filterRouteWaypointCandidates(null)).toEqual([]);
+    expect(filterRouteWaypointCandidates(undefined)).toEqual([]);
+    expect(filterRouteWaypointCandidates([])).toEqual([]);
+  });
+});

--- a/mapoi_webui/tests/web/poi-filter.test.js
+++ b/mapoi_webui/tests/web/poi-filter.test.js
@@ -17,6 +17,7 @@ const {
   filterGoalCandidates,
   filterInitialPoseCandidates,
   filterRouteWaypointCandidates,
+  validatePoiTags,
 } = filter;
 
 const poi = (name, tags) => ({ name, tags });
@@ -115,5 +116,38 @@ describe('filterRouteWaypointCandidates', () => {
     expect(filterRouteWaypointCandidates(null)).toEqual([]);
     expect(filterRouteWaypointCandidates(undefined)).toEqual([]);
     expect(filterRouteWaypointCandidates([])).toEqual([]);
+  });
+});
+
+describe('validatePoiTags', () => {
+  it('accepts non-conflicting combinations', () => {
+    expect(validatePoiTags(poi('a', ['goal'])).ok).toBe(true);
+    expect(validatePoiTags(poi('b', ['landmark'])).ok).toBe(true);
+    expect(validatePoiTags(poi('c', ['event', 'landmark', 'hazard'])).ok).toBe(true);
+    expect(validatePoiTags(poi('d', ['initial_pose', 'goal'])).ok).toBe(true);
+    expect(validatePoiTags(poi('e', [])).ok).toBe(true);
+  });
+
+  it('rejects goal + landmark combination', () => {
+    const result = validatePoiTags(poi('a', ['goal', 'landmark']));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/goal.*landmark/);
+  });
+
+  it('rejects initial_pose + landmark combination', () => {
+    const result = validatePoiTags(poi('a', ['initial_pose', 'landmark']));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/initial_pose.*landmark/);
+  });
+
+  it('matches case-insensitively for both system tags', () => {
+    expect(validatePoiTags(poi('a', ['GOAL', 'Landmark'])).ok).toBe(false);
+    expect(validatePoiTags(poi('b', ['Initial_Pose', 'LANDMARK'])).ok).toBe(false);
+  });
+
+  it('handles missing / null poi gracefully', () => {
+    expect(validatePoiTags(null).ok).toBe(true);
+    expect(validatePoiTags(undefined).ok).toBe(true);
+    expect(validatePoiTags({}).ok).toBe(true);
   });
 });

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -192,6 +192,9 @@
   <!-- geometry.js は MapoiGeometry を window に attach する pure helper 群。
        map-viewer.js より前に読み込む必要がある (showRoutes 経由で参照される) -->
   <script src="/js/geometry.js"></script>
+  <!-- poi-filter.js は MapoiPoiFilter を window に attach する pure helper 群 (#85)。
+       app.js より前に読み込む。 -->
+  <script src="/js/poi-filter.js"></script>
   <script src="/js/map-viewer.js"></script>
   <script src="/js/poi-editor.js"></script>
   <script src="/js/route-editor.js"></script>

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -138,7 +138,10 @@
   }
 
   function updateRouteEditorPoiNames() {
-    routeEditor.setPoiNames(poiEditor.pois.map((p) => p.name));
+    // landmark POI は Nav2 navigation goal にできない reference 専用 (#85)。
+    // route waypoint candidate からも除外する。
+    const navigablePois = MapoiPoiFilter.filterRouteWaypointCandidates(poiEditor.pois);
+    routeEditor.setPoiNames(navigablePois.map((p) => p.name));
   }
 
   // --- Load routes ---
@@ -346,17 +349,13 @@
   // --- Navigation controls ---
   function populateNavGoalSelect(pois) {
     navGoalSelect.innerHTML = '<option value="">-- Select POI --</option>';
-    pois
-      .filter((p) => {
-        const tags = (p.tags || []).map((t) => t.toLowerCase());
-        return tags.includes('goal');
-      })
-      .forEach((p) => {
-        const opt = document.createElement('option');
-        opt.value = p.name;
-        opt.textContent = p.name;
-        navGoalSelect.appendChild(opt);
-      });
+    // landmark POI は reference 専用、Nav2 goal candidate から除外 (#85)。
+    MapoiPoiFilter.filterGoalCandidates(pois).forEach((p) => {
+      const opt = document.createElement('option');
+      opt.value = p.name;
+      opt.textContent = p.name;
+      navGoalSelect.appendChild(opt);
+    });
   }
 
   function populateNavRouteSelect(routes) {
@@ -401,7 +400,8 @@
 
   function populateInitialPoseSelect(pois) {
     navInitialPoseSelect.innerHTML = '<option value="">-- Select POI --</option>';
-    pois.forEach((p) => {
+    // landmark + initial_pose は排他、initial pose candidate から除外 (#85)。
+    MapoiPoiFilter.filterInitialPoseCandidates(pois).forEach((p) => {
       const opt = document.createElement('option');
       opt.value = p.name;
       opt.textContent = p.name;

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -207,40 +207,6 @@ class MapViewer {
   }
 
   /**
-   * Create an SVG outline-triangle icon for a landmark POI marker (#85)。
-   * goal の塗りつぶし矢印に対し「fill 無し / stroke のみ」の三角輪郭で
-   * 「実体 (到達目標) vs 参照点」を視覚化。底辺中央が POI pose、頂点が
-   * yaw 方向を指す。SVG 内 rotate で底辺中央を中心に回転させる。
-   */
-  createLandmarkIcon(color, yaw, highlight) {
-    const strokeColor = highlight ? '#e67e22' : color;
-    const strokeWidth = highlight ? 3.5 : 2.5;
-    const rotDeg = 90 - (yaw * 180 / Math.PI);
-    // viewBox 32x32: 頂点 (16, 4)、底辺左 (4, 26)、底辺右 (28, 26)。底辺中央 (16, 26) が anchor。
-    const svg = `<svg width="32" height="32" viewBox="0 0 32 32">` +
-      `<g transform="rotate(${rotDeg} 16 26)">` +
-      `<path d="M16 4 L28 26 L4 26 Z" fill="none" stroke="${strokeColor}" stroke-width="${strokeWidth}" stroke-linejoin="round" stroke-linecap="round"/>` +
-      `</g></svg>`;
-    return L.divIcon({
-      className: 'poi-landmark-icon',
-      html: svg,
-      iconSize: [32, 32],
-      iconAnchor: [16, 26],
-    });
-  }
-
-  /**
-   * Build the appropriate POI marker icon based on tags (#85)。
-   * landmark タグ POI は中抜き三角、それ以外は塗りつぶし矢印。
-   */
-  createPoiIcon(poi, color, yaw, highlight) {
-    if (MapoiPoiFilter.hasLandmarkTag(poi)) {
-      return this.createLandmarkIcon(color, yaw, highlight);
-    }
-    return this.createArrowIcon(color, yaw, highlight);
-  }
-
-  /**
    * Display POI markers as directional arrows on the map.
    * @param {Array} pois - POI array
    * @param {Set|null} visibleSet - if provided, only show POIs whose index is in this set
@@ -255,7 +221,7 @@ class MapViewer {
       const color = this.getPoiColor(poi);
       const yaw = poi.pose.yaw || 0;
 
-      const icon = this.createPoiIcon(poi, color, yaw, false);
+      const icon = this.createArrowIcon(color, yaw, false);
       const marker = L.marker(latlng, { icon }).addTo(this.map);
 
       marker.bindTooltip(poi.name || `POI ${index}`, {
@@ -281,7 +247,7 @@ class MapViewer {
   highlightPoi(index) {
     this.poiMarkers.forEach((item) => {
       const isHighlighted = item.index === index;
-      const icon = this.createPoiIcon(item.poi, item.color, item.yaw, isHighlighted);
+      const icon = this.createArrowIcon(item.color, item.yaw, isHighlighted);
       item.marker.setIcon(icon);
       if (isHighlighted) {
         item.marker.setZIndexOffset(1000);
@@ -416,7 +382,7 @@ class MapViewer {
     const item = this.poiMarkers.find((m) => m.index === index);
     if (!item) return;
     item.yaw = yaw;
-    const icon = this.createPoiIcon(item.poi, item.color, yaw, true);
+    const icon = this.createArrowIcon(item.color, yaw, true);
     item.marker.setIcon(icon);
   }
 

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -207,6 +207,40 @@ class MapViewer {
   }
 
   /**
+   * Create an SVG outline-triangle icon for a landmark POI marker (#85)。
+   * goal の塗りつぶし矢印に対し「fill 無し / stroke のみ」の三角輪郭で
+   * 「実体 (到達目標) vs 参照点」を視覚化。底辺中央が POI pose、頂点が
+   * yaw 方向を指す。SVG 内 rotate で底辺中央を中心に回転させる。
+   */
+  createLandmarkIcon(color, yaw, highlight) {
+    const strokeColor = highlight ? '#e67e22' : color;
+    const strokeWidth = highlight ? 3.5 : 2.5;
+    const rotDeg = 90 - (yaw * 180 / Math.PI);
+    // viewBox 32x32: 頂点 (16, 4)、底辺左 (4, 26)、底辺右 (28, 26)。底辺中央 (16, 26) が anchor。
+    const svg = `<svg width="32" height="32" viewBox="0 0 32 32">` +
+      `<g transform="rotate(${rotDeg} 16 26)">` +
+      `<path d="M16 4 L28 26 L4 26 Z" fill="none" stroke="${strokeColor}" stroke-width="${strokeWidth}" stroke-linejoin="round" stroke-linecap="round"/>` +
+      `</g></svg>`;
+    return L.divIcon({
+      className: 'poi-landmark-icon',
+      html: svg,
+      iconSize: [32, 32],
+      iconAnchor: [16, 26],
+    });
+  }
+
+  /**
+   * Build the appropriate POI marker icon based on tags (#85)。
+   * landmark タグ POI は中抜き三角、それ以外は塗りつぶし矢印。
+   */
+  createPoiIcon(poi, color, yaw, highlight) {
+    if (MapoiPoiFilter.hasLandmarkTag(poi)) {
+      return this.createLandmarkIcon(color, yaw, highlight);
+    }
+    return this.createArrowIcon(color, yaw, highlight);
+  }
+
+  /**
    * Display POI markers as directional arrows on the map.
    * @param {Array} pois - POI array
    * @param {Set|null} visibleSet - if provided, only show POIs whose index is in this set
@@ -221,7 +255,7 @@ class MapViewer {
       const color = this.getPoiColor(poi);
       const yaw = poi.pose.yaw || 0;
 
-      const icon = this.createArrowIcon(color, yaw, false);
+      const icon = this.createPoiIcon(poi, color, yaw, false);
       const marker = L.marker(latlng, { icon }).addTo(this.map);
 
       marker.bindTooltip(poi.name || `POI ${index}`, {
@@ -247,7 +281,7 @@ class MapViewer {
   highlightPoi(index) {
     this.poiMarkers.forEach((item) => {
       const isHighlighted = item.index === index;
-      const icon = this.createArrowIcon(item.color, item.yaw, isHighlighted);
+      const icon = this.createPoiIcon(item.poi, item.color, item.yaw, isHighlighted);
       item.marker.setIcon(icon);
       if (isHighlighted) {
         item.marker.setZIndexOffset(1000);
@@ -382,7 +416,7 @@ class MapViewer {
     const item = this.poiMarkers.find((m) => m.index === index);
     if (!item) return;
     item.yaw = yaw;
-    const icon = this.createArrowIcon(item.color, yaw, true);
+    const icon = this.createPoiIcon(item.poi, item.color, yaw, true);
     item.marker.setIcon(icon);
   }
 

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -358,6 +358,12 @@ class PoiEditor {
       alert('POI name "' + poi.name + '" already exists.');
       return;
     }
+    // landmark 排他 check (#85): goal+landmark / initial_pose+landmark は不可。
+    const tagValidation = MapoiPoiFilter.validatePoiTags(poi);
+    if (!tagValidation.ok) {
+      alert(tagValidation.error);
+      return;
+    }
     if (this.editingIndex === -2) {
       // New POI
       this.pois.push(poi);

--- a/mapoi_webui/web/js/poi-filter.js
+++ b/mapoi_webui/web/js/poi-filter.js
@@ -32,11 +32,37 @@
     return (pois || []).filter((p) => !hasLandmarkTag(p));
   }
 
+  /**
+   * POI tag combination 排他 check (#85)。
+   * `goal+landmark` / `initial_pose+landmark` は仕様上排他。save 前に
+   * 弾くことで mapoi_config.yaml に invalid な POI が永続化するのを防ぐ。
+   *
+   * @returns {{ ok: boolean, error?: string }}
+   */
+  function validatePoiTags(poi) {
+    const tags = (poi && poi.tags ? poi.tags : []).map((t) => String(t).toLowerCase());
+    const has = (n) => tags.includes(n);
+    if (has('goal') && has('landmark')) {
+      return {
+        ok: false,
+        error: '"goal" と "landmark" は併用できません (landmark は Nav2 navigation goal 不可な reference 専用)。',
+      };
+    }
+    if (has('initial_pose') && has('landmark')) {
+      return {
+        ok: false,
+        error: '"initial_pose" と "landmark" は併用できません (landmark は到達不可な reference 点)。',
+      };
+    }
+    return { ok: true };
+  }
+
   const api = {
     hasLandmarkTag,
     filterGoalCandidates,
     filterInitialPoseCandidates,
     filterRouteWaypointCandidates,
+    validatePoiTags,
   };
 
   if (typeof window !== 'undefined') {

--- a/mapoi_webui/web/js/poi-filter.js
+++ b/mapoi_webui/web/js/poi-filter.js
@@ -1,0 +1,49 @@
+/**
+ * POI candidate filters for mapoi WebUI.
+ *
+ * landmark system tag (#85) は Nav2 navigation goal にしない reference 専用。
+ * goal candidate / route waypoint candidate / initial pose candidate の dropdown
+ * から landmark POI を除外する純関数群を集約する。
+ *
+ * Browser からは `MapoiPoiFilter.*` のグローバルとして使い、
+ * Node (vitest) からは `module.exports` 経由で import する dual export 形式。
+ * 依存ゼロの pure 関数で DOM / window 等を参照しない。
+ */
+(function () {
+  'use strict';
+
+  function hasLandmarkTag(poi) {
+    const tags = (poi && poi.tags) || [];
+    return tags.some((t) => typeof t === 'string' && t.toLowerCase() === 'landmark');
+  }
+
+  function filterGoalCandidates(pois) {
+    return (pois || []).filter((p) => {
+      const tags = (p && p.tags ? p.tags : []).map((t) => String(t).toLowerCase());
+      return tags.includes('goal') && !tags.includes('landmark');
+    });
+  }
+
+  function filterInitialPoseCandidates(pois) {
+    return (pois || []).filter((p) => !hasLandmarkTag(p));
+  }
+
+  function filterRouteWaypointCandidates(pois) {
+    return (pois || []).filter((p) => !hasLandmarkTag(p));
+  }
+
+  const api = {
+    hasLandmarkTag,
+    filterGoalCandidates,
+    filterInitialPoseCandidates,
+    filterRouteWaypointCandidates,
+  };
+
+  if (typeof window !== 'undefined') {
+    window.MapoiPoiFilter = window.MapoiPoiFilter || {};
+    Object.assign(window.MapoiPoiFilter, api);
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+}());


### PR DESCRIPTION
## Summary

- system tag `landmark` を追加。POI として登録・表示・参照したいが Nav2 の goal として設定したくない地点 (回避対象 / 階段 / 設備位置 / 撮影対象 等) を表現できるようにする
- `goal+landmark` / `landmark+initial_pose` の併用は仕様上排他で、nav_server / WebUI / Panel いずれの経路でも候補から除外し、explicit に topic で受け取った場合は ERROR ログで reject する
- 既存の `origin` system tag は本 PR では削除しない (非破壊。後続の破壊変更 issue で扱う前提)
- 表示 color の差別化は #70 (rviz visualization 仕様再整理) でまとめて検討。本 PR では矢印 + radius を default gray で描画する基本動作のみ確定

## 実装範囲

| 影響範囲 | 改修内容 |
|---|---|
| `mapoi_server/maps/tag_definitions.yaml` | system tag `landmark` を追加 |
| `mapoi_server/src/mapoi_nav_server.cpp` | `has_landmark_tag` helper を導入し goal/initialpose handler と `select_initial_pose_pois` で landmark POI を reject |
| `mapoi_server/src/mapoi_rviz2_publisher.cpp` | tag ループに landmark ブランチ。矢印 + label を gray で描画 |
| `mapoi_rviz_plugins/src/mapoi_panel.cpp` | `SetNav2GoalComboBox` から goal+landmark 併用も除外 |
| `mapoi_webui/web/js/poi-filter.js` (新規) | `hasLandmarkTag` / `filterGoalCandidates` / `filterInitialPoseCandidates` / `filterRouteWaypointCandidates` を dual export (browser global + module.exports) で提供 |
| `mapoi_webui/web/js/app.js` | `populateNavGoalSelect` / `populateInitialPoseSelect` / `updateRouteEditorPoiNames` を `MapoiPoiFilter.*` 経由に置き換え |
| `mapoi_*example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml` | `hazard_south` を `[event, landmark, hazard]` に変更し landmark の使用例を提示 |

## 排他ルール

| tag 組合せ | 妥当性 | 強制方法 |
|---|---|---|
| `landmark` + `goal` | ✗ 排他 | `mapoi_goal_pose_poi_cb` で ERROR + early return / WebUI Panel candidate から除外 |
| `landmark` + `initial_pose` | ✗ 排他 | `mapoi_initialpose_poi_cb` で ERROR + early return / `select_initial_pose_pois` でも除外 / WebUI candidate から除外 |
| `landmark` + `event` / custom | ✓ 自由併用 | sample `hazard_south` で `[event, landmark, hazard]` の例示 |

## Tests

- `mapoi_server/test/test_nav_server_unit.cpp`: `HasLandmarkTagDetection` (4 cases) と `SelectInitialPosePoisExcludesLandmark` を追加。10/10 pass
- `mapoi_webui/tests/web/poi-filter.test.js` (新規): `hasLandmarkTag` の 4 ケース + 各 filter 関数の 8 ケース、計 12 cases。24/24 pass

## Test plan

- [x] `colcon build --packages-select mapoi_server mapoi_rviz_plugins` 成功
- [x] `colcon test --packages-select mapoi_server` 全件 pass (gtest 10 件 + launch_test 4 件)
- [x] `cd mapoi_webui/tests/web && npm test` 全件 pass (24 件)
- [x] WebUI 動作確認: dev server 起動 → POI に landmark タグ追加 → goal / initialpose / route waypoint dropdown のいずれにも出ないこと
- [x] RViz 描画確認: landmark POI に gray 矢印 + radius 円が出ること
- [ ] turtlebot3_dqn_stage1 の `hazard_south` を WebUI から goal に設定しようとして reject されること (nav_server ERROR ログ確認)

## Notes

- `origin` の `landmark` 統合 / 削除は非破壊性を保つため本 PR では行わず、別の破壊変更 issue (#89 想定) で扱う
- color 統合 (`landmark + map_origin` で red、`landmark + hazard` で yellow 等) は #70 で別途整理する
- nav_server 側で route waypoint の landmark チェックは入れていない (issue scope 外)。WebUI candidate filter で実質ガードしているが、defense in depth が必要なら follow-up で追加可能

Close #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)