### PR TITLE
feat(webui): config 変更を SSE で frontend に push (Close #135 B)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -160,6 +160,18 @@ WebUI / rviz_plugins
     ``[-π, π]`` で表現するのが慣習で、それを超えるユースケースは事実上ない想定)。
     soft warning にせず hard reject を選んだ理由は typo 防止を優先するため。
 
+* WebUI で rviz / 外部 save 由来の config 変更を SSE で受信し即時反映 (#135 (B))。
+
+  - 旧: rviz の PoiEditor で save しても WebUI 側はブラウザ更新するまで反映されない
+  - 新: ``mapoi_webui_node`` に ``/api/events`` SSE endpoint を追加。
+    ``mapoi_config_path`` topic 受信時に ``{type: "config_changed"}`` を全 client に
+    broadcast。frontend (``app.js``) は ``EventSource`` で受信して
+    ``loadTagDefinitions / loadPois / loadRoutes`` を再 fetch
+  - 関連: ``Flask app.run(threaded=True)`` を明示 (SSE long-lived connection と他
+    request の並行処理のため)
+  - PR #168 で対応した #135 (A) (PoiEditor / MapoiPanel の callback 修正) と
+    合わせて #135 全体を close
+
 Samples
 -------
 

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -3,7 +3,9 @@
 
 import math
 import os
+import json
 import logging
+import queue
 import threading
 import time
 
@@ -178,6 +180,12 @@ class MapoiWebNode(Node):
         self.config_path_sub_ = self.create_subscription(
             String, 'mapoi_config_path', self.config_path_callback, config_path_qos)
 
+        # SSE clients (#135 (B)): rviz / 外部 save 由来の config 変更を frontend に push するための
+        # client queue 集合。/api/events で接続された client ごとに queue を 1 つ持ち、
+        # config_path_callback で全 client queue に broadcast する。
+        self._sse_clients = set()
+        self._sse_lock = threading.Lock()
+
         # If maps_path not set, try to get it from get_maps_info service or use default
         if not self.maps_path_:
             self.get_logger().warn('maps_path parameter not set. Set it to use the web editor.')
@@ -220,7 +228,7 @@ class MapoiWebNode(Node):
             self.robot_pose_ = None
 
     def config_path_callback(self, msg):
-        """Detect external map switches via mapoi_config_path topic."""
+        """Detect external map switches via mapoi_config_path topic + frontend に push (#135 (B))."""
         # Extract map_name from path: .../maps/<map_name>/mapoi_config.yaml
         path = msg.data
         try:
@@ -235,6 +243,26 @@ class MapoiWebNode(Node):
                     break
         except Exception as e:
             self.get_logger().warn(f'Failed to parse config path: {e}')
+        # 内容変更 (POI / route の save 後 reload による再 publish) でも frontend に通知して
+        # loadPois / loadRoutes / loadTagDefinitions を再実行させる (#135 (B))。
+        self._broadcast_sse_event('config_changed')
+
+    def _broadcast_sse_event(self, event_type, payload=None):
+        """SSE で接続中の全 frontend client にイベントを broadcast する (#135 (B))。
+
+        各 client の queue.Queue に put_nowait で event を流す。client 切断は
+        /api/events generator の finally で自動 discard されるので queue 漏れなし。
+        queue は unbounded (現状) なので Full 例外は通常発火しない。
+        """
+        data = {'type': event_type}
+        if payload is not None:
+            data['payload'] = payload
+        with self._sse_lock:
+            for q in self._sse_clients:
+                try:
+                    q.put_nowait(data)
+                except queue.Full:
+                    pass  # bounded queue にした場合の安全弁、現在は unbounded で発火しない
 
     def get_config_path(self, map_name=None):
         """Get the full path to mapoi_config.yaml for a given map."""
@@ -348,7 +376,8 @@ class MapoiWebNode(Node):
             host=self.web_host_,
             port=self.web_port_,
             debug=False,
-            use_reloader=False)
+            use_reloader=False,
+            threaded=True)  # SSE long-lived connection と他 request の並行のため明示 (#135 (B))
 
     def create_flask_app(self):
         """Create and configure the Flask application."""
