### PR TITLE
fix(test): test_mapoi_server_unit に yaml-cpp link を追加 (#149 hotfix)

### DIFF
--- a/mapoi_server/CMakeLists.txt
+++ b/mapoi_server/CMakeLists.txt
@@ -85,6 +85,9 @@ if(BUILD_TESTING)
   target_compile_definitions(test_mapoi_server_unit PRIVATE UNIT_TEST)
   # mapoi_server.cpp は yaml-cpp 依存。本体 executable と同じく test binary にも明示 link
   # (#149 で見落とし、別 PC clean build で undefined reference 発覚 → hotfix)。
+  # NOTE: humble の `ament_auto_add_gtest` 内で plain signature の target_link_libraries
+  # が使われているため、ここも plain (= PUBLIC/PRIVATE/INTERFACE 無し) で揃える必要がある。
+  # PRIVATE 化は CMake が「all-keyword or all-plain」混在を error にするため不可。
   target_link_libraries(test_mapoi_server_unit ${_mapoi_yaml_cpp_target})
 
   # Level 2: launch_testing integration tests

--- a/mapoi_server/CMakeLists.txt
+++ b/mapoi_server/CMakeLists.txt
@@ -83,6 +83,9 @@ if(BUILD_TESTING)
     src/mapoi_server.cpp
   )
   target_compile_definitions(test_mapoi_server_unit PRIVATE UNIT_TEST)
+  # mapoi_server.cpp は yaml-cpp 依存。本体 executable と同じく test binary にも明示 link
+  # (#149 で見落とし、別 PC clean build で undefined reference 発覚 → hotfix)。
+  target_link_libraries(test_mapoi_server_unit ${_mapoi_yaml_cpp_target})
 
   # Level 2: launch_testing integration tests
   add_launch_test(


### PR DESCRIPTION
## Summary

PR #149 で追加した `test_mapoi_server_unit` の `target_link_libraries` で yaml-cpp link が抜けており、clean build (`rm -rf build install log` 後) で **undefined reference to `YAML::Load(...)`** 等で link 失敗していました。

## 症状再現

別 PC (clean ws) でユーザーが下記を実行 → 失敗:
```
rm -rf build install log
colcon build --symlink-install
```
```
/usr/bin/ld: test_mapoi_server_unit.cpp:(.text+0x33):
  undefined reference to `YAML::Load(std::__cxx11::basic_string<...>)`
... (yaml-cpp の symbol 全般)
collect2: error: ld returned 1 exit status
Failed   <<< mapoi_server [51.9s, exited with code 2]
```

## 原因

`mapoi_server.cpp` は yaml-cpp 依存。本体 executable `mapoi_server` 側は `target_link_libraries(mapoi_server ${_mapoi_yaml_cpp_target})` で link されているが、test binary (= 同 `.cpp` を含む別 target) には伝播しない。

## 修正

```cmake
target_link_libraries(test_mapoi_server_unit ${_mapoi_yaml_cpp_target})
```

scope は plain (PUBLIC/PRIVATE/INTERFACE 無し)。humble の `ament_auto_add_gtest` 内で plain signature が使われているため、ここで PRIVATE を付けると CMake が「all-keyword or all-plain」混在を error にする (jazzy では通る、humble で fail を実機確認)。

## 検証

| 環境 | clean build | test | 結果 |
|---|---|---|---|
| Docker `ghcr.io/shimz-robotics/mapoi:jazzy` | `rm -rf build install log && colcon build` | 5 packages 全 success | ✅ |
| Docker `ghcr.io/shimz-robotics/mapoi:jazzy` | (上記後) `colcon test --packages-select mapoi_server` | 11 tests / 7 pass / 4 fail (#153 既知 flaky の `test_test_poi_event_integration.py` のみ、`test_mapoi_server_unit` は全 pass) | ✅ |
| Docker `ghcr.io/shimz-robotics/mapoi:humble` | `rm -rf build install log && colcon build --packages-up-to mapoi_server` | 2 packages 全 success | ✅ |
| Docker `ghcr.io/shimz-robotics/mapoi:humble` | `colcon test --packages-select mapoi_server --ctest-args -R test_mapoi_server_unit` | 12 tests / 0 fail | ✅ |

`test_nav_server_unit` 側は `mapoi_nav_server.cpp` が yaml-cpp を直接使わないため link 不要 (確認済)。

## flaky test との切り分け (review 補足)

clean build 後の `colcon test --packages-select mapoi_server` で残る fail は **`test_test_poi_event_integration.py`** のみ (= 既知 flaky #153)。本 PR の修正対象とは無関係。回帰判定時は **`test_mapoi_server_unit` の pass/fail のみを見る** こと。

🤖 Generated with [Claude Code](https://claude.com/claude-code)