### PR TITLE
refactor(server): initial pose 選定 logic を共通ヘッダに切り出し (#150)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -223,6 +223,16 @@ Fixes
   ``mapoi_gz_bridge``) は元々 ``poi_name`` 空を無視する規約のため、運用中の
   自己位置巻き戻しは発生しない (#149 round 4 で確立した invariant を維持)。
 
+Internal
+--------
+
+* initial pose 選定ロジックを共通ヘッダ
+  ``mapoi_server/include/mapoi_server/initial_pose_resolver.hpp`` に切り出し、
+  ``mapoi_server`` / ``mapoi_gazebo_bridge`` / ``mapoi_gz_bridge`` の 3 箇所の
+  重複実装を統合 (#150)。今後 ``initial_poi_name`` 仕様 (除外条件 / fallback)
+  が拡張された場合の simulator spawn と ``/initialpose`` の挙動乖離を防ぐ。
+  挙動は同一 (純関数の rename + 物理配置移動のみ、unit test 互換)。
+
 
 0.2.0 (2026-04-29)
 ==================

--- a/mapoi_server/CMakeLists.txt
+++ b/mapoi_server/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 
 ament_auto_add_executable(mapoi_server
   src/mapoi_server.cpp
+  src/initial_pose_resolver.cpp
 )
 target_link_libraries(mapoi_server ${_mapoi_yaml_cpp_target})
 
@@ -33,6 +34,7 @@ find_package(gazebo_msgs QUIET)
 if(gazebo_msgs_FOUND)
   ament_auto_add_executable(mapoi_gazebo_bridge
     src/mapoi_gazebo_bridge.cpp
+    src/initial_pose_resolver.cpp
   )
   target_link_libraries(mapoi_gazebo_bridge ${_mapoi_yaml_cpp_target})
   ament_target_dependencies(mapoi_gazebo_bridge gazebo_msgs)
@@ -50,6 +52,7 @@ find_package(ros_gz_interfaces QUIET)
 if(ros_gz_interfaces_FOUND AND NOT "$ENV{ROS_DISTRO}" STREQUAL "humble")
   ament_auto_add_executable(mapoi_gz_bridge
     src/mapoi_gz_bridge.cpp
+    src/initial_pose_resolver.cpp
   )
   target_link_libraries(mapoi_gz_bridge ${_mapoi_yaml_cpp_target})
   ament_target_dependencies(mapoi_gz_bridge ros_gz_interfaces)
@@ -78,12 +81,14 @@ if(BUILD_TESTING)
   )
   target_compile_definitions(test_nav_server_unit PRIVATE UNIT_TEST)
 
+  # initial_pose_resolver は純関数なので test には resolver の cpp だけを link する
+  # (#150 で mapoi_server.cpp 全体 link から軽量化、Node 依存を test から排除)。
   ament_auto_add_gtest(test_mapoi_server_unit
     test/test_mapoi_server_unit.cpp
-    src/mapoi_server.cpp
+    src/initial_pose_resolver.cpp
   )
   target_compile_definitions(test_mapoi_server_unit PRIVATE UNIT_TEST)
-  # mapoi_server.cpp は yaml-cpp 依存。本体 executable と同じく test binary にも明示 link
+  # initial_pose_resolver.cpp は yaml-cpp 依存。本体 executable と同じく test binary にも明示 link
   # (#149 で見落とし、別 PC clean build で undefined reference 発覚 → hotfix)。
   # NOTE: humble の `ament_auto_add_gtest` 内で plain signature の target_link_libraries
   # が使われているため、ここも plain (= PUBLIC/PRIVATE/INTERFACE 無し) で揃える必要がある。

--- a/mapoi_server/include/mapoi_server/initial_pose_resolver.hpp
+++ b/mapoi_server/include/mapoi_server/initial_pose_resolver.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+// initial pose 候補 POI 名の選定 (#144 / #149 / #150)。
+// `mapoi_server` (mapoi_initialpose_poi 配信) と `mapoi_gazebo_bridge` /
+// `mapoi_gz_bridge` (robot spawn 位置決定) で共通する選定ロジックを純関数
+// として切り出したもの。3 箇所の重複を排除して、`initial_poi_name` 仕様
+// (除外条件 / fallback) が拡張された場合の simulator spawn と /initialpose の
+// 挙動乖離を防ぐ (#150)。
+//
+// ロジック:
+//   1) requested_name が指定されていれば、その POI を探す
+//      - landmark タグ持ち → fall back
+//      - pose ノード or x/y/yaw 欠落 / numeric 不可 → fall back
+//   2) fall back: POI list 先頭で「landmark なし & pose 完備」の POI を採用
+//   3) 候補なしなら空文字列を返す
+//
+// state を持たないため呼び出し側で test しやすい (#149 round 4 high の意図を
+// 維持)。
+
+#include <string>
+
+#include <yaml-cpp/yaml.h>
+
+
+namespace mapoi
+{
+
+// 採用すべき initial POI 名を返す。候補なしなら空文字列。
+std::string select_initial_poi_name(
+  const YAML::Node & pois_list, const std::string & requested_name);
+
+}  // namespace mapoi

--- a/mapoi_server/include/mapoi_server/initial_pose_resolver.hpp
+++ b/mapoi_server/include/mapoi_server/initial_pose_resolver.hpp
@@ -14,6 +14,12 @@
 //   2) fall back: POI list 先頭で「landmark なし & pose 完備」の POI を採用
 //   3) 候補なしなら空文字列を返す
 //
+// 前提: POI 名はマップ内で一意 (project 全体の暗黙前提、`mapoi_nav_server` /
+//   bridge / WebUI の lookup は全て「先頭一致で break」する design)。同名 POI
+//   が複数定義された場合、本関数は先頭一致で判定するため、後続の同名 POI は
+//   探索しない。yaml schema validation は ``scripts/check_sample_yaml_consistency.py``
+//   等で別途担保する。
+//
 // state を持たないため呼び出し側で test しやすい (#149 round 4 high の意図を
 // 維持)。
 

--- a/mapoi_server/include/mapoi_server/mapoi_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_server.hpp
@@ -30,17 +30,6 @@ class MapoiServer : public rclcpp::Node
 public:
   MapoiServer();
 
-  // 純関数版: pois_list (YAML::Node) と requested_name から initial POI 名を決定する (#144)。
-  // ロジック:
-  //   1) requested_name が指定されていれば、その POI を探す
-  //      - landmark タグ持ち → fall back (round 1 high)
-  //      - pose ノード or x/y/yaw 欠落 / numeric 不可 → fall back (round 2 low)
-  //   2) fall back: POI list 先頭で「landmark なし & pose 完備」の POI を採用
-  //   3) 候補なしなら空文字列を返す
-  // static にしてあるのは unit test で直接呼べるようにするため (#149 round 4 high 対応)。
-  static std::string compute_initial_poi_name(
-    const YAML::Node & pois_list, const std::string & requested_name);
-
 private:
   // parameters & internal state
   std::string mapoi_server_pkg_;

--- a/mapoi_server/src/initial_pose_resolver.cpp
+++ b/mapoi_server/src/initial_pose_resolver.cpp
@@ -1,0 +1,63 @@
+#include "mapoi_server/initial_pose_resolver.hpp"
+
+
+namespace mapoi
+{
+
+namespace
+{
+
+bool is_landmark_poi(const YAML::Node & poi)
+{
+  if (!poi["tags"] || !poi["tags"].IsSequence()) return false;
+  for (const auto & t : poi["tags"]) {
+    if (t.as<std::string>() == "landmark") return true;
+  }
+  return false;
+}
+
+// pose ノード + x / y / yaw 全てを numeric として読めるかを確認する。
+// bridge 側は欠落時 0.0 fallback なので、ここで弾けば「意図しない (0,0) spawn」を防げる。
+bool has_valid_pose(const YAML::Node & poi)
+{
+  if (!poi["pose"]) return false;
+  const auto & pose = poi["pose"];
+  if (!pose.IsMap()) return false;
+  for (const char * k : {"x", "y", "yaw"}) {
+    if (!pose[k]) return false;
+    try {
+      (void)pose[k].as<double>();
+    } catch (const YAML::Exception &) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+std::string select_initial_poi_name(
+  const YAML::Node & pois_list, const std::string & requested_name)
+{
+  if (!pois_list || !pois_list.IsSequence()) {
+    return "";
+  }
+  if (!requested_name.empty()) {
+    for (const auto & poi : pois_list) {
+      if (poi["name"].as<std::string>("") != requested_name) continue;
+      if (is_landmark_poi(poi)) break;     // landmark → fall back
+      if (!has_valid_pose(poi)) break;     // pose 欠落 → fall back
+      return requested_name;
+    }
+    // not-found 警告は呼び出し側で扱う (state-less 化のため log は出さない)
+  }
+  for (const auto & poi : pois_list) {
+    if (is_landmark_poi(poi)) continue;     // landmark は到達不可、initial pose 候補から除外
+    if (!has_valid_pose(poi)) continue;     // pose 欠落 POI もスキップ
+    const std::string n = poi["name"].as<std::string>("");
+    if (!n.empty()) return n;
+  }
+  return "";
+}
+
+}  // namespace mapoi

--- a/mapoi_server/src/mapoi_gazebo_bridge.cpp
+++ b/mapoi_server/src/mapoi_gazebo_bridge.cpp
@@ -18,6 +18,8 @@
 
 #include <chrono>
 #include <cmath>
+
+#include "mapoi_server/initial_pose_resolver.hpp"
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -214,61 +216,36 @@ ConfigLoadStatus MapoiGazeboBridge::load_gazebo_info(
       out.has_gazebo = !out.world_model.uri.empty();
     }
     // initial pose は (1) latched mapoi_initialpose_poi (= SwitchMap.initial_poi_name 指定) があれば
-    // それを優先、(2) なければ POI list 先頭 (landmark 除外、pose 妥当性 check) を採用 (#144 /
-    // #149 round 7 ヘビー high 対応)。
-    // 注: map_name による世代検証は #149 round 10 で取り下げ (#155 で改めて検討)。
-    //   InitialPoseRequest が config_path 処理より先に届く正当ケースを「stale」誤判定する
-    //   regression を防ぐため。stale 排除は publisher 上書き (transient_local depth=1) に依存。
+    // それを優先、(2) なければ POI list 先頭 (landmark 除外、pose 妥当性 check) を採用。選定 logic は
+    // `mapoi_server::select_initial_poi_name` で共通化 (#144 / #149 round 7 ヘビー high / #150)。
+    // 注: map_name による世代検証は #149 round 10 で取り下げ (#174 で publisher 側 latched 上書きに移行)。
+    //   stale 排除は publisher 上書き (transient_local depth=1) に依存する。
     std::string requested;
     {
       std::lock_guard<std::mutex> lock(requested_initial_pose_mutex_);
       requested = requested_initial_pose_poi_;
     }
-    auto is_landmark_poi = [](const YAML::Node & poi) {
-      if (!poi["tags"] || !poi["tags"].IsSequence()) return false;
-      for (const auto & t : poi["tags"]) {
-        if (t.as<std::string>() == "landmark") return true;
+    const std::string target = mapoi::select_initial_poi_name(cfg["poi"], requested);
+    if (!target.empty()) {
+      if (!requested.empty() && target != requested) {
+        // requested 名は届いていたが採用に失敗した (= name not found / landmark / pose 不備) (#149 round 9 low)。
+        RCLCPP_WARN(this->get_logger(),
+          "Requested initial POI '%s' not adopted for spawn (not found / landmark / invalid pose); "
+          "falling back to POI list first ('%s').",
+          requested.c_str(), target.c_str());
+      } else if (!requested.empty()) {
+        RCLCPP_INFO(this->get_logger(),
+          "Adopted requested initial POI '%s' for spawn position.", target.c_str());
       }
-      return false;
-    };
-    auto try_apply_pose = [&](const YAML::Node & poi) -> bool {
-      if (is_landmark_poi(poi)) return false;
-      if (!poi["pose"] || !poi["pose"].IsMap()) return false;
-      const auto & pose = poi["pose"];
-      for (const char * k : {"x", "y", "yaw"}) {
-        if (!pose[k]) return false;
-        try { (void)pose[k].as<double>(); }
-        catch (const YAML::Exception &) { return false; }
-      }
-      out.initial_x = pose["x"].as<double>();
-      out.initial_y = pose["y"].as<double>();
-      out.initial_yaw = pose["yaw"].as<double>();
-      out.has_initial_pose = true;
-      return true;
-    };
-    if (cfg["poi"] && cfg["poi"].IsSequence()) {
-      bool applied = false;
-      if (!requested.empty()) {
-        for (const auto & poi : cfg["poi"]) {
-          if (poi["name"].as<std::string>("") != requested) continue;
-          if (try_apply_pose(poi)) {
-            applied = true;
-            RCLCPP_INFO(this->get_logger(),
-              "Adopted requested initial POI '%s' for spawn position.", requested.c_str());
-          }
-          break;
-        }
-      }
-      if (!applied) {
-        if (!requested.empty()) {
-          // requested 名は届いていたが採用に失敗した (= name not found / landmark / pose 不備) (#149 round 9 low)。
-          RCLCPP_WARN(this->get_logger(),
-            "Requested initial POI '%s' not adopted for spawn (not found / landmark / invalid pose); "
-            "falling back to POI list first.", requested.c_str());
-        }
-        for (const auto & poi : cfg["poi"]) {
-          if (try_apply_pose(poi)) break;
-        }
+      // select_initial_poi_name で valid pose 保証済 (landmark 除外 / x/y/yaw 全 numeric)。
+      for (const auto & poi : cfg["poi"]) {
+        if (poi["name"].as<std::string>("") != target) continue;
+        const auto & pose = poi["pose"];
+        out.initial_x = pose["x"].as<double>();
+        out.initial_y = pose["y"].as<double>();
+        out.initial_yaw = pose["yaw"].as<double>();
+        out.has_initial_pose = true;
+        break;
       }
     }
   } catch (const YAML::Exception & e) {

--- a/mapoi_server/src/mapoi_gazebo_bridge.cpp
+++ b/mapoi_server/src/mapoi_gazebo_bridge.cpp
@@ -217,7 +217,7 @@ ConfigLoadStatus MapoiGazeboBridge::load_gazebo_info(
     }
     // initial pose は (1) latched mapoi_initialpose_poi (= SwitchMap.initial_poi_name 指定) があれば
     // それを優先、(2) なければ POI list 先頭 (landmark 除外、pose 妥当性 check) を採用。選定 logic は
-    // `mapoi_server::select_initial_poi_name` で共通化 (#144 / #149 round 7 ヘビー high / #150)。
+    // `mapoi::select_initial_poi_name` で共通化 (#144 / #149 round 7 ヘビー high / #150)。
     // 注: map_name による世代検証は #149 round 10 で取り下げ (#174 で publisher 側 latched 上書きに移行)。
     //   stale 排除は publisher 上書き (transient_local depth=1) に依存する。
     std::string requested;

--- a/mapoi_server/src/mapoi_gz_bridge.cpp
+++ b/mapoi_server/src/mapoi_gz_bridge.cpp
@@ -230,7 +230,7 @@ ConfigLoadStatus MapoiGzBridge::load_gazebo_info(
     }
     // initial pose は (1) latched mapoi_initialpose_poi (= SwitchMap.initial_poi_name 指定) があれば
     // それを優先、(2) なければ POI list 先頭 (landmark 除外、pose 妥当性 check) を採用。選定 logic は
-    // `mapoi_server::select_initial_poi_name` で共通化 (#144 / #149 round 7 ヘビー high / #150)。
+    // `mapoi::select_initial_poi_name` で共通化 (#144 / #149 round 7 ヘビー high / #150)。
     // 注: map_name による世代検証は #149 round 10 で取り下げ (#174 で publisher 側 latched 上書きに移行)。
     //   stale 排除は publisher 上書き (transient_local depth=1) に依存する。
     std::string requested;

--- a/mapoi_server/src/mapoi_gz_bridge.cpp
+++ b/mapoi_server/src/mapoi_gz_bridge.cpp
@@ -29,6 +29,8 @@
 #include <yaml-cpp/yaml.h>
 #include <ros_gz_interfaces/msg/entity.hpp>
 
+#include "mapoi_server/initial_pose_resolver.hpp"
+
 using namespace std::chrono_literals;
 using std::placeholders::_1;
 
@@ -227,61 +229,36 @@ ConfigLoadStatus MapoiGzBridge::load_gazebo_info(
       out.has_gazebo = !out.world_model.uri.empty();
     }
     // initial pose は (1) latched mapoi_initialpose_poi (= SwitchMap.initial_poi_name 指定) があれば
-    // それを優先、(2) なければ POI list 先頭 (landmark 除外、pose 妥当性 check) を採用 (#144 /
-    // #149 round 7 ヘビー high 対応)。
-    // 注: map_name による世代検証は #149 round 10 で取り下げ (#155 で改めて検討)。
-    //   InitialPoseRequest が config_path 処理より先に届く正当ケースを「stale」誤判定する
-    //   regression を防ぐため。stale 排除は publisher 上書き (transient_local depth=1) に依存。
+    // それを優先、(2) なければ POI list 先頭 (landmark 除外、pose 妥当性 check) を採用。選定 logic は
+    // `mapoi_server::select_initial_poi_name` で共通化 (#144 / #149 round 7 ヘビー high / #150)。
+    // 注: map_name による世代検証は #149 round 10 で取り下げ (#174 で publisher 側 latched 上書きに移行)。
+    //   stale 排除は publisher 上書き (transient_local depth=1) に依存する。
     std::string requested;
     {
       std::lock_guard<std::mutex> lock(requested_initial_pose_mutex_);
       requested = requested_initial_pose_poi_;
     }
-    auto is_landmark_poi = [](const YAML::Node & poi) {
-      if (!poi["tags"] || !poi["tags"].IsSequence()) return false;
-      for (const auto & t : poi["tags"]) {
-        if (t.as<std::string>() == "landmark") return true;
+    const std::string target = mapoi::select_initial_poi_name(cfg["poi"], requested);
+    if (!target.empty()) {
+      if (!requested.empty() && target != requested) {
+        // requested 名は届いていたが採用に失敗した (= name not found / landmark / pose 不備) (#149 round 9 low)。
+        RCLCPP_WARN(this->get_logger(),
+          "Requested initial POI '%s' not adopted for spawn (not found / landmark / invalid pose); "
+          "falling back to POI list first ('%s').",
+          requested.c_str(), target.c_str());
+      } else if (!requested.empty()) {
+        RCLCPP_INFO(this->get_logger(),
+          "Adopted requested initial POI '%s' for spawn position.", target.c_str());
       }
-      return false;
-    };
-    auto try_apply_pose = [&](const YAML::Node & poi) -> bool {
-      if (is_landmark_poi(poi)) return false;
-      if (!poi["pose"] || !poi["pose"].IsMap()) return false;
-      const auto & pose = poi["pose"];
-      for (const char * k : {"x", "y", "yaw"}) {
-        if (!pose[k]) return false;
-        try { (void)pose[k].as<double>(); }
-        catch (const YAML::Exception &) { return false; }
-      }
-      out.initial_x = pose["x"].as<double>();
-      out.initial_y = pose["y"].as<double>();
-      out.initial_yaw = pose["yaw"].as<double>();
-      out.has_initial_pose = true;
-      return true;
-    };
-    if (cfg["poi"] && cfg["poi"].IsSequence()) {
-      bool applied = false;
-      if (!requested.empty()) {
-        for (const auto & poi : cfg["poi"]) {
-          if (poi["name"].as<std::string>("") != requested) continue;
-          if (try_apply_pose(poi)) {
-            applied = true;
-            RCLCPP_INFO(this->get_logger(),
-              "Adopted requested initial POI '%s' for spawn position.", requested.c_str());
-          }
-          break;
-        }
-      }
-      if (!applied) {
-        if (!requested.empty()) {
-          // requested 名は届いていたが採用に失敗した (= name not found / landmark / pose 不備) (#149 round 9 low)。
-          RCLCPP_WARN(this->get_logger(),
-            "Requested initial POI '%s' not adopted for spawn (not found / landmark / invalid pose); "
-            "falling back to POI list first.", requested.c_str());
-        }
-        for (const auto & poi : cfg["poi"]) {
-          if (try_apply_pose(poi)) break;
-        }
+      // select_initial_poi_name で valid pose 保証済 (landmark 除外 / x/y/yaw 全 numeric)。
+      for (const auto & poi : cfg["poi"]) {
+        if (poi["name"].as<std::string>("") != target) continue;
+        const auto & pose = poi["pose"];
+        out.initial_x = pose["x"].as<double>();
+        out.initial_y = pose["y"].as<double>();
+        out.initial_yaw = pose["yaw"].as<double>();
+        out.has_initial_pose = true;
+        break;
       }
     }
   } catch (const YAML::Exception & e) {

--- a/mapoi_server/src/mapoi_server.cpp
+++ b/mapoi_server/src/mapoi_server.cpp
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <cstdio>
 
+#include "mapoi_server/initial_pose_resolver.hpp"
+
 using namespace std::chrono_literals;
 
 MapoiServer::MapoiServer() : Node("mapoi_server") {
@@ -432,63 +434,12 @@ void MapoiServer::reload_map_info_service(
   RCLCPP_INFO(this->get_logger(), "Reloaded mapoi config: %s", config_path_.c_str());
 }
 
-// static (純関数). pois_list と requested_name から initial POI 名を決定。
-// state を持たないため unit test で直接呼び出せる (#149 round 4 high 対応)。
-std::string MapoiServer::compute_initial_poi_name(
-  const YAML::Node & pois_list, const std::string & requested_name)
-{
-  if (!pois_list || !pois_list.IsSequence()) {
-    return "";
-  }
-  auto is_landmark_poi = [](const YAML::Node & poi) {
-    if (!poi["tags"] || !poi["tags"].IsSequence()) return false;
-    for (const auto & t : poi["tags"]) {
-      if (t.as<std::string>() == "landmark") return true;
-    }
-    return false;
-  };
-  // pose ノード + x / y / yaw 全てを numeric として読めるかを確認する。
-  // bridge 側は欠落時 0.0 fallback なので、ここで弾けば「意図しない (0,0) spawn」を防げる。
-  auto has_valid_pose = [](const YAML::Node & poi) {
-    if (!poi["pose"]) return false;
-    const auto & pose = poi["pose"];
-    if (!pose.IsMap()) return false;
-    for (const char * k : {"x", "y", "yaw"}) {
-      if (!pose[k]) return false;
-      try {
-        (void)pose[k].as<double>();
-      } catch (const YAML::Exception &) {
-        return false;
-      }
-    }
-    return true;
-  };
-  if (!requested_name.empty()) {
-    bool found = false;
-    for (const auto & poi : pois_list) {
-      if (poi["name"].as<std::string>("") != requested_name) continue;
-      found = true;
-      if (is_landmark_poi(poi)) break;     // landmark → fall back
-      if (!has_valid_pose(poi)) break;     // pose 欠落 → fall back
-      return requested_name;
-    }
-    (void)found;  // not-found 警告は呼び出し側で扱う (state-less 化のため log は出さない)
-  }
-  for (const auto & poi : pois_list) {
-    if (is_landmark_poi(poi)) continue;     // landmark は到達不可、initial pose 候補から除外
-    if (!has_valid_pose(poi)) continue;     // pose 欠落 POI もスキップ
-    const std::string n = poi["name"].as<std::string>("");
-    if (!n.empty()) return n;
-  }
-  return "";
-}
-
 void MapoiServer::publish_initial_poi_name(const std::string & requested_name)
 {
   // requested_name は SwitchMap.initial_poi_name (空 = default、POI list 先頭採用)。
   // shared state を持たず、呼び出し側が直接渡す形にして thread safety / lifecycle race を排除
-  // (Cursor review #149 round 2 high 対応)。
-  const std::string target = compute_initial_poi_name(pois_list_, requested_name);
+  // (Cursor review #149 round 2 high 対応)。選定 logic は bridge 2 つと共通化済 (#150)。
+  const std::string target = mapoi::select_initial_poi_name(pois_list_, requested_name);
   // ログ順序: target.empty() の WARN は下流に任せ、ここでは「requested 不採用かつ fallback 候補が
   // 存在する」ケースのみ WARN を出す (#149 round 5 low: target.empty() 時に紛らわしい両 WARN が
   // 出るのを避ける)。

--- a/mapoi_server/test/test_mapoi_server_unit.cpp
+++ b/mapoi_server/test/test_mapoi_server_unit.cpp
@@ -1,9 +1,12 @@
-// MapoiServer の純関数 (compute_initial_poi_name) の unit test (#149 round 4 high 対応)。
-// rclcpp::Node の生成は不要 (= static 関数を直接叩ける)。
+// initial pose 選定純関数 (mapoi_server::select_initial_poi_name) の unit test
+// (#149 round 4 high で導入、#150 で共通ヘッダに移行)。
+// rclcpp::Node の生成は不要 (= 純関数を直接叩ける)。
 #include <gtest/gtest.h>
 #include <yaml-cpp/yaml.h>
 
-#include "mapoi_server/mapoi_server.hpp"
+#include "mapoi_server/initial_pose_resolver.hpp"
+
+using mapoi::select_initial_poi_name;
 
 namespace
 {
@@ -15,65 +18,65 @@ YAML::Node load_pois(const std::string & yaml_text)
 
 }  // namespace
 
-TEST(ComputeInitialPoiName, EmptyOrNonSequenceReturnsEmpty)
+TEST(SelectInitialPoiName, EmptyOrNonSequenceReturnsEmpty)
 {
   YAML::Node empty;
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(empty, ""), "");
+  EXPECT_EQ(select_initial_poi_name(empty, ""), "");
   YAML::Node scalar = YAML::Load("foo");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(scalar, ""), "");
+  EXPECT_EQ(select_initial_poi_name(scalar, ""), "");
 }
 
-TEST(ComputeInitialPoiName, DefaultPicksFirstNonLandmarkValidPose)
+TEST(SelectInitialPoiName, DefaultPicksFirstNonLandmarkValidPose)
 {
   auto pois = load_pois(R"(
 poi:
   - {name: a, pose: {x: 1.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
   - {name: b, pose: {x: 2.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
 )");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, ""), "a");
+  EXPECT_EQ(select_initial_poi_name(pois, ""), "a");
 }
 
-TEST(ComputeInitialPoiName, LandmarkAtFrontIsSkipped)
+TEST(SelectInitialPoiName, LandmarkAtFrontIsSkipped)
 {
   auto pois = load_pois(R"(
 poi:
   - {name: lm, pose: {x: 1.0, y: 0.0, yaw: 0.0}, tags: [landmark]}
   - {name: a, pose: {x: 2.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
 )");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, ""), "a");
+  EXPECT_EQ(select_initial_poi_name(pois, ""), "a");
 }
 
-TEST(ComputeInitialPoiName, MissingPoseIsSkipped)
+TEST(SelectInitialPoiName, MissingPoseIsSkipped)
 {
   auto pois = load_pois(R"(
 poi:
   - {name: no_pose, tags: [waypoint]}
   - {name: a, pose: {x: 2.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
 )");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, ""), "a");
+  EXPECT_EQ(select_initial_poi_name(pois, ""), "a");
 }
 
-TEST(ComputeInitialPoiName, PartialPoseIsSkipped)
+TEST(SelectInitialPoiName, PartialPoseIsSkipped)
 {
   auto pois = load_pois(R"(
 poi:
   - {name: only_x, pose: {x: 1.0}, tags: [waypoint]}
   - {name: a, pose: {x: 2.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
 )");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, ""), "a");
+  EXPECT_EQ(select_initial_poi_name(pois, ""), "a");
 }
 
-TEST(ComputeInitialPoiName, NonNumericPoseIsSkipped)
+TEST(SelectInitialPoiName, NonNumericPoseIsSkipped)
 {
   auto pois = load_pois(R"(
 poi:
   - {name: bad, pose: {x: not_a_number, y: 0.0, yaw: 0.0}, tags: [waypoint]}
   - {name: a, pose: {x: 2.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
 )");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, ""), "a");
+  EXPECT_EQ(select_initial_poi_name(pois, ""), "a");
 }
 
-TEST(ComputeInitialPoiName, RequestedNameIsAdopted)
+TEST(SelectInitialPoiName, RequestedNameIsAdopted)
 {
   auto pois = load_pois(R"(
 poi:
@@ -81,41 +84,41 @@ poi:
   - {name: b, pose: {x: 2.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
   - {name: c, pose: {x: 3.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
 )");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, "b"), "b");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, "c"), "c");
+  EXPECT_EQ(select_initial_poi_name(pois, "b"), "b");
+  EXPECT_EQ(select_initial_poi_name(pois, "c"), "c");
 }
 
-TEST(ComputeInitialPoiName, RequestedLandmarkFallsBackToFirst)
+TEST(SelectInitialPoiName, RequestedLandmarkFallsBackToFirst)
 {
   auto pois = load_pois(R"(
 poi:
   - {name: a, pose: {x: 1.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
   - {name: lm, pose: {x: 2.0, y: 0.0, yaw: 0.0}, tags: [landmark]}
 )");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, "lm"), "a");
+  EXPECT_EQ(select_initial_poi_name(pois, "lm"), "a");
 }
 
-TEST(ComputeInitialPoiName, RequestedInvalidPoseFallsBackToFirst)
+TEST(SelectInitialPoiName, RequestedInvalidPoseFallsBackToFirst)
 {
   auto pois = load_pois(R"(
 poi:
   - {name: a, pose: {x: 1.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
   - {name: bad, pose: {x: 2.0}, tags: [waypoint]}
 )");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, "bad"), "a");
+  EXPECT_EQ(select_initial_poi_name(pois, "bad"), "a");
 }
 
-TEST(ComputeInitialPoiName, RequestedNotFoundFallsBackToFirst)
+TEST(SelectInitialPoiName, RequestedNotFoundFallsBackToFirst)
 {
   auto pois = load_pois(R"(
 poi:
   - {name: a, pose: {x: 1.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
   - {name: b, pose: {x: 2.0, y: 0.0, yaw: 0.0}, tags: [waypoint]}
 )");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, "missing"), "a");
+  EXPECT_EQ(select_initial_poi_name(pois, "missing"), "a");
 }
 
-TEST(ComputeInitialPoiName, AllLandmarkOrInvalidReturnsEmpty)
+TEST(SelectInitialPoiName, AllLandmarkOrInvalidReturnsEmpty)
 {
   auto pois = load_pois(R"(
 poi:
@@ -123,5 +126,5 @@ poi:
   - {name: bad, tags: [waypoint]}
   - {name: lm2, pose: {x: 2.0, y: 0.0, yaw: 0.0}, tags: [landmark]}
 )");
-  EXPECT_EQ(MapoiServer::compute_initial_poi_name(pois, ""), "");
+  EXPECT_EQ(select_initial_poi_name(pois, ""), "");
 }


### PR DESCRIPTION
## Summary

- ``mapoi_server`` / ``mapoi_gazebo_bridge`` / ``mapoi_gz_bridge`` の 3 箇所で重複していた initial pose 候補 POI 名の選定ロジックを共通ヘッダ ``mapoi_server/include/mapoi_server/initial_pose_resolver.hpp`` に切り出し
- 純関数 ``mapoi::select_initial_poi_name(pois_list, requested_name)`` として統合
- 挙動は同一 (pure refactor、unit test 互換)

## 動機

PR #149 (#144) で initial pose の選定 logic を「POI list 先頭 (landmark / pose 欠落 を除外)」に統一したが、3 箇所で重複実装になっていた:

- ``mapoi_server::compute_initial_poi_name()`` (``/initialpose`` 配信用、static method)
- ``mapoi_gazebo_bridge::load_gazebo_info()`` 内 (Gazebo Classic robot spawn)
- ``mapoi_gz_bridge::load_gazebo_info()`` 内 (gz-sim robot spawn)

issue #150 の通り「3 箇所で同じ仕様。今後 ``initial_poi_name`` や除外条件が拡張された場合に simulator spawn と ``/initialpose`` の挙動が乖離しやすい」 という保守リスクの解消。

## 実装

| 領域 | 変更 |
|---|---|
| ``mapoi_server/include/mapoi_server/initial_pose_resolver.hpp`` (新規) | ``mapoi::select_initial_poi_name`` 宣言 |
| ``mapoi_server/src/initial_pose_resolver.cpp`` (新規) | 純関数の実装 (旧 ``compute_initial_poi_name`` の logic を移植) |
| ``mapoi_server/include/mapoi_server/mapoi_server.hpp`` | ``compute_initial_poi_name`` static method 宣言を削除 |
| ``mapoi_server/src/mapoi_server.cpp`` | 旧実装削除、呼び出しを ``mapoi::select_initial_poi_name`` に置換 |
| ``mapoi_server/src/mapoi_gazebo_bridge.cpp`` | 重複 logic (``is_landmark_poi`` / ``try_apply_pose`` lambda + 制御フロー) を ``mapoi::select_initial_poi_name`` 呼び出し + bridge 固有の pose 抽出に分離 |
| ``mapoi_server/src/mapoi_gz_bridge.cpp`` | 同上 |
| ``mapoi_server/test/test_mapoi_server_unit.cpp`` | テストを ``mapoi::select_initial_poi_name`` 呼び出しに更新 (rename のみ、挙動同一) |
| ``mapoi_server/CMakeLists.txt`` | 3 executable と test に ``initial_pose_resolver.cpp`` を link、test は ``src/mapoi_server.cpp`` 全体 link から軽量化 (Node 依存を排除) |
| ``CHANGELOG.rst`` | Internal セクション追加 |

namespace は class ``MapoiServer`` との混乱を避けるため ``mapoi`` (project 全体共通の short name) を採用。

## test

- ``test_mapoi_server_unit`` (gtest 純関数 11 件): 全 pass
- ``test_poi_event_integration.py`` (launch_test): pass
- ``test_reload_clears_initialpose.py`` (launch_test): pass
- 合計 **38 tests, 0 errors, 0 failures**

## 動作確認

| distro | bridge | 結果 |
|---|---|---|
| humble | ``mapoi_gazebo_bridge`` (Gazebo Classic) | build OK / test 38 件 pass |
| jazzy | ``mapoi_gz_bridge`` (gz-sim) | build OK / test 38 件 pass |

## 関連

- #144 (本機能の initial pose 廃止 PR)
- #149 review (low 指摘、本 issue の発端)
- #154 / #174 (publisher 側 latched 上書きで stale 排除、本 PR の前提)

Close #150