@@ -600,6 +629,26 @@ class MapoiWebNode(Node):
                 node.initialpose_poi_pub_, msg, 'mapoi_initialpose_poi')
             node.get_logger().info(f'Initial pose: {data["poi_name"]}')
             return jsonify({'success': True, 'warning': warning} if warning else {'success': True})
+
+        @app.route('/api/events')
+        def api_events():
+            """SSE endpoint: rviz / 外部 save 由来の config 変更を frontend に push (#135 (B))。
+
+            EventSource (frontend) で接続して、{"type": "config_changed"} 等のイベントを受信する。
+            client 切断時は generator の finally で client queue を discard する。
+            """
+            def gen():
+                q = queue.Queue()
+                with node._sse_lock:
+                    node._sse_clients.add(q)
+                try:
+                    while True:
+                        data = q.get()
+                        yield f'data: {json.dumps(data)}\n\n'
+                finally:
+                    with node._sse_lock:
+                        node._sse_clients.discard(q)
+            return Response(gen(), mimetype='text/event-stream')
 
         return app
 

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -234,17 +234,20 @@ class MapoiWebNode(Node):
         try:
             parts = path.replace('\\', '/').split('/')
             # Find config_file in path, map_name is the directory before it
+            map_name_parsed = None
             for i, part in enumerate(parts):
                 if part == self.config_file_ and i > 0:
-                    new_map = parts[i - 1]
-                    if new_map != self.map_name_:
-                        self.map_name_ = new_map
-                        self.get_logger().info(f'Map switched externally to: {new_map}')
+                    map_name_parsed = parts[i - 1]
+                    if map_name_parsed != self.map_name_:
+                        self.map_name_ = map_name_parsed
+                        self.get_logger().info(f'Map switched externally to: {map_name_parsed}')
                     break
-            # 内容変更 (POI / route の save 後 reload による再 publish) でも frontend に通知して
-            # loadPois / loadRoutes / loadTagDefinitions を再実行させる (#135 (B))。
-            # parse 成功時のみ broadcast: 異常メッセージで無駄な reload を避ける (#173 Round 1 medium)。
-            self._broadcast_sse_event('config_changed')
+            if map_name_parsed is not None:
+                # 内容変更 (POI / route の save 後 reload による再 publish) でも frontend に通知して
+                # loadPois / loadRoutes / loadTagDefinitions を再実行させる (#135 (B))。
+                # map 名が正しく解釈できた時のみ broadcast: 期待形式に部分一致するが map 特定でき
+                # ないケースで無駄な reload を避ける (#173 Round 1 / 2 medium)。
+                self._broadcast_sse_event('config_changed')
         except Exception as e:
             self.get_logger().warn(f'Failed to parse config path: {e}')
 

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -241,11 +241,12 @@ class MapoiWebNode(Node):
                         self.map_name_ = new_map
                         self.get_logger().info(f'Map switched externally to: {new_map}')
                     break
+            # 内容変更 (POI / route の save 後 reload による再 publish) でも frontend に通知して
+            # loadPois / loadRoutes / loadTagDefinitions を再実行させる (#135 (B))。
+            # parse 成功時のみ broadcast: 異常メッセージで無駄な reload を避ける (#173 Round 1 medium)。
+            self._broadcast_sse_event('config_changed')
         except Exception as e:
             self.get_logger().warn(f'Failed to parse config path: {e}')
