### PR TITLE
test(nav_server): route lifecycle / pause scope の C++ unit test を整備 (#148)

### DIFF
--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -181,7 +181,6 @@ private:
   // landmark POI は Nav2 navigation goal / initial_pose に使えない reference 専用。
   static bool has_landmark_tag(const mapoi_interfaces::msg::PointOfInterest & poi);
 
-public:
   // active route の POI 名集合を組み立てる純関数 (#143 / #148)。
   // waypoints と landmarks の両方を 1 つの set にマージし、radius_check の
   // pause 発火条件 (active route POI に含まれるか) を判定する用に使う。
@@ -193,12 +192,12 @@ public:
   // pause 自動発火の eligibility 判定純関数 (#143 / #148)。
   // ROUTE 走行中 + active route POI + "pause" タグありの 3 条件を全て満たす場合のみ true。
   // GOAL 走行中 / IDLE では false (操作者の意図しない停止を避けるため、route POI 限定)。
+  // **lock 契約**: `current_route_poi_names_` をそのまま渡す呼び出しでは、参照が
+  // 安定するように `data_mutex_` を保持中に呼ぶこと。snapshot を渡す場合は不要。
   static bool is_pause_eligible(
     const mapoi_interfaces::msg::PointOfInterest & poi,
     NavMode nav_mode,
     const std::unordered_set<std::string> & active_route_poi_names);
-
-private:
 
   // /initialpose 配信の単一エントリポイント（手動経路 / 自動経路で共通化）。
   // publish 直後に subscriber が居なければ非同期で retry timer を起動する。
@@ -228,9 +227,16 @@ private:
   FRIEND_TEST(NavServerTestFixture, RebuildEventPoisEmpty);
   FRIEND_TEST(NavServerTestFixture, PauseTagDetection);
   FRIEND_TEST(NavServerTestFixture, HasLandmarkTagDetection);
-  // ResetNavState は private member (reset_nav_state, current_route_poi_names_,
-  // nav_mode_) を直接覗くので FRIEND_TEST 必須。build_route_poi_names /
-  // is_pause_eligible は public static なので FRIEND_TEST 不要。
+  FRIEND_TEST(NavServerTestFixture, BuildRoutePoiNamesWaypointsOnly);
+  FRIEND_TEST(NavServerTestFixture, BuildRoutePoiNamesWaypointsAndLandmarks);
+  FRIEND_TEST(NavServerTestFixture, BuildRoutePoiNamesLandmarksEmptyBackwardCompat);
+  FRIEND_TEST(NavServerTestFixture, BuildRoutePoiNamesEmpty);
+  FRIEND_TEST(NavServerTestFixture, BuildRoutePoiNamesDuplicateNames);
+  FRIEND_TEST(NavServerTestFixture, IsPauseEligibleRouteModeActiveWithPauseTag);
+  FRIEND_TEST(NavServerTestFixture, IsPauseEligibleRouteModeActiveWithoutPauseTag);
+  FRIEND_TEST(NavServerTestFixture, IsPauseEligibleRouteModeNonActivePoi);
+  FRIEND_TEST(NavServerTestFixture, IsPauseEligibleGoalMode);
+  FRIEND_TEST(NavServerTestFixture, IsPauseEligibleIdleMode);
   FRIEND_TEST(NavServerTestFixture, ResetNavStateClearsRouteContext);
 #endif
 };

--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -181,6 +181,25 @@ private:
   // landmark POI は Nav2 navigation goal / initial_pose に使えない reference 専用。
   static bool has_landmark_tag(const mapoi_interfaces::msg::PointOfInterest & poi);
 
