### PR TITLE
fix(rviz_plugins+server): POI Editor 表示の save 後同期を修正 + 定期 publish 廃止 (Close #135 A)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,22 @@ Unreleased
 Breaking changes
 ----------------
 
+* ``mapoi_server`` の ``pub_interval_ms`` parameter を廃止 (#135)。
+
+  - 旧: ``mapoi_config_path`` topic を ``pub_interval_ms`` (default 5000ms、
+    sample launch では 500ms) 間隔で定期 publish
+  - 新: 起動時 / ``SwitchMap`` / ``reload_map_info`` で明示 publish。
+    publisher は ``transient_local`` QoS のまま、subscriber 側も
+    ``transient_local`` に統一 (``poi_editor`` / ``mapoi_panel`` /
+    ``mapoi_webui_node`` を default QoS から変更)
+  - 移行: launch ファイル / param yaml で ``pub_interval_ms`` を指定して
+    いる場合は削除する (引き続き渡しても unused parameter として ROS が
+    warn するだけで動作には影響しない)
+  - 動機: 編集中の ``poi_editor`` table / ``mapoi_panel`` ComboBox が定期
+    publish trigger で再構築されて選択 / テキスト入力が中断される問題
+    (PR #168 動作確認で発覚)。``transient_local`` QoS で起動順序問題は解消
+    済みなので heartbeat 不要
+
 * ``initial_pose`` system tag を廃止 (#89 段階 3, #144)。
 
   - 旧: ``initial_pose`` タグ付き POI の pose を地図ロード/切替時に自動配信

--- a/README.md
+++ b/README.md
@@ -274,7 +274,6 @@ maps/
       - {name: maps_path, value: "$(find-pkg-share your_package)/maps"}
       - {name: map_name, value: "site_a"}
       - {name: config_file, value: "mapoi_config.yaml"}
-      - {name: pub_interval_ms, value: 500}
 
 - node:
     pkg: mapoi_server

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -110,6 +110,11 @@ protected:
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr config_path_sub_;
   void ConfigPathCallback(std_msgs::msg::String::SharedPtr msg);
 
+  // Save 直後の 1.5 秒間は config_path callback 経由の UpdatePoiTable を抑制し、
+  // SAVED! の green feedback を維持する (#135 副作用対応)。1.5 秒後の QTimer 末尾で
+  // rebuild + flag クリアされる。
+  bool suppress_config_callback_update_ = false;
+
   // Functions
   void InitConfigs(std::string map_name);
   void UpdatePoiTable();

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -75,7 +75,7 @@ void MapoiPanel::onInitialize()
   mapoi_highlight_route_pub_ = node_->create_publisher<std_msgs::msg::String>("mapoi_highlight_route", 1);
 
   config_path_sub_ = node_->create_subscription<std_msgs::msg::String>(
-      "mapoi_config_path", 10,
+      "mapoi_config_path", rclcpp::QoS(1).transient_local(),
       std::bind(&MapoiPanel::ConfigPathCallback, this, std::placeholders::_1));
 
   // QoS は mapoi_nav_server と同じ transient_local。後起動 panel でも latched 値を受信できる。

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -245,12 +245,21 @@ void MapoiPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
 {
   std::filesystem::path config_path(msg->data);
   std::string map_name = config_path.parent_path().filename().string();
-  if(current_map_ != map_name){
-    current_map_ = map_name;
-    QMetaObject::invokeMethod(this, [this, map_name]() {
+  bool map_changed = (current_map_ != map_name);
+  current_map_ = map_name;
+
+  // 同じ map で path も同じ場合 (= save 後の reload_map_info で再 publish される flow) でも
+  // POI / route list が変わっている可能性があるため Nav2GoalComboBox / MapoiRouteComboBox を
+  // 再 fetch する (#135)。map 切替時は highlight クリア + MapComboBox 同期も必要なので
+  // SetMapComboBox を呼ぶ。
+  QMetaObject::invokeMethod(this, [this, map_name, map_changed]() {
+    if (map_changed) {
       SetMapComboBox(map_name);
-    }, Qt::QueuedConnection);
-  }
+    } else {
+      SetNav2GoalComboBox();
+      SetMapoiRouteComboBox();
+    }
+  }, Qt::QueuedConnection);
 }
 
 void MapoiPanel::SetMapComboBox(std::string map_name)

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -288,6 +288,11 @@ void MapoiPanel::SetMapComboBox(std::string map_name)
 
 void MapoiPanel::SetNav2GoalComboBox()
 {
+  // 再構築前に現在 selection を保存し、同名項目があれば復元する (#135 副作用対応)。
+  // 他クライアント save (POI 追加 / pose 変更など) の reload で goal 選択が消えるのを防ぐ。
+  // 削除 / 名前変更で同名項目が消えた場合は currentIndex 0 (default) に fallback。
+  QString prev_selection = ui_->Nav2GoalComboBox->currentText();
+
   auto request_gtp = std::make_shared<mapoi_interfaces::srv::GetPoisInfo::Request>();
 
   if (!get_pois_info_client_->wait_for_service(3s)) {
@@ -316,7 +321,11 @@ void MapoiPanel::SetNav2GoalComboBox()
         ui_->Nav2GoalComboBox->addItem(QString::fromStdString(p.name));
       }
     }
-    goal_combobox_ind_ = 0;
+    int idx = ui_->Nav2GoalComboBox->findText(prev_selection);
+    if (idx >= 0) {
+      ui_->Nav2GoalComboBox->setCurrentIndex(idx);
+    }
+    goal_combobox_ind_ = ui_->Nav2GoalComboBox->currentIndex();
   }else{
     RCLCPP_ERROR(LOGGER, "Failed to call service get_pois_info");
   }
@@ -324,6 +333,10 @@ void MapoiPanel::SetNav2GoalComboBox()
 
 void MapoiPanel::SetMapoiRouteComboBox()
 {
+  // 再構築前に現在 selection を保存し、同名項目があれば復元する (#135 副作用対応)。
+  // 他クライアント save (route 追加 / 内容変更) の reload で route 選択が消えるのを防ぐ。
+  QString prev_selection = ui_->MapoiRouteComboBox->currentText();
+
   if (!get_routes_info_client_->wait_for_service(3s)) {
     RCLCPP_ERROR(LOGGER, "get_routes_info service not available after 3s timeout.");
     return;
@@ -339,7 +352,11 @@ void MapoiPanel::SetMapoiRouteComboBox()
     for(const auto & route : route_name_list_){
       ui_->MapoiRouteComboBox->addItem(QString::fromStdString(route));
     }
-    route_combobox_ind_ = 0;
+    int idx = ui_->MapoiRouteComboBox->findText(prev_selection);
+    if (idx >= 0) {
+      ui_->MapoiRouteComboBox->setCurrentIndex(idx);
+    }
+    route_combobox_ind_ = ui_->MapoiRouteComboBox->currentIndex();
   }else{
     RCLCPP_ERROR(LOGGER, "Failed to call service get_routes_info");
   }

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -540,9 +540,13 @@ void PoiEditorPanel::SaveButton()
   // 短い窓 + Save 直後の操作頻度低さから許容。必要なら future PR で member QTimer + cancel
   // pattern に拡張可能。
   ui_->SaveButton->setEnabled(false);
+  // SAVED! の green feedback を 1.5 秒見せる間、外部 (mapoi_config_path 再 publish 由来) からの
+  // UpdatePoiTable trigger を抑制する。1.5 秒後に rebuild + flag リセットで通常 flow に戻る。
+  suppress_config_callback_update_ = true;
   QTimer::singleShot(1500, this, [this]() {
     UpdatePoiTable();
     ui_->SaveButton->setEnabled(true);
+    suppress_config_callback_update_ = false;
   });
 }
 
@@ -580,10 +584,12 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
   // 同じ map で path も同じ場合 (= save 後の reload_map_info で再 publish される flow)
   // でも POI 内容が変わっている可能性があるため UpdatePoiTable で table を再 fetch する (#135)。
   // map 切替 / 初回受信時は MapComboBox 同期 + FileComboBox 再構築も必要なので InitConfigs を呼ぶ。
+  // 自分自身が save 直後 (suppress_config_callback_update_) は 1.5 秒の SAVED! feedback を
+  // 守るため UpdatePoiTable を skip する (QTimer 末尾で rebuild + flag クリアされる)。
   QMetaObject::invokeMethod(this, [this, map_name, map_changed, first_config]() {
     if (map_changed || first_config) {
       InitConfigs(map_name);
-    } else {
+    } else if (!suppress_config_callback_update_) {
       UpdatePoiTable();
     }
   }, Qt::QueuedConnection);

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -98,7 +98,7 @@ void PoiEditorPanel::onInitialize()
   LoadTagDefinitions();
 
   config_path_sub_ = node_->create_subscription<std_msgs::msg::String>(
-    "mapoi_config_path", 10,
+    "mapoi_config_path", rclcpp::QoS(1).transient_local(),
     std::bind(&PoiEditorPanel::ConfigPathCallback, this, std::placeholders::_1));
 
   // Display Settings group: mapoi_rviz2_publisher の表示系 parameter を Panel から制御 (#99)

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -573,13 +573,20 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
   std::filesystem::path resolved_p(resolved_path);
   std::string map_name = resolved_p.parent_path().filename().string();
   bool first_config = config_path_.empty();
+  bool map_changed = (current_map_ != map_name);
   config_path_ = resolved_path;
-  if(current_map_ != map_name || first_config){
-    current_map_ = map_name;
-    QMetaObject::invokeMethod(this, [this, map_name]() {
+  current_map_ = map_name;
+
+  // 同じ map で path も同じ場合 (= save 後の reload_map_info で再 publish される flow)
+  // でも POI 内容が変わっている可能性があるため UpdatePoiTable で table を再 fetch する (#135)。
+  // map 切替 / 初回受信時は MapComboBox 同期 + FileComboBox 再構築も必要なので InitConfigs を呼ぶ。
+  QMetaObject::invokeMethod(this, [this, map_name, map_changed, first_config]() {
+    if (map_changed || first_config) {
       InitConfigs(map_name);
-    }, Qt::QueuedConnection);
-  }
+    } else {
+      UpdatePoiTable();
+    }
+  }, Qt::QueuedConnection);
 }
 
 // Tag Filter

--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -14,7 +14,6 @@ mapoi のメインパッケージです。
       - {name: maps_path, value: "/path/to/your/maps"}    # REQUIRED
       - {name: map_name, value: "initial_map_name"}        # REQUIRED
       - {name: config_file, value: "mapoi_config.yaml"}    # optional
-      - {name: pub_interval_ms, value: "500"}              # optional
       - {name: simulator, value: "none"}                   # gazebo|gz|none (default: none)
       - {name: robot_entity_name, value: "burger"}         # simulator=gazebo|gz のとき必要
       - {name: robot_sdf_path, value: "/path/.../model.sdf"} # simulator=gazebo のとき必要

--- a/mapoi_server/include/mapoi_server/mapoi_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_server.hpp
@@ -55,10 +55,13 @@ private:
   // mapoi_initialpose_poi topic に publish。mapoi_nav_server がそれを受けて /initialpose を流す。
   // QoS: transient_local (depth=1) で後起動 subscriber でも受信できる。
   rclcpp::Publisher<mapoi_interfaces::msg::InitialPoseRequest>::SharedPtr initialpose_poi_publisher_;
-  rclcpp::TimerBase::SharedPtr timer_;
 
   // initial pose 用の POI 名 publish (#144)。compute_initial_poi_name は class-level public static。
   void publish_initial_poi_name(const std::string & requested_name);
+
+  // mapoi_config_path topic の publish (transient_local QoS で latched)。起動時 / SwitchMap /
+  // reload_map_info で呼ぶ。定期 publish は subscriber を transient_local に揃えて廃止 (#135)。
+  void publish_config_path();
 
   // methods
   void load_mapoi_config_file();

--- a/mapoi_server/launch/mapoi_bringup.launch.yaml
+++ b/mapoi_server/launch/mapoi_bringup.launch.yaml
@@ -31,11 +31,6 @@ launch:
     description: "Config file name inside each map directory"
 
 - arg:
-    name: pub_interval_ms
-    default: "500"
-    description: "mapoi_config_path publish interval (ms)"
-
-- arg:
     name: simulator
     default: "none"
     description: >
@@ -86,7 +81,6 @@ launch:
       - {name: maps_path, value: "$(var maps_path)"}
       - {name: map_name, value: "$(var map_name)"}
       - {name: config_file, value: "$(var config_file)"}
-      - {name: pub_interval_ms, value: "$(var pub_interval_ms)"}
 
 - node:
     pkg: mapoi_server

--- a/mapoi_server/src/mapoi_server.cpp
+++ b/mapoi_server/src/mapoi_server.cpp
@@ -10,7 +10,6 @@ MapoiServer::MapoiServer() : Node("mapoi_server") {
   this->declare_parameter<std::string>("maps_path", mapoi_server_pkg_ + "/maps");
   this->declare_parameter<std::string>("map_name", "turtlebot3_world");
   this->declare_parameter<std::string>("config_file", "mapoi_config.yaml");
-  this->declare_parameter<int>("pub_interval_ms", 5000);
 
   // initial maps path
   maps_path_ = this->get_parameter("maps_path").as_string();
@@ -20,19 +19,17 @@ MapoiServer::MapoiServer() : Node("mapoi_server") {
   load_tag_definitions();
   load_mapoi_config_file();
 
-  // Publish config_path_
+  // Publish config_path_ (transient_local QoS で latched、subscriber も transient_local に揃え
+  // たので定期 publish は廃止、起動時 / SwitchMap / reload_map_info で明示 publish する仕様に
+  // 移行 (#135))。
   config_path_publisher_ = this->create_publisher<std_msgs::msg::String>(
     "mapoi_config_path", rclcpp::QoS(1).transient_local());
+  publish_config_path();  // 起動時に latched 値として publish
+
   // Publish initial pose POI name (#144): mapoi_nav_server がこれを受けて /initialpose を流す。
   // 起動時 / SwitchMap / reload で publish する。後起動 subscriber でも受信できるよう transient_local。
   initialpose_poi_publisher_ = this->create_publisher<mapoi_interfaces::msg::InitialPoseRequest>(
     "mapoi_initialpose_poi", rclcpp::QoS(1).transient_local());
-  int pub_interval_ms = this->get_parameter("pub_interval_ms").as_int();
-  timer_ = this->create_wall_timer(std::chrono::milliseconds(pub_interval_ms), [this]() {
-    auto msg = std_msgs::msg::String();
-    msg.data = config_path_;
-    config_path_publisher_->publish(msg);
-  });
 
   // 起動時の最初の map に対する initial pose POI を publish (#144)。
   // 順序保証: load_mapoi_config_file() (line 21) → publish_initial_poi_name() の順に実行。
@@ -134,6 +131,13 @@ mapoi_interfaces::msg::PointOfInterest MapoiServer::yaml_to_poi_msg(const YAML::
   msg.tags = poi["tags"].as<std::vector<std::string>>(std::vector<std::string>{});
   msg.description = poi["description"].as<std::string>("");
   return msg;
+}
+
+void MapoiServer::publish_config_path()
+{
+  auto msg = std_msgs::msg::String();
+  msg.data = config_path_;
+  config_path_publisher_->publish(msg);
 }
 
 void MapoiServer::load_mapoi_config_file()
@@ -360,6 +364,10 @@ void MapoiServer::switch_map_service(const std::shared_ptr<mapoi_interfaces::srv
   // send_load_map_request 全件成功後にここへ来る。失敗 (上の return) では publish しない。
   publish_initial_poi_name(request->initial_poi_name);
 
+  // mapoi_config_path を再 publish (transient_local で latched 値更新)。subscriber は新 path を
+  // 受け取って table / ComboBox を再 fetch する (#135)。
+  publish_config_path();
+
   RCLCPP_INFO(this->get_logger(), "The map was switched into %s", map_name_.c_str());
   response->success = true;
 }
@@ -371,6 +379,9 @@ void MapoiServer::reload_map_info_service(
 {
   (void)request;
   load_mapoi_config_file();
+  // mapoi_config_path を再 publish (transient_local で latched 値更新)。subscriber が
+  // table / ComboBox を再 fetch することで save 後の内容更新が反映される (#135)。
+  publish_config_path();
   // reload は POI 編集後の再読込 trigger。ここで `mapoi_initialpose_poi` を再 publish すると、
   // mapoi_nav_server 側で /initialpose が再配信され **運用中の自己位置が巻き戻される** 回帰がある
   // (Cursor review #149 round 4 medium 対応)。

--- a/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
@@ -74,7 +74,6 @@ launch:
       - {name: maps_path, value: "$(find-pkg-share mapoi_turtlebot3_example)/maps"}
       - {name: map_name, value: "turtlebot3_world"}
       - {name: config_file, value: "mapoi_config.yaml"}
-      - {name: pub_interval_ms, value: "500"}
       - {name: simulator, value: "$(eval \"'gazebo' if '$(env ROS_DISTRO)' == 'humble' else 'gz'\")"}
       - {name: robot_entity_name, value: "$(env TURTLEBOT3_MODEL)"}
       - {name: robot_sdf_path, value: "$(find-pkg-share turtlebot3_gazebo)/models/turtlebot3_$(env TURTLEBOT3_MODEL)/model.sdf"}

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -172,9 +172,11 @@ class MapoiWebNode(Node):
         self.nav_status_sub_ = self.create_subscription(
             String, 'mapoi_nav_status', self.nav_status_callback, nav_status_qos)
 
-        # Subscribe to mapoi_config_path for external map switches
+        # Subscribe to mapoi_config_path for external map switches.
+        # transient_local QoS で publisher (mapoi_server) の latched 値を受信する (#135)。
+        config_path_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
         self.config_path_sub_ = self.create_subscription(
-            String, 'mapoi_config_path', self.config_path_callback, 10)
+            String, 'mapoi_config_path', self.config_path_callback, config_path_qos)
 
         # If maps_path not set, try to get it from get_maps_info service or use default
         if not self.maps_path_:


### PR DESCRIPTION
## 概要

`PoiEditorPanel` / `MapoiPanel` の `ConfigPathCallback` で同 map・path 不変時に何も呼ばれず table / ComboBox が stale になる問題を修正。動作確認で発覚した「定期 publish が編集中の cell / ComboBox 選択をリセットする」regression の根本原因として `mapoi_config_path` の publish 設計も整理。

## 修正

### 1. `ConfigPathCallback` の責務分離 (`PoiEditorPanel` / `MapoiPanel`)

| 旧 | 新 |
|---|---|
| `current_map_ != map_name` のときだけ full init、それ以外は何もしない | map 切替時は full init、同 map 内容変更時は table / ComboBox の再 fetch のみ |

- `PoiEditorPanel`: map 切替 → `InitConfigs`、同 map 内容変更 → `UpdatePoiTable` のみ
- `MapoiPanel`: map 切替 → `SetMapComboBox`、同 map 内容変更 → `SetNav2GoalComboBox` + `SetMapoiRouteComboBox` のみ

issue 起票時には PoiEditor のみ言及されていたが、`MapoiPanel` も同根本原因の bug (POI 追加 / 名前変更 / 削除が `Nav2GoalComboBox` に反映されない) のため scope 拡張。

### 2. `mapoi_config_path` の publish 設計整理 (Breaking change)

動作確認で「定期 publish (default 5000ms、sample launch では 500ms) が編集中の cell / ComboBox を再構築して選択 / 入力中の状態が失われる」 regression が発覚。 publish 設計を以下に整理:

- **`mapoi_server`**: `pub_interval_ms` parameter / timer 廃止、起動時 / `SwitchMap` / `reload_map_info` で `publish_config_path()` を明示呼び出しに集約
- **subscriber 統一**: `poi_editor` / `mapoi_panel` / `mapoi_webui_node` の QoS を default → `transient_local` に変更 (既存 `mapoi_nav_server` / `mapoi_rviz2_publisher` / `mapoi_gz_bridge` は既に transient_local)
- **launch / README**: `pub_interval_ms` 記述を削除
- **CHANGELOG.rst**: Breaking changes 節に廃止記載

`transient_local` QoS なら latched で後起動 subscriber も 1 回受信できるため、定期 publish (heartbeat) は不要。

#### Migration

`pub_interval_ms` を launch / param yaml で指定している箇所は削除する (引き続き渡しても unused parameter として ROS が warn するだけで動作には影響しない)。

## Test plan

- [x] Docker (\`mapoi:dev-humble\`) で \`colcon build --packages-up-to mapoi_webui\` 通過 (mapoi_interfaces + mapoi_server + mapoi_webui、warning 無し、33.2s)
- [x] Docker で \`colcon build --packages-up-to mapoi_rviz_plugins\` 通過 (mapoi_interfaces + mapoi_rviz_plugins、warning 無し、32.7s)
- [x] WebUI で POI 編集 → save → RViz \`PoiEditor\` table 反映 (Round 1 で確認済)
- [ ] **再確認**: RViz \`PoiEditor\` で POI cell の選択 / テキスト入力ができる (定期 publish 廃止後)
- [ ] **再確認**: \`MapoiPanel\` \`Nav2GoalComboBox\` で goal 選択が維持される (定期 publish 廃止後)
- [ ] WebUI で POI 追加 / 名前変更 / 削除 → save → RViz \`PoiEditor\` table 反映
- [ ] RViz で POI 追加 (waypoint タグ) → save → \`MapoiPanel\` \`Nav2GoalComboBox\` 候補追加
- [ ] 副作用確認: rviz で save 直後の SAVED! green feedback (1.5s) が即時消えていないか

## Scope 外 (別 PR)

- WebUI 側の rviz → ブラウザ反映 — issue #135 body 記載の (B) 部分 (SSE push 機構の新規実装、別 PR)

## 関連

- Close #135 (A 部分のみ、(B) は別 PR で別途対応)
- follow-up #169: \`ConfigPathCallback\` 系の自動テスト整備

🤖 Generated with [Claude Code](https://claude.com/claude-code)