-        # 内容変更 (POI / route の save 後 reload による再 publish) でも frontend に通知して
-        # loadPois / loadRoutes / loadTagDefinitions を再実行させる (#135 (B))。
-        self._broadcast_sse_event('config_changed')
 
     def _broadcast_sse_event(self, event_type, payload=None):
         """SSE で接続中の全 frontend client にイベントを broadcast する (#135 (B))。
@@ -635,20 +636,35 @@ class MapoiWebNode(Node):
             """SSE endpoint: rviz / 外部 save 由来の config 変更を frontend に push (#135 (B))。
 
             EventSource (frontend) で接続して、{"type": "config_changed"} 等のイベントを受信する。
-            client 切断時は generator の finally で client queue を discard する。
+            client 切断時は heartbeat (30s 周期) の write error で generator が例外を受け、
+            finally で client queue を discard する (#173 Round 1 high)。
             """
             def gen():
-                q = queue.Queue()
+                # bounded queue: 遅いクライアントで event が積み上がる場合の DoS 対策 (#173 Round 1 high)。
+                # 通常は frontend が即座に drain するので 10 件以内に収まる、overflow は drop。
+                q = queue.Queue(maxsize=10)
                 with node._sse_lock:
                     node._sse_clients.add(q)
                 try:
                     while True:
-                        data = q.get()
-                        yield f'data: {json.dumps(data)}\n\n'
+                        try:
+                            # 30s timeout + heartbeat: client 切断検知 + プロキシバッファ flush。
+                            # timeout 時は SSE comment (`:\n\n`) を yield することで socket write を発火し、
+                            # client 切断時は ConnectionResetError → finally で discard される。
+                            data = q.get(timeout=30)
+                            yield f'data: {json.dumps(data)}\n\n'
+                        except queue.Empty:
+                            yield ': heartbeat\n\n'
                 finally:
                     with node._sse_lock:
                         node._sse_clients.discard(q)
-            return Response(gen(), mimetype='text/event-stream')
+            # SSE response headers: プロキシ (nginx 等) のバッファリング無効化 + cache 無効化
+            # (#173 Round 1 medium)。
+            return Response(gen(), mimetype='text/event-stream',
+                            headers={
+                                'Cache-Control': 'no-cache',
+                                'X-Accel-Buffering': 'no',
+                            })
 
         return app
 

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -492,6 +492,26 @@
   setupSectionToggle('btn-nav-toggle', document.getElementById('nav-body'));
   startNavStatusPolling();
 
+  // --- SSE: rviz / 外部 save 由来の config 変更で再 fetch (#135 (B)) ---
+  // mapoi_webui_node が mapoi_config_path topic 受信時に push する。EventSource は
+  // browser が自動 reconnect するので最初の setup のみ。
+  const evtSrc = new EventSource('/api/events');
+  evtSrc.onmessage = (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      if (data.type === 'config_changed') {
+        Promise.all([loadTagDefinitions(), loadPois(), loadRoutes()])
+          .catch((err) => console.error('SSE reload failed:', err));
+      }
+    } catch (err) {
+      console.error('Invalid SSE event:', err);
+    }
+  };
+  evtSrc.onerror = (err) => {
+    // EventSource は readyState=CONNECTING に戻って自動 reconnect する
+    console.warn('SSE connection error, browser will auto-reconnect:', err);
+  };
+
   // --- Initialize ---
   await loadMaps();
 })();

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -495,13 +495,23 @@
   // --- SSE: rviz / 外部 save 由来の config 変更で再 fetch (#135 (B)) ---
   // mapoi_webui_node が mapoi_config_path topic 受信時に push する。EventSource は
   // browser が自動 reconnect するので最初の setup のみ。
+  // 短時間のバースト時は 200ms にまとめて 1 回だけ fetch する debounce (#173 Round 1 medium)。
+  let configChangedTimer = null;
+  function scheduleConfigChangedReload() {
+    if (configChangedTimer) clearTimeout(configChangedTimer);
+    configChangedTimer = setTimeout(() => {
+      configChangedTimer = null;
+      Promise.all([loadTagDefinitions(), loadPois(), loadRoutes()])
+        .catch((err) => console.error('SSE reload failed:', err));
+    }, 200);
+  }
+
   const evtSrc = new EventSource('/api/events');
   evtSrc.onmessage = (e) => {
     try {
       const data = JSON.parse(e.data);
       if (data.type === 'config_changed') {
-        Promise.all([loadTagDefinitions(), loadPois(), loadRoutes()])
-          .catch((err) => console.error('SSE reload failed:', err));
+        scheduleConfigChangedReload();
       }
     } catch (err) {
       console.error('Invalid SSE event:', err);

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -492,9 +492,14 @@
   setupSectionToggle('btn-nav-toggle', document.getElementById('nav-body'));
   startNavStatusPolling();
 
+  // --- Initialize ---
+  await loadMaps();
+
   // --- SSE: rviz / 外部 save 由来の config 変更で再 fetch (#135 (B)) ---
-  // mapoi_webui_node が mapoi_config_path topic 受信時に push する。EventSource は
-  // browser が自動 reconnect するので最初の setup のみ。
+  // 初期 load (loadMaps → switchMap → loadPois/Routes/TagDefs) 完了後に setup する
+  // (#173 Round 2 high: 初期化前の SSE 受信で reload が前提データ未 load 状態に
+  // なるのを回避)。mapoi_webui_node が mapoi_config_path topic 受信時に push する。
+  // EventSource は browser が自動 reconnect するので最初の setup のみ。
   // 短時間のバースト時は 200ms にまとめて 1 回だけ fetch する debounce (#173 Round 1 medium)。
   let configChangedTimer = null;
   function scheduleConfigChangedReload() {
@@ -521,7 +526,4 @@
     // EventSource は readyState=CONNECTING に戻って自動 reconnect する
     console.warn('SSE connection error, browser will auto-reconnect:', err);
   };
-
-  // --- Initialize ---
-  await loadMaps();
 })();


### PR DESCRIPTION
## 概要

issue #135 の (B) 部分: rviz / 外部 (他 client) の save 後、WebUI 側がブラウザ更新するまで反映されない問題を **SSE push** で解消。PR #168 で対応済の (A) (\`PoiEditor\` / \`MapoiPanel\` の callback 修正) と合わせて issue #135 全体 close。

## 修正

### Backend (\`mapoi_webui_node.py\`)

- **\`/api/events\` SSE endpoint** 追加 (\`Response(generator, mimetype='text/event-stream')\`)
- **broadcast queue 集合** (per-client \`queue.Queue\`) + \`threading.Lock\` で fan-out
- **\`config_path_callback\` で broadcast**: \`{type: "config_changed"}\` を全 connected client に push
- **\`Flask app.run(threaded=True)\`** 明示: SSE long-lived connection と他 request の並行処理を保証 (Werkzeug 1.0+ default で True だが explicit)
- imports 追加: \`json\`, \`queue\`

### Frontend (\`app.js\`)

- **\`EventSource('/api/events')\`** 接続を IIFE 末尾で追加
- **\`onmessage\`** で event parse: \`type === 'config_changed'\` で \`Promise.all([loadTagDefinitions(), loadPois(), loadRoutes()])\` を実行
- **\`onerror\`** で auto-reconnect (EventSource standard 挙動: \`readyState=CONNECTING\` に戻り再接続)

## Test plan

- [x] Docker (\`mapoi:dev-humble\`) で \`colcon build --packages-up-to mapoi_webui\` 通過 (3 packages、warning 無し、33.0s)
- [x] 別 PC で \`gh pr checkout\` 後の動作確認:
  - [x] WebUI を開いて、rviz \`PoiEditor\` で POI 追加 → save → **ブラウザ更新せずに WebUI に反映** (本 PR の主目的)
  - [ ] rviz で route 編集 → save → WebUI の route list に即時反映
  - [x] WebUI で POI 編集して save → 自分自身の WebUI も更新される (一貫性)
  - [ ] ブラウザの dev tools Network タブで \`/api/events\` が \`text/event-stream\` で開く + auto-reconnect 確認
  - [x] 複数ブラウザタブで開いても全て即時反映 (multi-client broadcast)

## Scope 外 (別 issue)

- 自動テスト (SSE integration test): 既存 web test (\`geometry.test.js\` / \`poi-filter.test.js\`) は static helper の unit test、SSE は playwright 等での integration が必要で別 issue 候補
- README 整備 (#172): SSE 機構の利用者向け記載は別 PR で対応

## 関連

- Close #135 (A は PR #168 で対応済、本 PR で B を完了して issue 全体 close)
- 関連 PR: #168 (#135 A)、#170 (#163 段階 1+2)
- follow-up issue: #169 (ConfigPathCallback 系自動テスト)、#171 (server sample 不在 CI 検知)、#172 (README CLI 起動例)

🤖 Generated with [Claude Code](https://claude.com/claude-code)