### PR TITLE
fix(server): reload で initialpose latched を skip message でクリア (#154)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -211,6 +211,18 @@ Samples
   (``waypoint × landmark``、``landmark × pause``)、``tolerance.{xy,yaw}``
   の min 制約 (>= 0.001) を pull request / push で自動検証。
 
+Fixes
+-----
+
+* ``mapoi_server`` の ``reload_map_info`` service で ``mapoi_initialpose_poi``
+  topic に skip message (``poi_name`` 空) を明示 publish するように修正
+  (#154)。``transient_local`` (depth=1) の latched 値が reload 直前の古い
+  POI 名のまま残り、reload 後に起動する nav_server / 再 connection した
+  RViz が編集前の POI 名を受信してしまう stale message 問題を排除する。
+  subscriber 側 (``mapoi_nav_server`` / ``mapoi_gazebo_bridge`` /
+  ``mapoi_gz_bridge``) は元々 ``poi_name`` 空を無視する規約のため、運用中の
+  自己位置巻き戻しは発生しない (#149 round 4 で確立した invariant を維持)。
+
 
 0.2.0 (2026-04-29)
 ==================

--- a/mapoi_server/CMakeLists.txt
+++ b/mapoi_server/CMakeLists.txt
@@ -94,6 +94,9 @@ if(BUILD_TESTING)
   add_launch_test(
     test/test_poi_event_integration.py
   )
+  add_launch_test(
+    test/test_reload_clears_initialpose.py
+  )
 
   # Install test config
   install(

--- a/mapoi_server/include/mapoi_server/mapoi_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_server.hpp
@@ -58,6 +58,10 @@ private:
 
   // initial pose 用の POI 名 publish (#144)。compute_initial_poi_name は class-level public static。
   void publish_initial_poi_name(const std::string & requested_name);
+  // transient_local の latched 値を「採用候補なし」を示す skip message (poi_name 空) で
+  // 上書きする (#154)。reload で呼び、reload 直前の古い POI 名が late subscriber に
+  // 配信される問題を防ぐ。
+  void publish_initialpose_clear();
 
   // mapoi_config_path topic の publish (transient_local QoS で latched)。起動時 / SwitchMap /
   // reload_map_info で呼ぶ。定期 publish は subscriber を transient_local に揃えて廃止 (#135)。

--- a/mapoi_server/src/mapoi_server.cpp
+++ b/mapoi_server/src/mapoi_server.cpp
@@ -515,6 +515,9 @@ void MapoiServer::publish_initial_poi_name(const std::string & requested_name)
 
 void MapoiServer::publish_initialpose_clear()
 {
+  // initialpose_poi_publisher_ は constructor で先に生成済み (publish_initial_poi_name と同じ
+  // invariant)。service callback は spin 開始後にしか呼ばれないため、reload_map_info_service
+  // 経由でここに来た時点で publisher は必ず存在する (#174 review high 対応)。
   // poi_name 空 = 「採用候補なし、subscriber は無視」(InitialPoseRequest.msg コメント参照)。
   // transient_local depth=1 の latched 値をこの skip message で上書きすることで、
   // reload 直前の古い POI 名が後起動の subscriber に latched 配信される stale 問題を排除する。

--- a/mapoi_server/src/mapoi_server.cpp
+++ b/mapoi_server/src/mapoi_server.cpp
@@ -416,11 +416,17 @@ void MapoiServer::reload_map_info_service(
   // mapoi_config_path を再 publish (transient_local で latched 値更新)。subscriber が
   // table / ComboBox を再 fetch することで save 後の内容更新が反映される (#135)。
   publish_config_path();
-  // reload は POI 編集後の再読込 trigger。ここで `mapoi_initialpose_poi` を再 publish すると、
-  // mapoi_nav_server 側で /initialpose が再配信され **運用中の自己位置が巻き戻される** 回帰がある
-  // (Cursor review #149 round 4 medium 対応)。
+  // reload は POI 編集後の再読込 trigger。ここで `mapoi_initialpose_poi` を「採用候補あり」で
+  // 再 publish すると、mapoi_nav_server 側で /initialpose が再配信され **運用中の自己位置が
+  // 巻き戻される** 回帰がある (Cursor review #149 round 4 medium 対応)。
+  // 一方で latched message は古い POI 名のまま残り、reload 後に nav_server が再起動 / 再 connection
+  // すると stale な POI 名が配信される問題が残っていた (#154)。
+  // 対策: skip message (poi_name 空、subscriber 側で無視される規約) を明示 publish して
+  // transient_local の latched 値を上書きする。運用中 subscriber には影響なく (空は無視)、
+  // 後起動 subscriber も古い POI 名を拾わない。
   // 初期姿勢の (再) 設定は SwitchMap (= 地図切替) または手動経路 (RViz / WebUI / mapoi_initialpose_poi
-  // 直接 publish) を使うのが正しい運用。ここでは publish_initial_poi_name を呼ばない。
+  // 直接 publish) を使うのが正しい運用。
+  publish_initialpose_clear();
   response->success = true;
   response->message = config_path_;
   RCLCPP_INFO(this->get_logger(), "Reloaded mapoi config: %s", config_path_.c_str());
@@ -505,6 +511,20 @@ void MapoiServer::publish_initial_poi_name(const std::string & requested_name)
   RCLCPP_INFO(this->get_logger(),
     "Published initial pose POI name '%s' for map '%s' (#144).",
     target.c_str(), map_name_.c_str());
+}
+
+void MapoiServer::publish_initialpose_clear()
+{
+  // poi_name 空 = 「採用候補なし、subscriber は無視」(InitialPoseRequest.msg コメント参照)。
+  // transient_local depth=1 の latched 値をこの skip message で上書きすることで、
+  // reload 直前の古い POI 名が後起動の subscriber に latched 配信される stale 問題を排除する。
+  auto msg = mapoi_interfaces::msg::InitialPoseRequest();
+  msg.map_name = map_name_;
+  msg.poi_name = "";
+  initialpose_poi_publisher_->publish(msg);
+  RCLCPP_INFO(this->get_logger(),
+    "Cleared latched mapoi_initialpose_poi for map '%s' (#154 stale guard on reload).",
+    map_name_.c_str());
 }
 
 void MapoiServer::load_tag_definitions()

--- a/mapoi_server/test/test_reload_clears_initialpose.py
+++ b/mapoi_server/test/test_reload_clears_initialpose.py
@@ -1,0 +1,125 @@
+# #154: reload_map_info で `mapoi_initialpose_poi` topic に skip message
+# (poi_name="") が publish され、transient_local (depth=1) の latched 値が
+# 上書きされることを検証する launch_test。
+#
+# 「reload 後に起動した late subscriber が古い POI 名を latched 配信されない」
+# というシナリオを直接検証する。test design は subscribe を 2 段階に分け、
+# (1) reload 前 subscriber が起動時 latched (POI list 先頭) を受信、
+# (2) reload 後 subscriber が skip message (poi_name="") を受信、
+# を確認する形 (#149 round 7 follow-up)。
+import os
+import unittest
+
+import launch
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+
+import rclpy
+from rclpy.qos import QoSProfile, DurabilityPolicy, HistoryPolicy, ReliabilityPolicy
+from std_srvs.srv import Trigger
+from mapoi_interfaces.msg import InitialPoseRequest
+from ament_index_python.packages import get_package_share_directory
+
+
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    pkg_share = get_package_share_directory('mapoi_server')
+    test_config_dir = os.path.join(pkg_share, 'test')
+
+    mapoi_server_node = launch_ros.actions.Node(
+        package='mapoi_server',
+        executable='mapoi_server',
+        name='mapoi_server',
+        parameters=[{
+            'maps_path': test_config_dir,
+            'map_name': '.',
+            'config_file': 'test_mapoi_config.yaml',
+        }],
+    )
+
+    return launch.LaunchDescription([
+        mapoi_server_node,
+        launch_testing.actions.ReadyToTest(),
+    ]), {'mapoi_server': mapoi_server_node}
+
+
+def _transient_local_qos():
+    # publisher 側 (rclcpp::QoS(1).transient_local()) と互換: reliable + keep_last(1) + transient_local。
+    return QoSProfile(
+        depth=1,
+        reliability=ReliabilityPolicy.RELIABLE,
+        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        history=HistoryPolicy.KEEP_LAST,
+    )
+
+
+class TestReloadClearsInitialpose(unittest.TestCase):
+    """reload_map_info 後に新規 subscribe する late subscriber が、起動時の
+    POI 名ではなく skip message (poi_name="") を latched 受信することを確認する (#154)。"""
+
+    SPIN_TIMEOUT = 5.0
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('test_reload_clears_initialpose_node')
+        cls.reload_client = cls.node.create_client(Trigger, 'reload_map_info')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def _spin_until(self, predicate, timeout=None):
+        timeout = timeout if timeout is not None else self.SPIN_TIMEOUT
+        end = self.node.get_clock().now().nanoseconds + int(timeout * 1e9)
+        while self.node.get_clock().now().nanoseconds < end:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+            if predicate():
+                return True
+        return False
+
+    def _take_one_latched(self, timeout=None):
+        """新規 subscription を作って transient_local の latched 値を 1 個受信する。"""
+        received = []
+        sub = self.node.create_subscription(
+            InitialPoseRequest, 'mapoi_initialpose_poi',
+            lambda msg: received.append(msg),
+            _transient_local_qos())
+        try:
+            got = self._spin_until(lambda: len(received) >= 1, timeout=timeout)
+            self.assertTrue(got, "Latched message not received within timeout")
+            return received[0]
+        finally:
+            self.node.destroy_subscription(sub)
+
+    def test_initial_latched_is_first_poi_name(self):
+        # 前提条件: 起動直後の latched は POI list 先頭 ("poi_goal_only")。
+        # この test が壊れた場合は publish_initial_poi_name 側の regression を疑う。
+        self.assertTrue(
+            self.reload_client.wait_for_service(timeout_sec=self.SPIN_TIMEOUT),
+            "reload_map_info service did not become available")
+        msg = self._take_one_latched()
+        self.assertEqual(msg.poi_name, "poi_goal_only",
+                         f"Initial latched poi_name should be POI list first, got '{msg.poi_name}'")
+
+    def test_reload_clears_latched_for_late_subscriber(self):
+        # 起動時 publish が完了するまで service の準備を待つ。
+        self.assertTrue(
+            self.reload_client.wait_for_service(timeout_sec=self.SPIN_TIMEOUT),
+            "reload_map_info service did not become available")
+
+        # reload を呼ぶ。reload_map_info_service 内で publish_initialpose_clear が呼ばれ、
+        # transient_local の latched 値が skip message (poi_name="") に上書きされる。
+        future = self.reload_client.call_async(Trigger.Request())
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=self.SPIN_TIMEOUT)
+        result = future.result()
+        self.assertIsNotNone(result, "reload_map_info call did not complete")
+        self.assertTrue(result.success, f"reload_map_info failed: {result.message}")
+
+        # reload 後に subscribe する late subscriber は、上書きされた skip message を受信する。
+        msg = self._take_one_latched()
+        self.assertEqual(msg.poi_name, "",
+                         f"Expected empty poi_name after reload (skip message), got '{msg.poi_name}'")

--- a/mapoi_server/test/test_reload_clears_initialpose.py
+++ b/mapoi_server/test/test_reload_clears_initialpose.py
@@ -57,7 +57,12 @@ def _transient_local_qos():
 
 class TestReloadClearsInitialpose(unittest.TestCase):
     """reload_map_info 後に新規 subscribe する late subscriber が、起動時の
-    POI 名ではなく skip message (poi_name="") を latched 受信することを確認する (#154)。"""
+    POI 名ではなく skip message (poi_name="") を latched 受信することを確認する (#154)。
+
+    mapoi_server は launch_test 内で 1 プロセスのみ起動するため、状態遷移
+    (起動時 latched → reload 後 latched) を 1 メソッドで順次検証する形にする
+    (#174 review r2 high #1 対応: メソッドを分けると実行順序依存になるため)。
+    """
 
     SPIN_TIMEOUT = 5.0
 
@@ -82,7 +87,11 @@ class TestReloadClearsInitialpose(unittest.TestCase):
         return False
 
     def _take_one_latched(self, timeout=None):
-        """新規 subscription を作って transient_local の latched 値を 1 個受信する。"""
+        """新規 subscription を作って transient_local の latched 値を 1 個受信する。
+
+        毎回新しい subscription を作って destroy することで、後起動の subscriber が
+        latched 値をどう受信するかをシナリオとして直接検証できる。
+        """
         received = []
         sub = self.node.create_subscription(
             InitialPoseRequest, 'mapoi_initialpose_poi',
@@ -95,31 +104,29 @@ class TestReloadClearsInitialpose(unittest.TestCase):
         finally:
             self.node.destroy_subscription(sub)
 
-    def test_initial_latched_is_first_poi_name(self):
-        # 前提条件: 起動直後の latched は POI list 先頭 ("poi_goal_only")。
-        # この test が壊れた場合は publish_initial_poi_name 側の regression を疑う。
+    def test_reload_overwrites_latched_with_skip_message(self):
         self.assertTrue(
             self.reload_client.wait_for_service(timeout_sec=self.SPIN_TIMEOUT),
             "reload_map_info service did not become available")
+
+        # 1) 起動直後の latched は POI list 先頭 ("poi_goal_only")。
+        #    publish_initial_poi_name の回帰検知も兼ねる (起動時 publish のガード)。
         msg = self._take_one_latched()
-        self.assertEqual(msg.poi_name, "poi_goal_only",
-                         f"Initial latched poi_name should be POI list first, got '{msg.poi_name}'")
+        self.assertEqual(
+            msg.poi_name, "poi_goal_only",
+            f"Initial latched poi_name should be POI list first, got '{msg.poi_name}'")
 
-    def test_reload_clears_latched_for_late_subscriber(self):
-        # 起動時 publish が完了するまで service の準備を待つ。
-        self.assertTrue(
-            self.reload_client.wait_for_service(timeout_sec=self.SPIN_TIMEOUT),
-            "reload_map_info service did not become available")
-
-        # reload を呼ぶ。reload_map_info_service 内で publish_initialpose_clear が呼ばれ、
-        # transient_local の latched 値が skip message (poi_name="") に上書きされる。
+        # 2) reload_map_info を呼ぶ。reload_map_info_service 内で publish_initialpose_clear が
+        #    呼ばれ、transient_local の latched 値が skip message (poi_name="") に上書きされる。
         future = self.reload_client.call_async(Trigger.Request())
         rclpy.spin_until_future_complete(self.node, future, timeout_sec=self.SPIN_TIMEOUT)
         result = future.result()
         self.assertIsNotNone(result, "reload_map_info call did not complete")
         self.assertTrue(result.success, f"reload_map_info failed: {result.message}")
 
-        # reload 後に subscribe する late subscriber は、上書きされた skip message を受信する。
+        # 3) reload 後に subscribe する late subscriber は、上書きされた skip message を受信する。
+        #    これが #154 本旨の直接検証。
         msg = self._take_one_latched()
-        self.assertEqual(msg.poi_name, "",
-                         f"Expected empty poi_name after reload (skip message), got '{msg.poi_name}'")
+        self.assertEqual(
+            msg.poi_name, "",
+            f"Expected empty poi_name after reload (skip message), got '{msg.poi_name}'")


### PR DESCRIPTION
## Summary

- ``reload_map_info`` service で ``mapoi_initialpose_poi`` topic に skip message (``poi_name`` 空) を明示 publish して ``transient_local`` (depth=1) の latched 値を上書きする
- reload 後に起動 / 再 connection した subscriber が編集前の古い POI 名を受け取る stale message 問題を排除

## 問題 (シナリオ)

1. T0: SwitchMap で ``poi_name="A"`` が latched
2. T1: ユーザーが POI を編集 (rename / 削除)
3. T2: reload は ``mapoi_initialpose_poi`` を re-publish しない (運用中の自己位置巻き戻し回避、#149 round 4)
4. T3: nav_server 再起動 / RViz 再 connection → latched の古い ``"A"`` を受信 → not-found → default fallback (POI list 先頭) に流れて意図しない POI で初期化

(Cursor review #149 round 7 ヘビー medium 指摘)

## 対策

reload 時に **skip message** (``poi_name=""``) を明示 publish して latched を上書きする。

- 空 ``poi_name`` の semantics は ``InitialPoseRequest.msg`` 既存コメントで「採用候補なし、subscriber は無視」と明文化済
- subscriber 側 (``mapoi_nav_server::mapoi_initialpose_poi_cb``) は既に ``poi_name.empty()`` で early return する logic を持つ
- 運用中の subscriber には影響なし (空 message → 無視)、後起動 subscriber も古い POI 名を拾わない

代替案 (条件付き publish / volatile QoS / topic 2 系統分離) は issue #154 で評価済、上記が最小コスト最大効果と判断。

## 実装

| ファイル | 変更 |
|---|---|
| ``mapoi_server/include/mapoi_server/mapoi_server.hpp`` | ``publish_initialpose_clear()`` 宣言追加 |
| ``mapoi_server/src/mapoi_server.cpp`` | ``publish_initialpose_clear()`` 実装、``reload_map_info_service`` から呼び出し、コメント更新 |
| ``mapoi_server/CMakeLists.txt`` | 新規 launch_test 登録 |
| ``mapoi_server/test/test_reload_clears_initialpose.py`` | publisher 側 契約 test 新規 |
| ``CHANGELOG.rst`` | Unreleased に Fixes セクション追加 |

## test

- 既存 unit test (``compute_initial_poi_name`` 純関数 + ``test_poi_event_integration``) 全件 pass
- **publisher 側の契約 test を新規追加** (PR review medium 対応):
  - ``test_initial_latched_is_first_poi_name``: 起動時 latched が POI list 先頭であることを確認 (``publish_initial_poi_name`` の regression guard)
  - ``test_reload_clears_latched_for_late_subscriber``: reload 後に subscribe する late subscriber が skip message (``poi_name=""``) を latched 受信することを確認 (#154 本旨の直接検証)
- subscriber 側 (``mapoi_nav_server`` / bridge) を含む E2E integration test は #169 系で別途巻き取る

## 動作確認

- Docker (humble): ``colcon build --packages-up-to mapoi_server`` 成功
- Docker (humble): ``colcon test --packages-select mapoi_server`` 全 39 件 pass

## 残課題 / follow-up

- #155 (InitialPoseRequest 世代検証 pending 戦略) — 本 PR で publisher 側の上書きで stale を排除したため subscriber 側世代検証は優先度低下、必要性を再評価して別 PR で対応
- #150 (initial pose 選定 logic 共通化 refactor) — 別 PR

Close #154