### PR TITLE
feat(sample): 全パターン網羅の sample POI / route セットを整理 (#146)

### DIFF
--- a/.github/workflows/consistency-check.yml
+++ b/.github/workflows/consistency-check.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Check robot_radius drift between WebUI launch and Nav2 yaml
         run: python3 scripts/check_robot_radius_drift.py
 
+      - name: Check sample mapoi_config.yaml consistency
+        run: python3 scripts/check_sample_yaml_consistency.py
+
   webui_js_tests:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -120,6 +120,29 @@ WebUI / rviz_plugins
     ``[-π, π]`` で表現するのが慣習で、それを超えるユースケースは事実上ない想定)。
     soft warning にせず hard reject を選んだ理由は typo 防止を優先するため。
 
+Samples
+-------
+
+* Sample yaml (``turtlebot3_world`` / ``turtlebot3_dqn_stage1``) を全パターン
+  網羅シナリオに刷新 (#146)。新機能 (``route.landmarks`` #143、扇形描画 #136、
+  ``tolerance.yaw`` #138) のリグレッション検証カバレッジを底上げする。
+
+  - ``turtlebot3_world`` (オフィス見学ツアー): POI 5 → 9 に拡張。連続 ``pause``
+    (``corridor_a`` + ``corridor_b``)、撮影地点 (``conference_room`` の
+    ``tolerance.yaw=0.10``)、yaw 不問の通り過ぎ (``corridor_*`` の
+    ``tolerance.yaw=π``)、純粋 ``landmark`` / ``landmark + audio_info`` /
+    ``landmark + capture_target`` の 3 パターン、route ``tour_full``
+    (waypoints + landmarks 両方持ち) と ``tour_short`` (landmarks 省略) の対比。
+    custom tag ``capture_trigger`` / ``capture_target`` を追加。
+  - ``turtlebot3_dqn_stage1`` (障害物 sandbox での回避): POI 5 → 7 に拡張。
+    複合 tag (``event + landmark + hazard``) のハザード、``tolerance.yaw=π`` で
+    yaw 不問の通過点 (= pass_through 代替) として ``checkpoint_west/east``、
+    pause 中継 (``pause_intersection``)、route ``avoidance_a``
+    (waypoints + landmarks) と ``avoidance_b`` (waypoints のみ)。custom tag
+    ``observation`` を追加。
+  - ``mapoi_turtlebot3_example/README.md`` にサンプル一覧表 (各シナリオで
+    検証できる機能 / POI tag 構成) を追記。
+
 
 0.2.0 (2026-04-29)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -143,6 +143,22 @@ Samples
   - ``mapoi_turtlebot3_example/README.md`` にサンプル一覧表 (各シナリオで
     検証できる機能 / POI tag 構成) を追記。
 
+  **Route 名のリネーム** (旧 → 新):
+
+  - ``turtlebot3_world``: ``route_1`` → ``tour_full``、``route_2`` → ``tour_short``
+  - ``turtlebot3_dqn_stage1``: 変更なし (``avoidance_a`` / ``avoidance_b``)
+
+  ``tour_short`` は旧 ``route_2`` 互換 (``[elevator_hall, corridor_a,
+  conference_room]``) で経路は同じ。launch / クライアント / 社内スクリプトで
+  ``route_1`` / ``route_2`` を直接参照している場合は新名への移行が必要。
+  サンプル YAML の固定スナップショットを前提にした外部チュートリアル等も同様
+  (POI 数 / 名前 / tag 組合せが大幅に拡張されているため)。
+
+* ``scripts/check_sample_yaml_consistency.py`` 新設 + CI 組み込み (#146)。
+  サンプル yaml の POI 名 / route waypoint / landmark 参照の整合性、tag 排他
+  (``waypoint × landmark``、``landmark × pause``)、``tolerance.{xy,yaw}``
+  の min 制約 (>= 0.001) を pull request / push で自動検証。
+
 
 0.2.0 (2026-04-29)
 ==================

--- a/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -1,10 +1,18 @@
+# シナリオ: 障害物 sandbox での回避走行 (ハザード回避 + 観察 + 通過点)。
+# 検証カバレッジ (#146): 複合 tag (event + landmark + custom hazard)、tolerance.yaw=π で
+# yaw 不問の通過点 (= pass_through 代替)、pause 中継、route の landmarks 利用。
 custom_tags:
 - {name: hazard, description: Hazard zone (avoidance target)}
 - {name: checkpoint, description: Intermediate waypoint}
+- {name: observation, description: Observation point (landmark で参照する観察対象)}
 
 route:
+# avoidance_a: 西回り。waypoints + landmarks 両方持ちで、ハザード / 観察対象を route 走行中
+# だけ監視対象に。
 - name: avoidance_a
-  waypoints: [start_zone, checkpoint_west, north_goal]
+  waypoints: [start_zone, checkpoint_west, pause_intersection, north_goal]
+  landmarks: [hazard_south, observation_point]
+# avoidance_b: 東回り。landmarks 無しの短縮版。
 - name: avoidance_b
   waypoints: [start_zone, checkpoint_east, north_goal]
 
@@ -20,33 +28,45 @@ gazebo:
 # turtlebot3_world (office テーマ) と視覚的区別を明確にするため、obstacle 多数の sandbox world で
 # navigation 精度が要求されるシーンに合わせて配置・tolerance.xy ともに不均一化。tolerance.xy は
 # Nav2 controller の xy_goal_tolerance (0.25) より大きく取る (Nav2 が POI tolerance.xy 内に入る前
-# にゴール判定で停止し、radius event が発火しないため)。最小 0.30 (5cm 余裕)、最大 0.45 で意味付け
-# (中央 start_zone は余裕、東 checkpoint は wall 制約で最狭、南 hazard は最も広い回避ゾーン、
-# 北 north_goal は精密目標)。tolerance.yaw は 0 = 未指定で Nav2 yaw_goal_tolerance default に
-# フォールバック。yaw を厳密制御したい POI は tolerance.yaw に 0.05〜0.10 (rad) を指定する。
+# にゴール判定で停止し、radius event が発火しないため)。最小 0.30 (5cm 余裕)、最大 0.45 で意味付け。
+# tolerance.yaw は >= 0.001 (rad) を指定する (msg spec #138 で 0 / 負値は禁止)。
+# default 0.785 (≒ π/4 = 45°)、yaw 厳密目標は 0.10 (≒ 5.7°)、yaw 不問の通過点は 3.14 (≒ 180°)。
+# start_zone は POI list 先頭 (= default initial pose、#149) で Gazebo spawn の (0, 0) と一致。
 poi:
 - name: start_zone
-  description: 開始地点
+  description: 開始地点 (POI list 先頭 = default initial pose)
   pose: {x: 0.0, y: 0.0, yaw: 0.0}
   tolerance: {xy: 0.40, yaw: 0.785}
   tags: [waypoint]
 - name: checkpoint_west
-  description: 西側中継点
+  description: 西側中継点 (yaw 不問の通過点、tolerance.yaw=π)
   pose: {x: -1.6, y: 0.5, yaw: 1.57}
-  tolerance: {xy: 0.35, yaw: 0.785}
+  tolerance: {xy: 0.35, yaw: 3.14}
   tags: [waypoint, checkpoint]
 - name: checkpoint_east
-  description: 東側中継点
+  description: 東側中継点 (yaw 不問の通過点、tolerance.yaw=π)
   pose: {x: 1.4, y: -0.3, yaw: -1.6}
-  tolerance: {xy: 0.30, yaw: 0.785}
+  tolerance: {xy: 0.30, yaw: 3.14}
   tags: [waypoint, checkpoint]
+- name: pause_intersection
+  description: 交差点で自動停止 (avoidance_a の連続走行で pause 発火を検証)
+  pose: {x: -0.4, y: 1.0, yaw: 1.57}
+  tolerance: {xy: 0.30, yaw: 3.14}
+  tags: [waypoint, pause]
+- name: north_goal
+  description: 北側目標地点 (yaw 厳密)
+  pose: {x: 0.4, y: 1.7, yaw: -2.0}
+  tolerance: {xy: 0.30, yaw: 0.10}
+  tags: [waypoint]
+# 以下 landmark 群: Nav2 navigation 不可な reference 点 (#85, #143)。
+# avoidance_a の landmarks: [...] で route 走行中だけ radius event 監視対象。
 - name: hazard_south
-  description: 南側ハザード (回避対象、Nav2 goal 不可)
+  description: 南側ハザード (event + landmark + custom hazard、Nav2 goal 不可な複合 tag)
   pose: {x: 0.5, y: -1.3, yaw: 0.0}
   tolerance: {xy: 0.45, yaw: 0.785}
   tags: [event, landmark, hazard]
-- name: north_goal
-  description: 北側目標地点
-  pose: {x: 0.4, y: 1.7, yaw: -2.0}
+- name: observation_point
+  description: 観察対象 (landmark + observation、route 走行中の参照点)
+  pose: {x: -1.0, y: -0.6, yaw: 0.0}
   tolerance: {xy: 0.30, yaw: 0.785}
-  tags: [waypoint]
+  tags: [landmark, observation]

--- a/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
@@ -13,9 +13,10 @@ route:
 - name: tour_full
   waypoints: [meeting_room_a, conference_room, corridor_a, corridor_b, model_exhibit]
   landmarks: [tour_landmark, exhibit_display, capture_target_painting]
-# tour_short: landmarks 無しの短縮版。route schema が landmarks 省略でも動く検証用。
+# tour_short: landmarks 無しの短縮版 (旧 route_2 互換、corridor_a 経由)。
+# route schema が landmarks 省略でも動く検証用。
 - name: tour_short
-  waypoints: [elevator_hall, conference_room]
+  waypoints: [elevator_hall, corridor_a, conference_room]
 map:
 - {node_name: /map_server, map_file: localization.yaml}
 # mapoi_gazebo_bridge が SwitchMap 時に読む。

--- a/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_server/maps/turtlebot3_world/mapoi_config.yaml
@@ -1,15 +1,21 @@
+# シナリオ: オフィス見学ツアー (見学客を案内、要所で撮影 / 音声ガイド / 自動停止)。
+# 検証カバレッジ (#146): system tag 単独 / 複合、tolerance.yaw 厳密 ↔ 緩い、route の
+# waypoints + landmarks 両方持ち、連続 pause、撮影 / 音声 / 観察対象の custom tag。
 custom_tags:
 - {name: event, description: Event trigger area}
 - {name: destination, description: General destination point}
-- {name: audio_info, description: Audio guide trigger}
+- {name: audio_info, description: Audio guide trigger (POI 進入で音声再生)}
+- {name: capture_trigger, description: Capture action trigger (POI 進入で撮影起動)}
+- {name: capture_target, description: Capture action target (撮影対象、landmark で参照)}
 route:
-- name: route_1
-  waypoints: [meeting_room_a, conference_room, corridor_a, model_exhibit]
-  # route 走行中に意識する補助 POI 群 (#143)。Nav2 へは送らず radius 監視のみ。
-  # tour_landmark の tolerance.xy 進入で EVENT_ENTER が publish される。
-  landmarks: [tour_landmark]
-- name: route_2
-  waypoints: [elevator_hall, corridor_a, conference_room]
+# tour_full: フルツアー。waypoints + landmarks 両方を持ち、連続 pause / 撮影 / 観察対象の
+# 全シナリオを 1 route で踏む (#143 route.landmarks の動作確認用)。
+- name: tour_full
+  waypoints: [meeting_room_a, conference_room, corridor_a, corridor_b, model_exhibit]
+  landmarks: [tour_landmark, exhibit_display, capture_target_painting]
+# tour_short: landmarks 無しの短縮版。route schema が landmarks 省略でも動く検証用。
+- name: tour_short
+  waypoints: [elevator_hall, conference_room]
 map:
 - {node_name: /map_server, map_file: localization.yaml}
 # mapoi_gazebo_bridge が SwitchMap 時に読む。
@@ -18,43 +24,60 @@ gazebo:
   world_model:
     uri: model://turtlebot3_world
     name: turtlebot3_world
-# elevator_hall は POI list 先頭 (= default initial pose、#144) で、Gazebo robot spawn の
+# elevator_hall は POI list 先頭 (= default initial pose、#149) で、Gazebo robot spawn の
 # デフォルト位置 (-2, -0.5) と一致。
 # tolerance.xy は Nav2 controller の xy_goal_tolerance (0.25) より大きく取らないと、Nav2 が POI
 # tolerance.xy 内に入る前にゴール判定で停止し radius event が発火しない。最小 0.30 (5cm 余裕) で
-# 各部屋の規模感に合わせ 0.30〜0.50 にバラす。位置も grid 的整列 (-0.5 / 0.5) を少し崩して非対称に。
+# 各部屋の規模感に合わせ 0.30〜0.50 にバラす。
 # tolerance.yaw は >= 0.001 (rad) を指定する (msg spec #138 で 0 / 負値は禁止)。
-# default 0.785 (≒ π/4 = 45°)。yaw を厳密制御したい POI はより小さい値を指定する。
+# default 0.785 (≒ π/4 = 45°)。撮影位置等 yaw を厳密制御したい POI はより小さい値、
+# 通り過ぎる経由点等 yaw を問わない POI は π (≒ 180°) 近辺を指定する。
 poi:
-- description: エレベーターホール
+- description: エレベーターホール (POI list 先頭 = default initial pose)
   name: elevator_hall
   pose: {x: -2.0, y: -0.5, yaw: 0.0}
   tolerance: {xy: 0.50, yaw: 0.785}
   tags: [waypoint]
-- description: 会議室A
+- description: 会議室A (普通の経由点)
   name: meeting_room_a
   pose: {x: -0.6, y: -0.6, yaw: 0.0}
   tolerance: {xy: 0.35, yaw: 0.785}
   tags: [waypoint]
-- description: 大会議室
+- description: 大会議室 (撮影地点、yaw 厳密)
   name: conference_room
   pose: {x: 0.7, y: -0.4, yaw: 1.57}
-  tolerance: {xy: 0.45, yaw: 0.785}
-  tags: [waypoint]
-- description: 廊下
+  tolerance: {xy: 0.45, yaw: 0.10}
+  tags: [waypoint, capture_trigger]
+- description: 廊下A (連続 pause #1、yaw 不問で通り過ぎる)
   name: corridor_a
   pose: {x: 0.4, y: 0.6, yaw: -3.14}
-  tolerance: {xy: 0.30, yaw: 0.785}
+  tolerance: {xy: 0.30, yaw: 3.14}
   tags: [waypoint, pause]
-- description: 模型展示
+- description: 廊下B (連続 pause #2、tour_full で連続 pause 発火を検証)
+  name: corridor_b
+  pose: {x: 0.0, y: 0.6, yaw: -3.14}
+  tolerance: {xy: 0.30, yaw: 3.14}
+  tags: [waypoint, pause]
+- description: 模型展示 (音声ガイド再生、waypoint + custom tag)
   name: model_exhibit
   pose: {x: -0.5, y: 0.5, yaw: -1.57}
   tolerance: {xy: 0.40, yaw: 0.785}
   tags: [waypoint, audio_info]
-# tour_landmark は landmark タグ付き = Nav2 navigation 不可な reference 点 (#85, #143)。
-# route_1 の landmarks: [tour_landmark] で route 走行中だけ radius event 監視対象として扱う。
-- description: ツアー中の観察点 (route_1 の通り道に置いた展示物想定)
+# 以下 landmark 群: Nav2 navigation 不可な reference 点 (#85, #143)。
+# tour_full の landmarks: [...] で route 走行中だけ radius event 監視対象として扱う。
+# landmark × pause は排他 (#143 validation で reject) なので組み合わせない。
+- description: 観察点 (純粋 landmark、tag 単独)
   name: tour_landmark
   pose: {x: 0.0, y: 0.2, yaw: 0.0}
   tolerance: {xy: 0.30, yaw: 0.785}
   tags: [landmark]
+- description: 展示物 (landmark + audio_info、観察対象でガイド再生)
+  name: exhibit_display
+  pose: {x: -0.3, y: 0.3, yaw: 0.0}
+  tolerance: {xy: 0.30, yaw: 0.785}
+  tags: [landmark, audio_info]
+- description: 絵画 (landmark + capture_target、撮影アクションの対象として参照)
+  name: capture_target_painting
+  pose: {x: 0.6, y: 0.0, yaw: 1.57}
+  tolerance: {xy: 0.30, yaw: 0.785}
+  tags: [landmark, capture_target]

--- a/mapoi_turtlebot3_example/README.md
+++ b/mapoi_turtlebot3_example/README.md
@@ -137,7 +137,7 @@ ros2 run mapoi_turtlebot3_example get_pois_info_client
 
 | POI | tags | 役割 |
 | --- | --- | --- |
-| `start_zone` | `waypoint` | POI list 先頭 = default initial pose |
+| `start_zone` | `waypoint` | POI list 先頭 = default initial pose (#149) |
 | `checkpoint_west` | `waypoint`, `checkpoint` | yaw 不問の通過点 (`tolerance.yaw=π`) |
 | `checkpoint_east` | `waypoint`, `checkpoint` | yaw 不問の通過点 (`tolerance.yaw=π`) |
 | `pause_intersection` | `waypoint`, `pause` | 交差点で自動停止 |

--- a/mapoi_turtlebot3_example/README.md
+++ b/mapoi_turtlebot3_example/README.md
@@ -110,9 +110,41 @@ ros2 run mapoi_turtlebot3_example get_pois_info_client
 
 ## サンプル地図
 
-| 地図名 | 説明 |
-| --- | --- |
-| `turtlebot3_world` | TurtleBot3 標準ワールドの地図（POI・ルート設定済み） |
-| `turtlebot3_dqn_stage1` | DQN ステージ1 の地図 |
+シナリオに即した POI 配置 + tag 組合せの全パターンをカバーする 2 サンプルを同梱しています (#146)。
+
+| 地図名 | シナリオ | 検証できる主な機能 |
+| --- | --- | --- |
+| `turtlebot3_world` | オフィス見学ツアー (見学客を案内、要所で撮影 / 音声ガイド / 自動停止) | system tag 単独 / 複合、`tolerance.yaw` 厳密 ↔ 緩い、`route.waypoints + landmarks` 両方持ち、連続 `pause`、撮影 / 音声 / 観察対象の custom tag |
+| `turtlebot3_dqn_stage1` | 障害物 sandbox での回避走行 (ハザード / 観察 / 通過点) | 複合 tag (`event + landmark + custom`)、`tolerance.yaw=π` で yaw 不問の通過点 (= pass_through 代替)、`pause` 中継、`route.landmarks` の利用 |
+
+### POI / tag 構成
+
+#### turtlebot3_world (route: `tour_full` / `tour_short`)
+
+| POI | tags | 役割 |
+| --- | --- | --- |
+| `elevator_hall` | `waypoint` | POI list 先頭 = default initial pose (#149) |
+| `meeting_room_a` | `waypoint` | 普通の経由点 |
+| `conference_room` | `waypoint`, `capture_trigger` | 撮影地点、`tolerance.yaw=0.10` で厳密 |
+| `corridor_a` | `waypoint`, `pause` | 連続 `pause` #1、`tolerance.yaw=π` で通り過ぎ |
+| `corridor_b` | `waypoint`, `pause` | 連続 `pause` #2 (`tour_full` で連続 pause 発火を検証) |
+| `model_exhibit` | `waypoint`, `audio_info` | 音声ガイド再生 (waypoint + custom tag) |
+| `tour_landmark` | `landmark` | 純粋 landmark (tag 単独) |
+| `exhibit_display` | `landmark`, `audio_info` | 観察対象でガイド再生 |
+| `capture_target_painting` | `landmark`, `capture_target` | 撮影アクションの対象として参照 |
+
+#### turtlebot3_dqn_stage1 (route: `avoidance_a` / `avoidance_b`)
+
+| POI | tags | 役割 |
+| --- | --- | --- |
+| `start_zone` | `waypoint` | POI list 先頭 = default initial pose |
+| `checkpoint_west` | `waypoint`, `checkpoint` | yaw 不問の通過点 (`tolerance.yaw=π`) |
+| `checkpoint_east` | `waypoint`, `checkpoint` | yaw 不問の通過点 (`tolerance.yaw=π`) |
+| `pause_intersection` | `waypoint`, `pause` | 交差点で自動停止 |
+| `north_goal` | `waypoint` | 北側目標、`tolerance.yaw=0.10` で厳密 |
+| `hazard_south` | `event`, `landmark`, `hazard` | 複合 tag のハザード (Nav2 goal 不可) |
+| `observation_point` | `landmark`, `observation` | 観察対象 (route 走行中の参照点) |
+
+> **NOTE**: `landmark × pause` は #143 validation で reject されるため組み合わせていません。
 
 参考: [TurtleBot3 E-Manual (Simulation)](https://emanual.robotis.com/docs/en/platform/turtlebot3/simulation/)

--- a/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -1,10 +1,18 @@
+# シナリオ: 障害物 sandbox での回避走行 (ハザード回避 + 観察 + 通過点)。
+# 検証カバレッジ (#146): 複合 tag (event + landmark + custom hazard)、tolerance.yaw=π で
+# yaw 不問の通過点 (= pass_through 代替)、pause 中継、route の landmarks 利用。
 custom_tags:
 - {name: hazard, description: Hazard zone (avoidance target)}
 - {name: checkpoint, description: Intermediate waypoint}
+- {name: observation, description: Observation point (landmark で参照する観察対象)}
 
 route:
+# avoidance_a: 西回り。waypoints + landmarks 両方持ちで、ハザード / 観察対象を route 走行中
+# だけ監視対象に。
 - name: avoidance_a
-  waypoints: [start_zone, checkpoint_west, north_goal]
+  waypoints: [start_zone, checkpoint_west, pause_intersection, north_goal]
+  landmarks: [hazard_south, observation_point]
+# avoidance_b: 東回り。landmarks 無しの短縮版。
 - name: avoidance_b
   waypoints: [start_zone, checkpoint_east, north_goal]
 
@@ -20,33 +28,45 @@ gazebo:
 # turtlebot3_world (office テーマ) と視覚的区別を明確にするため、obstacle 多数の sandbox world で
 # navigation 精度が要求されるシーンに合わせて配置・tolerance.xy ともに不均一化。tolerance.xy は
 # Nav2 controller の xy_goal_tolerance (0.25) より大きく取る (Nav2 が POI tolerance.xy 内に入る前
-# にゴール判定で停止し、radius event が発火しないため)。最小 0.30 (5cm 余裕)、最大 0.45 で意味付け
-# (中央 start_zone は余裕、東 checkpoint は wall 制約で最狭、南 hazard は最も広い回避ゾーン、
-# 北 north_goal は精密目標)。tolerance.yaw は >= 0.001 (rad) を指定する (msg spec #138 で
-# 0 / 負値は禁止)。default 0.785 (≒ π/4 = 45°)。yaw を厳密制御したい POI はより小さい値を指定する。
+# にゴール判定で停止し、radius event が発火しないため)。最小 0.30 (5cm 余裕)、最大 0.45 で意味付け。
+# tolerance.yaw は >= 0.001 (rad) を指定する (msg spec #138 で 0 / 負値は禁止)。
+# default 0.785 (≒ π/4 = 45°)、yaw 厳密目標は 0.10 (≒ 5.7°)、yaw 不問の通過点は 3.14 (≒ 180°)。
+# start_zone は POI list 先頭 (= default initial pose、#149) で Gazebo spawn の (0, 0) と一致。
 poi:
 - name: start_zone
-  description: 開始地点
+  description: 開始地点 (POI list 先頭 = default initial pose)
   pose: {x: 0.0, y: 0.0, yaw: 0.0}
   tolerance: {xy: 0.40, yaw: 0.785}
   tags: [waypoint]
 - name: checkpoint_west
-  description: 西側中継点
+  description: 西側中継点 (yaw 不問の通過点、tolerance.yaw=π)
   pose: {x: -1.6, y: 0.5, yaw: 1.57}
-  tolerance: {xy: 0.35, yaw: 0.785}
+  tolerance: {xy: 0.35, yaw: 3.14}
   tags: [waypoint, checkpoint]
 - name: checkpoint_east
-  description: 東側中継点
+  description: 東側中継点 (yaw 不問の通過点、tolerance.yaw=π)
   pose: {x: 1.4, y: -0.3, yaw: -1.6}
-  tolerance: {xy: 0.30, yaw: 0.785}
+  tolerance: {xy: 0.30, yaw: 3.14}
   tags: [waypoint, checkpoint]
+- name: pause_intersection
+  description: 交差点で自動停止 (avoidance_a の連続走行で pause 発火を検証)
+  pose: {x: -0.4, y: 1.0, yaw: 1.57}
+  tolerance: {xy: 0.30, yaw: 3.14}
+  tags: [waypoint, pause]
+- name: north_goal
+  description: 北側目標地点 (yaw 厳密)
+  pose: {x: 0.4, y: 1.7, yaw: -2.0}
+  tolerance: {xy: 0.30, yaw: 0.10}
+  tags: [waypoint]
+# 以下 landmark 群: Nav2 navigation 不可な reference 点 (#85, #143)。
+# avoidance_a の landmarks: [...] で route 走行中だけ radius event 監視対象。
 - name: hazard_south
-  description: 南側ハザード (回避対象、Nav2 goal 不可)
+  description: 南側ハザード (event + landmark + custom hazard、Nav2 goal 不可な複合 tag)
   pose: {x: 0.5, y: -1.3, yaw: 0.0}
   tolerance: {xy: 0.45, yaw: 0.785}
   tags: [event, landmark, hazard]
-- name: north_goal
-  description: 北側目標地点
-  pose: {x: 0.4, y: 1.7, yaw: -2.0}
+- name: observation_point
+  description: 観察対象 (landmark + observation、route 走行中の参照点)
+  pose: {x: -1.0, y: -0.6, yaw: 0.0}
   tolerance: {xy: 0.30, yaw: 0.785}
-  tags: [waypoint]
+  tags: [landmark, observation]

--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -1,15 +1,21 @@
+# シナリオ: オフィス見学ツアー (見学客を案内、要所で撮影 / 音声ガイド / 自動停止)。
+# 検証カバレッジ (#146): system tag 単独 / 複合、tolerance.yaw 厳密 ↔ 緩い、route の
+# waypoints + landmarks 両方持ち、連続 pause、撮影 / 音声 / 観察対象の custom tag。
 custom_tags:
 - {name: event, description: Event trigger area}
 - {name: destination, description: General destination point}
-- {name: audio_info, description: Audio guide trigger}
+- {name: audio_info, description: Audio guide trigger (POI 進入で音声再生)}
+- {name: capture_trigger, description: Capture action trigger (POI 進入で撮影起動)}
+- {name: capture_target, description: Capture action target (撮影対象、landmark で参照)}
 route:
-- name: route_1
-  waypoints: [meeting_room_a, conference_room, corridor_a, model_exhibit]
-  # route 走行中に意識する補助 POI 群 (#143)。Nav2 へは送らず radius 監視のみ。
-  # tour_landmark の tolerance.xy 進入で EVENT_ENTER が publish される。
-  landmarks: [tour_landmark]
-- name: route_2
-  waypoints: [elevator_hall, corridor_a, conference_room]
+# tour_full: フルツアー。waypoints + landmarks 両方を持ち、連続 pause / 撮影 / 観察対象の
+# 全シナリオを 1 route で踏む (#143 route.landmarks の動作確認用)。
+- name: tour_full
+  waypoints: [meeting_room_a, conference_room, corridor_a, corridor_b, model_exhibit]
+  landmarks: [tour_landmark, exhibit_display, capture_target_painting]
+# tour_short: landmarks 無しの短縮版。route schema が landmarks 省略でも動く検証用。
+- name: tour_short
+  waypoints: [elevator_hall, conference_room]
 map:
 - {node_name: /map_server, map_file: turtlebot3.yaml}
 # mapoi_gazebo_bridge が SwitchMap 時に読む。
@@ -18,43 +24,60 @@ gazebo:
   world_model:
     uri: model://turtlebot3_world
     name: turtlebot3_world
-# elevator_hall は POI list 先頭 (= default initial pose、#144) で、Gazebo robot spawn の
+# elevator_hall は POI list 先頭 (= default initial pose、#149) で、Gazebo robot spawn の
 # デフォルト位置 (-2, -0.5) と一致。
 # tolerance.xy は Nav2 controller の xy_goal_tolerance (0.25) より大きく取らないと、Nav2 が POI
 # tolerance.xy 内に入る前にゴール判定で停止し radius event が発火しない。最小 0.30 (5cm 余裕) で
-# 各部屋の規模感に合わせ 0.30〜0.50 にバラす。位置も grid 的整列 (-0.5 / 0.5) を少し崩して非対称に。
+# 各部屋の規模感に合わせ 0.30〜0.50 にバラす。
 # tolerance.yaw は >= 0.001 (rad) を指定する (msg spec #138 で 0 / 負値は禁止)。
-# default 0.785 (≒ π/4 = 45°)。yaw を厳密制御したい POI はより小さい値を指定する。
+# default 0.785 (≒ π/4 = 45°)。撮影位置等 yaw を厳密制御したい POI はより小さい値、
+# 通り過ぎる経由点等 yaw を問わない POI は π (≒ 180°) 近辺を指定する。
 poi:
-- description: エレベーターホール
+- description: エレベーターホール (POI list 先頭 = default initial pose)
   name: elevator_hall
   pose: {x: -2.0, y: -0.5, yaw: 0.0}
   tolerance: {xy: 0.50, yaw: 0.785}
   tags: [waypoint]
-- description: 会議室A
+- description: 会議室A (普通の経由点)
   name: meeting_room_a
   pose: {x: -0.6, y: -0.6, yaw: 0.0}
   tolerance: {xy: 0.35, yaw: 0.785}
   tags: [waypoint]
-- description: 大会議室
+- description: 大会議室 (撮影地点、yaw 厳密)
   name: conference_room
   pose: {x: 0.7, y: -0.4, yaw: 1.57}
-  tolerance: {xy: 0.45, yaw: 0.785}
-  tags: [waypoint]
-- description: 廊下
+  tolerance: {xy: 0.45, yaw: 0.10}
+  tags: [waypoint, capture_trigger]
+- description: 廊下A (連続 pause #1、yaw 不問で通り過ぎる)
   name: corridor_a
   pose: {x: 0.4, y: 0.6, yaw: -3.14}
-  tolerance: {xy: 0.30, yaw: 0.785}
+  tolerance: {xy: 0.30, yaw: 3.14}
   tags: [waypoint, pause]
-- description: 模型展示
+- description: 廊下B (連続 pause #2、tour_full で連続 pause 発火を検証)
+  name: corridor_b
+  pose: {x: 0.0, y: 0.6, yaw: -3.14}
+  tolerance: {xy: 0.30, yaw: 3.14}
+  tags: [waypoint, pause]
+- description: 模型展示 (音声ガイド再生、waypoint + custom tag)
   name: model_exhibit
   pose: {x: -0.5, y: 0.5, yaw: -1.57}
   tolerance: {xy: 0.40, yaw: 0.785}
   tags: [waypoint, audio_info]
-# tour_landmark は landmark タグ付き = Nav2 navigation 不可な reference 点 (#85, #143)。
-# route_1 の landmarks: [tour_landmark] で route 走行中だけ radius event 監視対象として扱う。
-- description: ツアー中の観察点 (route_1 の通り道に置いた展示物想定)
+# 以下 landmark 群: Nav2 navigation 不可な reference 点 (#85, #143)。
+# tour_full の landmarks: [...] で route 走行中だけ radius event 監視対象として扱う。
+# landmark × pause は排他 (#143 validation で reject) なので組み合わせない。
+- description: 観察点 (純粋 landmark、tag 単独)
   name: tour_landmark
   pose: {x: 0.0, y: 0.2, yaw: 0.0}
   tolerance: {xy: 0.30, yaw: 0.785}
   tags: [landmark]
+- description: 展示物 (landmark + audio_info、観察対象でガイド再生)
+  name: exhibit_display
+  pose: {x: -0.3, y: 0.3, yaw: 0.0}
+  tolerance: {xy: 0.30, yaw: 0.785}
+  tags: [landmark, audio_info]
+- description: 絵画 (landmark + capture_target、撮影アクションの対象として参照)
+  name: capture_target_painting
+  pose: {x: 0.6, y: 0.0, yaw: 1.57}
+  tolerance: {xy: 0.30, yaw: 0.785}
+  tags: [landmark, capture_target]

--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -13,9 +13,10 @@ route:
 - name: tour_full
   waypoints: [meeting_room_a, conference_room, corridor_a, corridor_b, model_exhibit]
   landmarks: [tour_landmark, exhibit_display, capture_target_painting]
-# tour_short: landmarks 無しの短縮版。route schema が landmarks 省略でも動く検証用。
+# tour_short: landmarks 無しの短縮版 (旧 route_2 互換、corridor_a 経由)。
+# route schema が landmarks 省略でも動く検証用。
 - name: tour_short
-  waypoints: [elevator_hall, conference_room]
+  waypoints: [elevator_hall, corridor_a, conference_room]
 map:
 - {node_name: /map_server, map_file: turtlebot3.yaml}
 # mapoi_gazebo_bridge が SwitchMap 時に読む。

--- a/scripts/check_sample_yaml_consistency.py
+++ b/scripts/check_sample_yaml_consistency.py
@@ -182,8 +182,9 @@ def main() -> int:
         if not example_path.exists():
             issues.append(f'sample yaml が存在しない: {example_path.relative_to(REPO_ROOT)}')
             continue
-        for path in (server_path, example_path):
-            issues.extend(_validate_single(path, _load(path)))
+        # server を代表として individual validation。example 側は同期 check に
+        # 委ねる (両方を走らせると同一違反を 2 重 report してしまうため)。
+        issues.extend(_validate_single(server_path, _load(server_path)))
         issues.extend(_validate_pair_sync(server_path, example_path))
 
     if issues:

--- a/scripts/check_sample_yaml_consistency.py
+++ b/scripts/check_sample_yaml_consistency.py
@@ -6,11 +6,18 @@ mapoi_server / mapoi_turtlebot3_example 配下の同名サンプル yaml は ``m
 
 - POI 名のユニーク性
 - ``route.waypoints`` / ``route.landmarks`` が POI 一覧に存在する
+- ``route.waypoints`` の参照 POI は ``waypoint`` タグ持ち、``route.landmarks``
+  の参照 POI は ``landmark`` タグ持ち (タグと route 用途のミスマッチを検出)
 - tag 排他 (``waypoint × landmark``、``landmark × pause``、#85 / #143)
 - ``tolerance.{xy,yaw}`` の範囲制約 (>= 0.001、yaw <= 2π、#138 / #158)
 - ``poi`` 配列の先頭が ``landmark`` ではなく pose 完備 (= default initial pose、#149)
 
 CI で本 script を回し、上記いずれかが破れたら fail させる。
+
+**スコープ**: 本 script はサンプル yaml のドリフト防止を目的とした **軽量バリ
+データ** で、``mapoi_server`` の yaml load (C++ 側) や ``mapoi_webui_node`` の
+backend validation の網羅的レプリカではない。``map`` block / ``gazebo`` block
+の妥当性、custom_tags 名規約、pose 数値の物理的妥当性などはチェックしない。
 
 使い方::
     python3 scripts/check_sample_yaml_consistency.py
@@ -109,6 +116,11 @@ def _validate_single(path: Path, data: dict) -> list[str]:
             f'(#149 default initial pose 採用条件に違反)'
         )
 
+    poi_tags = {
+        poi['name']: [str(t).lower() for t in (poi.get('tags') or [])]
+        for poi in pois
+        if isinstance(poi, dict) and isinstance(poi.get('name'), str)
+    }
     routes = data.get('route') or []
     if isinstance(routes, list):
         route_names_seen: set[str] = set()
@@ -123,7 +135,7 @@ def _validate_single(path: Path, data: dict) -> list[str]:
             if rname in route_names_seen:
                 issues.append(f'{rel}: route 名 "{rname}" が重複している')
             route_names_seen.add(rname)
-            for field in ('waypoints', 'landmarks'):
+            for field, expected_tag in (('waypoints', 'waypoint'), ('landmarks', 'landmark')):
                 refs = route.get(field) or []
                 if not isinstance(refs, list):
                     issues.append(f'{rel}: route "{rname}" の {field} が list ではない')
@@ -132,6 +144,12 @@ def _validate_single(path: Path, data: dict) -> list[str]:
                     if ref not in names_seen:
                         issues.append(
                             f'{rel}: route "{rname}" の {field} が未定義 POI を参照: "{ref}"'
+                        )
+                        continue
+                    if expected_tag not in poi_tags.get(ref, []):
+                        issues.append(
+                            f'{rel}: route "{rname}" の {field} に列挙された POI "{ref}" に '
+                            f'"{expected_tag}" タグがない (route 用途と tag のミスマッチ)'
                         )
 
     return issues

--- a/scripts/check_sample_yaml_consistency.py
+++ b/scripts/check_sample_yaml_consistency.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""sample mapoi_config.yaml の整合性を検査する (#146 / PR #160 review follow-up)。
+
+mapoi_server / mapoi_turtlebot3_example 配下の同名サンプル yaml は ``map_file``
+行を除いて同期している必要がある。また個別 yaml も以下を満たすべき:
+
+- POI 名のユニーク性
+- ``route.waypoints`` / ``route.landmarks`` が POI 一覧に存在する
+- tag 排他 (``waypoint × landmark``、``landmark × pause``、#85 / #143)
+- ``tolerance.{xy,yaw}`` の範囲制約 (>= 0.001、yaw <= 2π、#138 / #158)
+- ``poi`` 配列の先頭が ``landmark`` ではなく pose 完備 (= default initial pose、#149)
+
+CI で本 script を回し、上記いずれかが破れたら fail させる。
+
+使い方::
+    python3 scripts/check_sample_yaml_consistency.py
+
+Exit codes:
+- 0: OK
+- 1: 整合性違反を検出 / yaml 構造異常
+"""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SAMPLE_PAIRS = [
+    (
+        REPO_ROOT / 'mapoi_server' / 'maps' / 'turtlebot3_world' / 'mapoi_config.yaml',
+        REPO_ROOT / 'mapoi_turtlebot3_example' / 'maps' / 'turtlebot3_world' / 'mapoi_config.yaml',
+    ),
+    (
+        REPO_ROOT / 'mapoi_server' / 'maps' / 'turtlebot3_dqn_stage1' / 'mapoi_config.yaml',
+        REPO_ROOT / 'mapoi_turtlebot3_example' / 'maps' / 'turtlebot3_dqn_stage1' / 'mapoi_config.yaml',
+    ),
+]
+
+TOL_MIN = 0.001
+TOL_YAW_MAX = 2 * math.pi
+
+
+def _load(path: Path) -> dict:
+    with path.open() as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise SystemExit(f'ERROR: {path} の top level が dict ではない: {type(data).__name__}')
+    return data
+
+
+def _validate_single(path: Path, data: dict) -> list[str]:
+    issues: list[str] = []
+    rel = path.relative_to(REPO_ROOT)
+
+    pois = data.get('poi') or []
+    if not isinstance(pois, list) or not pois:
+        issues.append(f'{rel}: "poi" 配列が空または存在しない')
+        return issues
+
+    names_seen: set[str] = set()
+    for i, poi in enumerate(pois):
+        if not isinstance(poi, dict):
+            issues.append(f'{rel}: poi[{i}] が object ではない')
+            continue
+        name = poi.get('name')
+        if not isinstance(name, str) or not name:
+            issues.append(f'{rel}: poi[{i}] に有効な "name" がない')
+            continue
+        if name in names_seen:
+            issues.append(f'{rel}: POI 名 "{name}" が重複している')
+        names_seen.add(name)
+
+        tags = poi.get('tags') or []
+        tags_l = [str(t).lower() for t in tags] if isinstance(tags, list) else []
+        if 'waypoint' in tags_l and 'landmark' in tags_l:
+            issues.append(f'{rel}: POI "{name}" に "waypoint" と "landmark" を併用 (#85 排他)')
+        if 'pause' in tags_l and 'landmark' in tags_l:
+            issues.append(f'{rel}: POI "{name}" に "pause" と "landmark" を併用 (#143 排他)')
+
+        tol = poi.get('tolerance')
+        if not isinstance(tol, dict):
+            issues.append(f'{rel}: POI "{name}" の "tolerance" が dict ではない')
+        else:
+            for key, max_value in (('xy', None), ('yaw', TOL_YAW_MAX)):
+                v = tol.get(key)
+                if not isinstance(v, (int, float)) or isinstance(v, bool):
+                    issues.append(f'{rel}: POI "{name}" tolerance.{key} が数値ではない: {v!r}')
+                    continue
+                fv = float(v)
+                if not math.isfinite(fv) or fv < TOL_MIN:
+                    issues.append(
+                        f'{rel}: POI "{name}" tolerance.{key} = {fv} が下限 {TOL_MIN} 未満'
+                    )
+                if max_value is not None and fv > max_value:
+                    issues.append(
+                        f'{rel}: POI "{name}" tolerance.{key} = {fv} が上限 {max_value:.6f} 超過'
+                    )
+
+    first = pois[0] if isinstance(pois[0], dict) else {}
+    first_tags = [str(t).lower() for t in (first.get('tags') or [])]
+    if 'landmark' in first_tags:
+        issues.append(
+            f'{rel}: POI list 先頭 "{first.get("name", "?")}" が landmark タグ持ち '
+            f'(#149 default initial pose 採用条件に違反)'
+        )
+
+    routes = data.get('route') or []
+    if isinstance(routes, list):
+        route_names_seen: set[str] = set()
+        for i, route in enumerate(routes):
+            if not isinstance(route, dict):
+                issues.append(f'{rel}: route[{i}] が object ではない')
+                continue
+            rname = route.get('name')
+            if not isinstance(rname, str) or not rname:
+                issues.append(f'{rel}: route[{i}] に有効な "name" がない')
+                continue
+            if rname in route_names_seen:
+                issues.append(f'{rel}: route 名 "{rname}" が重複している')
+            route_names_seen.add(rname)
+            for field in ('waypoints', 'landmarks'):
+                refs = route.get(field) or []
+                if not isinstance(refs, list):
+                    issues.append(f'{rel}: route "{rname}" の {field} が list ではない')
+                    continue
+                for ref in refs:
+                    if ref not in names_seen:
+                        issues.append(
+                            f'{rel}: route "{rname}" の {field} が未定義 POI を参照: "{ref}"'
+                        )
+
+    return issues
+
+
+def _validate_pair_sync(server_path: Path, example_path: Path) -> list[str]:
+    issues: list[str] = []
+    server = _load(server_path)
+    example = _load(example_path)
+
+    rel_s = server_path.relative_to(REPO_ROOT)
+    rel_e = example_path.relative_to(REPO_ROOT)
+
+    for key in ('custom_tags', 'route', 'gazebo', 'poi'):
+        if server.get(key) != example.get(key):
+            issues.append(
+                f'{rel_s} と {rel_e} の "{key}" が同期していない '
+                f'(server / example で同一であるべき)'
+            )
+    return issues
+
+
+def main() -> int:
+    issues: list[str] = []
+
+    for server_path, example_path in SAMPLE_PAIRS:
+        if not server_path.exists():
+            issues.append(f'sample yaml が存在しない: {server_path.relative_to(REPO_ROOT)}')
+            continue
+        if not example_path.exists():
+            issues.append(f'sample yaml が存在しない: {example_path.relative_to(REPO_ROOT)}')
+            continue
+        for path in (server_path, example_path):
+            issues.extend(_validate_single(path, _load(path)))
+        issues.extend(_validate_pair_sync(server_path, example_path))
+
+    if issues:
+        print('sample yaml consistency check failed:', file=sys.stderr)
+        for i in issues:
+            print(f'  - {i}', file=sys.stderr)
+        return 1
+
+    print(f'OK: {len(SAMPLE_PAIRS)} sample yaml pair(s) are consistent.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

新機能 (route.landmarks #143、扇形描画 #136、tolerance.yaw #138) のリグレッション検証カバレッジを底上げするため、sample yaml 2 セットをシナリオベースで刷新する。

- **turtlebot3_world** (オフィス見学ツアー、5 → 9 POI)
- **turtlebot3_dqn_stage1** (障害物 sandbox、5 → 7 POI)

## 検証カバレッジ (Issue #146 の不足項目を網羅)

| 項目 | 実装場所 |
|---|---|
| `landmark` 単独 (純粋 reference 点) | `tour_landmark` |
| `landmark + audio_info` (観察対象でガイド再生) | `exhibit_display` |
| `landmark + capture_target` (custom tag 連動) | `capture_target_painting` |
| route の `landmarks` field (#143) | `tour_full` / `avoidance_a` |
| `tolerance.yaw` 厳密 (0.10) | `conference_room` / `north_goal` |
| `tolerance.yaw` 緩い (default 0.785) | 多数 |
| `tolerance.yaw=π` (yaw 不問、pass_through 代替) | `corridor_a/b` / `checkpoint_west/east` / `pause_intersection` |
| 撮影 / 音声 / pause の custom tag シナリオ | `capture_trigger` / `audio_info` / `pause` |
| 複合 tag (`event + landmark + hazard`) | `hazard_south` |
| 連続 `pause` POI を持つ route | `tour_full` (`corridor_a` → `corridor_b`) |
| POI list 先頭 = default initial pose (#149) | `elevator_hall` / `start_zone` |

## 変更内容

- `mapoi_server/maps/turtlebot3_world/mapoi_config.yaml`: 5 → 9 POI
- `mapoi_server/maps/turtlebot3_dqn_stage1/mapoi_config.yaml`: 5 → 7 POI
- `mapoi_turtlebot3_example/maps/...` 同上 2 セット (server と内容同期、map_file 名のみ差分)
- `mapoi_turtlebot3_example/README.md`: サンプル一覧表 + POI tag 構成表を追記
- `CHANGELOG.rst`: Unreleased に Samples セクション新設

## 設計メモ

- `landmark × pause` は #143 validation で reject されるため組み合わせていない
- `landmark × waypoint` も同様 (#85 排他)
- POI list 先頭は landmark を避けて `waypoint` 単独で配置 (default initial pose 採用条件)
- `tolerance.xy` は Nav2 controller の `xy_goal_tolerance` (0.25) より大きく取る慣例を維持

## Test plan

- [x] yaml 構文 + 整合性 (POI 名 / route waypoint / landmark 参照、tag 排他、tolerance >= 0.001) を Python で検証
- [x] Docker (`mapoi-dev-jazzy`) で `mapoi_server` 起動 → `get_pois_info` / `get_routes_info` レスポンスが新 POI 構成を返す確認
- [x] `Published initial pose POI name 'elevator_hall' / 'start_zone'` log で POI list 先頭採用 (#149) が機能している確認
- [ ] WebUI / RViz Panel で POI / route 一覧表示の visual 確認 (post-merge)
- [ ] フル launch (`turtlebot3_navigation.launch.yaml`) で route 走行 + 連続 pause / capture_trigger 発火の動作確認 (post-merge)

## 関連

Close #146

関連 issue: #143 (route.landmarks)、#138 (tolerance.yaw)、#149 (initial_pose 廃止 + POI list 先頭 default)、#136 (扇形描画)

🤖 Generated with [Claude Code](https://claude.com/claude-code)