+public:
+  // active route の POI 名集合を組み立てる純関数 (#143 / #148)。
+  // waypoints と landmarks の両方を 1 つの set にマージし、radius_check の
+  // pause 発火条件 (active route POI に含まれるか) を判定する用に使う。
+  // 同名の重複は set 性質で自動的に 1 つに集約される。
+  static std::unordered_set<std::string> build_route_poi_names(
+    const std::vector<mapoi_interfaces::msg::PointOfInterest> & waypoints,
+    const std::vector<mapoi_interfaces::msg::PointOfInterest> & landmarks);
+
+  // pause 自動発火の eligibility 判定純関数 (#143 / #148)。
+  // ROUTE 走行中 + active route POI + "pause" タグありの 3 条件を全て満たす場合のみ true。
+  // GOAL 走行中 / IDLE では false (操作者の意図しない停止を避けるため、route POI 限定)。
+  static bool is_pause_eligible(
+    const mapoi_interfaces::msg::PointOfInterest & poi,
+    NavMode nav_mode,
+    const std::unordered_set<std::string> & active_route_poi_names);
+
+private:
+
   // /initialpose 配信の単一エントリポイント（手動経路 / 自動経路で共通化）。
   // publish 直後に subscriber が居なければ非同期で retry timer を起動する。
   void publish_initial_pose(
@@ -209,6 +228,10 @@ private:
   FRIEND_TEST(NavServerTestFixture, RebuildEventPoisEmpty);
   FRIEND_TEST(NavServerTestFixture, PauseTagDetection);
   FRIEND_TEST(NavServerTestFixture, HasLandmarkTagDetection);
+  // ResetNavState は private member (reset_nav_state, current_route_poi_names_,
+  // nav_mode_) を直接覗くので FRIEND_TEST 必須。build_route_poi_names /
+  // is_pause_eligible は public static なので FRIEND_TEST 不要。
+  FRIEND_TEST(NavServerTestFixture, ResetNavStateClearsRouteContext);
 #endif
 };
 

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -308,6 +308,39 @@ bool MapoiNavServer::has_landmark_tag(const mapoi_interfaces::msg::PointOfIntere
   return false;
 }
 
+std::unordered_set<std::string> MapoiNavServer::build_route_poi_names(
+  const std::vector<mapoi_interfaces::msg::PointOfInterest> & waypoints,
+  const std::vector<mapoi_interfaces::msg::PointOfInterest> & landmarks)
+{
+  std::unordered_set<std::string> result;
+  for (const auto & p : waypoints) {
+    result.insert(p.name);
+  }
+  for (const auto & p : landmarks) {
+    result.insert(p.name);
+  }
+  return result;
+}
+
+bool MapoiNavServer::is_pause_eligible(
+  const mapoi_interfaces::msg::PointOfInterest & poi,
+  NavMode nav_mode,
+  const std::unordered_set<std::string> & active_route_poi_names)
+{
+  if (nav_mode != NavMode::ROUTE) {
+    return false;
+  }
+  if (active_route_poi_names.count(poi.name) == 0) {
+    return false;
+  }
+  for (const auto & tag : poi.tags) {
+    if (tag == "pause") {
+      return true;
+    }
+  }
+  return false;
+}
+
 void MapoiNavServer::publish_initial_pose(
   const geometry_msgs::msg::Pose & pose, const std::string & source)
 {
@@ -450,15 +483,10 @@ void MapoiNavServer::on_route_received(
 
   // active route の POI 名 set を構築 (waypoints + landmarks 両方を radius_check で
   // pause 発火対象として扱う)。lock 下で書き込み (#143)。
+  // 構築ロジックは pure helper に切り出し、unit test で検証する (#148)。
   {
     std::lock_guard<std::mutex> lock(data_mutex_);
-    current_route_poi_names_.clear();
-    for (const auto & p : route_poi) {
-      current_route_poi_names_.insert(p.name);
-    }
-    for (const auto & p : route_landmarks) {
-      current_route_poi_names_.insert(p.name);
-    }
+    current_route_poi_names_ = build_route_poi_names(route_poi, route_landmarks);
   }
 
   current_route_waypoints_ = waypoints;
@@ -918,16 +946,9 @@ void MapoiNavServer::radius_check_callback()
       double dist = distance_2d(poi.pose, rx, ry);
       bool was_inside = poi_inside_state_[poi.name];
 
-      // pause タグを持つかつ active route の POI かを確認 (#143):
-      //   - pause 自動発火は **ROUTE 走行中の active route POI のみ** に厳格化
-      //   - 別 route で pause タグが付いた POI に偶然 ENTER しても発火しない
-      //   - GOAL 走行 / IDLE では発火しない (操作者の意図しない停止を避ける)
-      bool is_pause_poi = false;
-      if (nav_mode_ == NavMode::ROUTE && current_route_poi_names_.count(poi.name) > 0) {
-        for (const auto & tag : poi.tags) {
-          if (tag == "pause") { is_pause_poi = true; break; }
-        }
-      }
+      // pause 自動発火は ROUTE 走行中 + active route POI + "pause" タグの 3 条件 (#143)。
+      // 判定 logic は is_pause_eligible に切り出して unit test (#148)。
+      const bool is_pause_poi = is_pause_eligible(poi, nav_mode_, current_route_poi_names_);
 
       if (!was_inside && dist <= poi.tolerance.xy) {
         // ENTER event: 全POIでPoiEvent発行

--- a/mapoi_server/test/test_nav_server_unit.cpp
+++ b/mapoi_server/test/test_nav_server_unit.cpp
@@ -104,6 +104,124 @@ TEST_F(NavServerTestFixture, HasLandmarkTagDetection)
     make_poi("landmark_combo", 0.0, 0.0, 0.5, {"event", "landmark", "hazard"})));
 }
 
+// --- build_route_poi_names (#143 / #148) ---
+
+TEST_F(NavServerTestFixture, BuildRoutePoiNamesWaypointsOnly)
+{
+  auto wp1 = make_poi("wp1", 0.0, 0.0, 0.5, {"waypoint"});
+  auto wp2 = make_poi("wp2", 1.0, 0.0, 0.5, {"waypoint", "pause"});
+  auto result = MapoiNavServer::build_route_poi_names({wp1, wp2}, {});
+  EXPECT_EQ(result.size(), 2u);
+  EXPECT_EQ(result.count("wp1"), 1u);
+  EXPECT_EQ(result.count("wp2"), 1u);
+}
+
+TEST_F(NavServerTestFixture, BuildRoutePoiNamesWaypointsAndLandmarks)
+{
+  // route 受信時、waypoints と landmarks の両方が active set に入る (#143)。
+  auto wp = make_poi("wp1", 0.0, 0.0, 0.5, {"waypoint"});
+  auto lm = make_poi("lm1", 1.0, 0.0, 0.5, {"landmark"});
+  auto result = MapoiNavServer::build_route_poi_names({wp}, {lm});
+  EXPECT_EQ(result.size(), 2u);
+  EXPECT_EQ(result.count("wp1"), 1u);
+  EXPECT_EQ(result.count("lm1"), 1u);
+}
+
+TEST_F(NavServerTestFixture, BuildRoutePoiNamesLandmarksEmptyBackwardCompat)
+{
+  // 旧 yaml (route.landmarks 未指定) は landmarks empty で読まれる。waypoints のみで
+  // active set が成立し、空にならない (#143 後方互換契約)。
+  auto wp = make_poi("wp1", 0.0, 0.0, 0.5, {"waypoint"});
+  auto result = MapoiNavServer::build_route_poi_names({wp}, {});
+  EXPECT_EQ(result.size(), 1u);
+  EXPECT_EQ(result.count("wp1"), 1u);
+}
+
+TEST_F(NavServerTestFixture, BuildRoutePoiNamesEmpty)
+{
+  auto result = MapoiNavServer::build_route_poi_names({}, {});
+  EXPECT_TRUE(result.empty());
+}
+
+TEST_F(NavServerTestFixture, BuildRoutePoiNamesDuplicateNames)
+{
+  // 同名が waypoint と landmark の両方に出てきても set 性質で 1 つに集約。
+  auto wp = make_poi("dup", 0.0, 0.0, 0.5, {"waypoint"});
+  auto lm = make_poi("dup", 1.0, 0.0, 0.5, {"landmark"});
+  auto result = MapoiNavServer::build_route_poi_names({wp}, {lm});
+  EXPECT_EQ(result.size(), 1u);
+  EXPECT_EQ(result.count("dup"), 1u);
+}
+
+// --- is_pause_eligible (#143 / #148) ---
+
+TEST_F(NavServerTestFixture, IsPauseEligibleRouteModeActiveWithPauseTag)
+{
+  auto poi = make_poi("p1", 0.0, 0.0, 0.5, {"waypoint", "pause"});
+  std::unordered_set<std::string> active = {"p1"};
+  EXPECT_TRUE(MapoiNavServer::is_pause_eligible(
+    poi, MapoiNavServer::NavMode::ROUTE, active));
+}
+
+TEST_F(NavServerTestFixture, IsPauseEligibleRouteModeActiveWithoutPauseTag)
+{
+  auto poi = make_poi("p1", 0.0, 0.0, 0.5, {"waypoint"});
+  std::unordered_set<std::string> active = {"p1"};
+  EXPECT_FALSE(MapoiNavServer::is_pause_eligible(
+    poi, MapoiNavServer::NavMode::ROUTE, active));
+}
+
+TEST_F(NavServerTestFixture, IsPauseEligibleRouteModeNonActivePoi)
+{
+  // pause タグはあるが active route POI ではない (= 別 route の POI に偶然 ENTER)。
+  // 厳格化前は発火していたが #143 で発火しないようになった。
+  auto poi = make_poi("p1", 0.0, 0.0, 0.5, {"waypoint", "pause"});
+  std::unordered_set<std::string> active = {"p2"};
+  EXPECT_FALSE(MapoiNavServer::is_pause_eligible(
+    poi, MapoiNavServer::NavMode::ROUTE, active));
+}
+
+TEST_F(NavServerTestFixture, IsPauseEligibleGoalMode)
+{
+  // GOAL 走行中は pause タグ + active set 一致でも発火しない (#143)。
+  auto poi = make_poi("p1", 0.0, 0.0, 0.5, {"waypoint", "pause"});
+  std::unordered_set<std::string> active = {"p1"};
+  EXPECT_FALSE(MapoiNavServer::is_pause_eligible(
+    poi, MapoiNavServer::NavMode::GOAL, active));
+}
+
+TEST_F(NavServerTestFixture, IsPauseEligibleIdleMode)
+{
+  auto poi = make_poi("p1", 0.0, 0.0, 0.5, {"waypoint", "pause"});
+  std::unordered_set<std::string> active = {"p1"};
+  EXPECT_FALSE(MapoiNavServer::is_pause_eligible(
+    poi, MapoiNavServer::NavMode::IDLE, active));
+}
+
+// --- reset_nav_state (#143 / #148) ---
+
+TEST_F(NavServerTestFixture, ResetNavStateClearsRouteContext)
+{
+  // route 走行中に相当する状態を fixture から直接 set し、reset_nav_state() が
+  // route lifecycle 終了時 (cancel / SUCCEEDED / ABORTED / GOAL 切替) に走らせる
+  // クリーンアップ動作を再現する。
+  {
+    std::lock_guard<std::mutex> lock(node_->data_mutex_);
+    node_->current_route_poi_names_.insert("wp1");
+    node_->current_route_poi_names_.insert("lm1");
+  }
+  node_->nav_mode_ = MapoiNavServer::NavMode::ROUTE;
+  node_->is_paused_ = true;
+  node_->current_waypoint_index_ = 3;
+
+  node_->reset_nav_state();
+
+  EXPECT_TRUE(node_->current_route_poi_names_.empty());
+  EXPECT_EQ(node_->nav_mode_, MapoiNavServer::NavMode::IDLE);
+  EXPECT_FALSE(node_->is_paused_);
+  EXPECT_EQ(node_->current_waypoint_index_, 0u);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/mapoi_server/test/test_nav_server_unit.cpp
+++ b/mapoi_server/test/test_nav_server_unit.cpp
@@ -202,9 +202,11 @@ TEST_F(NavServerTestFixture, IsPauseEligibleIdleMode)
 
 TEST_F(NavServerTestFixture, ResetNavStateClearsRouteContext)
 {
-  // route 走行中に相当する状態を fixture から直接 set し、reset_nav_state() が
-  // route lifecycle 終了時 (cancel / SUCCEEDED / ABORTED / GOAL 切替) に走らせる
-  // クリーンアップ動作を再現する。
+  // route 走行中 + pause 中に相当する状態を fixture から直接 set し、
+  // reset_nav_state() が route lifecycle 終了時 (cancel / SUCCEEDED / ABORTED /
+  // GOAL 切替) に行うクリーンアップ動作を再現する。`reset_nav_state()` の
+  // 契約に含まれる全 member をまとめて検証することで、将来 reset 対象が漏れた
+  // 場合を unit test で検出できる。
   {
     std::lock_guard<std::mutex> lock(node_->data_mutex_);
     node_->current_route_poi_names_.insert("wp1");
@@ -214,12 +216,25 @@ TEST_F(NavServerTestFixture, ResetNavStateClearsRouteContext)
   node_->is_paused_ = true;
   node_->current_waypoint_index_ = 3;
 
+  geometry_msgs::msg::PoseStamped wp;
+  wp.pose.position.x = 1.0;
+  node_->current_route_waypoints_.push_back(wp);
+  node_->paused_waypoints_.push_back(wp);
+
+  geometry_msgs::msg::PoseStamped paused_goal;
+  paused_goal.pose.position.x = 9.0;
+  node_->paused_goal_pose_ = paused_goal;
+
   node_->reset_nav_state();
 
   EXPECT_TRUE(node_->current_route_poi_names_.empty());
   EXPECT_EQ(node_->nav_mode_, MapoiNavServer::NavMode::IDLE);
   EXPECT_FALSE(node_->is_paused_);
   EXPECT_EQ(node_->current_waypoint_index_, 0u);
+  EXPECT_TRUE(node_->current_route_waypoints_.empty());
+  EXPECT_TRUE(node_->paused_waypoints_.empty());
+  // paused_goal_pose_ は default-constructed PoseStamped に戻る (pose.position は 0)。
+  EXPECT_DOUBLE_EQ(node_->paused_goal_pose_.pose.position.x, 0.0);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Summary

PR #147 (#143) で導入した route 関連ロジック (route_generation_ stale handling、`current_route_poi_names_` の add/clear、route-scoped pause) の退行検知用 unit test を整備する。

既存実装の logic を 2 つの pure helper に切り出し（内部リファクタリング）、それぞれを直接 unit test できる形にした。

## 追加 helper (private static + FRIEND_TEST)

| 関数 | 用途 |
|---|---|
| `build_route_poi_names(waypoints, landmarks) → unordered_set<string>` | `on_route_received` 内の active POI set 構築ロジックを抽出 |
| `is_pause_eligible(poi, nav_mode, active_route_poi_names) → bool` | `radius_check_callback` 内の pause 自動発火条件 (ROUTE + active POI + pause タグ) を抽出 |

呼び出し元 (`on_route_received` / `radius_check_callback`) は新 helper を呼ぶ形に置換。動作は等価。既存 `has_landmark_tag` と同じ private static + FRIEND_TEST 方式で API surface を最小化。

## 追加 test (11 件、`test_nav_server_unit.cpp`)

### `build_route_poi_names` (5 件)
- waypoints のみ
- waypoints + landmarks 両方
- **landmarks 空 (旧 yaml 後方互換)** — `route.landmarks` 未指定 yaml で active set が空にならない契約
- 両方空 → 空 set
- 同名重複の set 集約

### `is_pause_eligible` (5 件)
- ROUTE mode + active POI + pause タグ → true
- ROUTE mode + active POI + pause タグなし → false
- ROUTE mode + 非 active POI + pause タグあり → false（別 route の POI に偶然 ENTER しても発火しない）
- GOAL mode → false
- IDLE mode → false

### `reset_nav_state` (1 件、FRIEND_TEST 経由)
- `ResetNavStateClearsRouteContext`: route 走行中 + pause 中相当の state を fixture から直接 set し、`reset_nav_state()` 後に `current_route_poi_names_` / `nav_mode_` / `is_paused_` / `current_waypoint_index_` / `current_route_waypoints_` / `paused_waypoints_` / `paused_goal_pose_` がクリアされることを検証

## カバーしたシナリオ (#148)

| # | シナリオ | 対応 test |
|---|---|---|
| 1 | route.landmarks 未指定時の後方互換 | `BuildRoutePoiNamesLandmarksEmptyBackwardCompat` |
| 2 | on_route_received 相当 (waypoints + landmarks 両方が active set) | `BuildRoutePoiNamesWaypointsAndLandmarks` |
| 3 | lifecycle clear (cancel / result / GOAL 切替) | `ResetNavStateClearsRouteContext` |
| 4 | stale generation (route_generation_ stale 判定) | scope 外 — 単純な generation 比較で test の追加価値が薄い |
| 5 | pause 発火条件 (ROUTE && active route POI のみ) | `IsPauseEligible*` 5 件 |

## 検証

| 環境 | nav_server_unit | 全 mapoi_server |
|---|---|---|
| ROS 2 humble (Docker) | **17/17 PASS** | 33/33 PASS |
| ROS 2 jazzy (Docker) | **17/17 PASS** | 33/33 PASS |

## Test plan

- [x] humble で `colcon test --packages-select mapoi_server` 全 PASS
- [x] jazzy で `colcon test --packages-select mapoi_server` 全 PASS
- [x] 既存 test (16 件) + 新規 test (11 件) で 33 tests 全 PASS
- [x] helper の置換で既存実装の動作が等価に保たれている

Close #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)