### PR TITLE
feat(nav_server): EVENT_STOPPED / EVENT_RESUMED publish logic 実装 (#140)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -126,6 +126,12 @@ Breaking changes
   削除。yaml load で違反値を検出した場合は ``0.001`` に補正 + WARN ログ。
   (#138)
 
+* ``mapoi_nav_server`` の ROS parameter ``radius_check_hz`` を
+  ``tolerance_check_hz`` にリネーム (#140)。``PointOfInterest.radius``
+  field 廃止 (#87) → ``tolerance.xy`` 化に伴う命名整合。default 値 / 単位
+  / 動作は変更なし。launch / yaml で ``radius_check_hz`` を指定している場合
+  は ``tolerance_check_hz`` への置換が必要。
+
 Interfaces
 ----------
 
@@ -222,6 +228,37 @@ Fixes
   subscriber 側 (``mapoi_nav_server`` / ``mapoi_gazebo_bridge`` /
   ``mapoi_gz_bridge``) は元々 ``poi_name`` 空を無視する規約のため、運用中の
   自己位置巻き戻しは発生しない (#149 round 4 で確立した invariant を維持)。
+
+Navigation server
+-----------------
+
+* ``mapoi_nav_server`` で ``EVENT_STOPPED`` / ``EVENT_RESUMED`` の publish 判定
+  logic を実装 (#140)。``PoiEvent.msg`` に #87 で追加済の定数を実際に発火
+  させる。判定 source は OR で 2 系統:
+
+  - **Nav2 action SUCCEEDED**: ``FollowWaypoints`` / ``NavigateToPose`` の
+    result_callback で SUCCEEDED を検知したら、現在 inside 状態の全 POI に
+    ``EVENT_STOPPED`` を即時 publish (cmd_vel dwell 待ちを経由しない)
+  - **cmd_vel ベース**: 線速・角速の両方が ``stopped_speed_threshold``
+    (default ``0.01``) 未満の状態が ``stopped_dwell_time_sec`` (default
+    ``1.0`` 秒) 続いたら ``EVENT_STOPPED`` を publish。tolerance_check_callback
+    の各 tick で判定
+  - **EVENT_RESUMED**: STOPPED 状態の POI で速度が閾値超に戻ったら即時
+    publish (dwell 不要)。新規 ``mapoi_goal_pose_poi`` / ``mapoi_route``
+    受信時にも全 STOPPED POI に対して RESUMED を publish (subscriber 側で
+    「停止解除」を即時検知できるようにする)
+  - **EXIT 時**: poi_inside_state_ → false と同時に poi_stopped_state_ も
+    reset。EXIT イベントが「停止解除」を兼ねる扱い (RESUMED は明示 publish
+    しない、ライフサイクルを ENTER → STOPPED → EXIT に整理)
+
+  新規 ROS parameter:
+
+  - ``stopped_speed_threshold`` (default ``0.01`` m/s 相当)
+  - ``stopped_dwell_time_sec`` (default ``1.0``)
+  - ``cmd_vel_topic`` (default ``cmd_vel``)
+
+  state machine 純関数 ``compute_stopped_transition`` を切り出し、
+  ``test_nav_server_unit`` で unit test カバレッジ確保 (5 件追加)。
 
 Internal
 --------

--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -180,13 +180,19 @@ private:
   // --- STOPPED/RESUMED 判定 (#140) ---
   // cmd_vel subscriber: 速度判定の source の一つ。Nav2 action SUCCEEDED もう一つの source は
   // result_callback / ntp_result_callback で hook する (両方 OR で STOPPED 判定)。
+  // dwell 判定は robot 全体で 1 つ (POI ごとには持たない)。線速ノルムと角速度絶対値の両方が
+  // 同じ閾値 ``stopped_speed_threshold`` 未満のとき停止扱い。線速 (m/s) と角速 (rad/s) に
+  // 単位の異なる同一閾値を使う割り切りは、撮影シナリオで「その場旋回も停止扱いしたくない」
+  // 用途と整合する (param 説明 / CHANGELOG にも明記)。
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
   void cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
-  // 最後に観測した速度 (m/s 換算、|linear| + |angular|*r_eff の単純合算で近似)。
-  double last_cmd_vel_speed_ {0.0};
   // 速度が閾値以下になり始めた時刻 (steady_clock)。閾値超えに戻ったら reset。
   std::chrono::steady_clock::time_point last_zero_velocity_start_ {};
   bool zero_velocity_active_ {false};
+  // STOPPED 判定 param のキャッシュ (cmd_vel callback で毎 tick 取得すると lock コストが高いため
+  // constructor で読み込んで保持。ROS 動的 reconfigure で変更したい場合は再起動が必要)。
+  double stopped_speed_threshold_ {0.01};
+  double stopped_dwell_time_sec_ {1.0};
 
   // 状態遷移判定の純関数 (unit test 用、#140)。inputs から transition を返すだけで副作用なし。
   enum class StoppedTransition { NONE, TO_STOPPED, TO_RESUMED };
@@ -197,9 +203,11 @@ private:
   };
   static StoppedTransition compute_stopped_transition(const StoppedDetectionInputs & in);
 
-  // 全 inside POI に対して STOPPED publish (Nav2 SUCCEEDED 受信時)。
-  // 既に STOPPED state の POI は idempotent に skip。``reason`` は log 用 ("Nav2 succeeded" 等)。
-  void stop_all_inside_pois(const std::string & reason);
+  // STOPPED publish (Nav2 SUCCEEDED 受信時)。``target_poi_name`` が指定された場合、その POI は
+  // inside check を skip して強制的に STOPPED publish する (SUCCEEDED と tolerance_check tick の
+  // 非同期で「まだ inside と判定されていない」瞬間に SUCCEEDED が来ても取りこぼさない)。それ以外
+  // の inside POI は通常通り poi_inside_state_ を見て publish。``reason`` は log 用。
+  void stop_all_inside_pois(const std::string & reason, const std::string & target_poi_name = "");
   // 全 stopped POI に対して RESUMED publish (新規 goal 受信時)。
   void resume_all_stopped_pois();
 

--- a/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav_server.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist.hpp>
 #include <nav2_msgs/action/follow_waypoints.hpp>
 #include <nav2_msgs/action/navigate_to_pose.hpp>
 #include <std_msgs/msg/string.hpp>
@@ -117,7 +118,7 @@ private:
 
   // active route の POI 名 set (waypoints + landmarks 両方を含む) (#143)。
   // route 受信 (on_route_received) で set、route 終端 / cancel / GOAL 切替で clear。
-  // radius_check_callback の pause 発火条件 (active route POI に含まれる時のみ) で参照。
+  // tolerance_check_callback の pause 発火条件 (active route POI に含まれる時のみ) で参照。
   std::unordered_set<std::string> current_route_poi_names_;
   void clear_current_route_poi_names_();
 
@@ -150,7 +151,7 @@ private:
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
-  rclcpp::TimerBase::SharedPtr radius_check_timer_;
+  rclcpp::TimerBase::SharedPtr tolerance_check_timer_;
   rclcpp::Publisher<mapoi_interfaces::msg::PoiEvent>::SharedPtr poi_event_pub_;
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr config_path_sub_;
   rclcpp::Client<mapoi_interfaces::srv::GetTagDefinitions>::SharedPtr tag_defs_client_;
@@ -168,13 +169,45 @@ private:
   std::unordered_set<std::string> system_tags_;
   bool system_tags_loaded_ = false;
   std::unordered_map<std::string, bool> poi_inside_state_;  // key: poi.name
+  // STOPPED/RESUMED 判定用の per-POI 状態 (#140)。
+  //   was_stopped == true: 既に EVENT_STOPPED 発火済 (RESUMED まで持続)。
+  //   was_stopped == false: 未停止 / OUTSIDE / RESUMED 後。
+  // ENTER/EXIT 判定 (poi_inside_state_) と独立して持つ: STOPPED は inside 内での
+  // sub-state なので、EXIT 時は inside_state→false と同時に stopped_state→false に reset する。
+  std::unordered_map<std::string, bool> poi_stopped_state_;  // key: poi.name
   std::vector<mapoi_interfaces::msg::PointOfInterest> event_pois_;
+
+  // --- STOPPED/RESUMED 判定 (#140) ---
+  // cmd_vel subscriber: 速度判定の source の一つ。Nav2 action SUCCEEDED もう一つの source は
+  // result_callback / ntp_result_callback で hook する (両方 OR で STOPPED 判定)。
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
+  void cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
+  // 最後に観測した速度 (m/s 換算、|linear| + |angular|*r_eff の単純合算で近似)。
+  double last_cmd_vel_speed_ {0.0};
+  // 速度が閾値以下になり始めた時刻 (steady_clock)。閾値超えに戻ったら reset。
+  std::chrono::steady_clock::time_point last_zero_velocity_start_ {};
+  bool zero_velocity_active_ {false};
+
+  // 状態遷移判定の純関数 (unit test 用、#140)。inputs から transition を返すだけで副作用なし。
+  enum class StoppedTransition { NONE, TO_STOPPED, TO_RESUMED };
+  struct StoppedDetectionInputs {
+    bool inside;                 // robot が POI の tolerance.xy 内に居るか
+    bool was_stopped;            // 前 tick での poi_stopped_state_
+    bool zero_velocity_dwelled;  // 速度が閾値以下で dwell_time 以上経過
+  };
+  static StoppedTransition compute_stopped_transition(const StoppedDetectionInputs & in);
+
+  // 全 inside POI に対して STOPPED publish (Nav2 SUCCEEDED 受信時)。
+  // 既に STOPPED state の POI は idempotent に skip。``reason`` は log 用 ("Nav2 succeeded" 等)。
+  void stop_all_inside_pois(const std::string & reason);
+  // 全 stopped POI に対して RESUMED publish (新規 goal 受信時)。
+  void resume_all_stopped_pois();
 
   void fetch_system_tags();
   void on_system_tags_received(rclcpp::Client<mapoi_interfaces::srv::GetTagDefinitions>::SharedFuture future);
   void on_config_path_changed(const std_msgs::msg::String::SharedPtr msg);
   void rebuild_event_pois();
-  void radius_check_callback();
+  void tolerance_check_callback();
   double distance_2d(const geometry_msgs::msg::Pose & poi_pose, double rx, double ry);
 
   // landmark system tag を持つかを判定する純関数 (#85)。
@@ -182,7 +215,7 @@ private:
   static bool has_landmark_tag(const mapoi_interfaces::msg::PointOfInterest & poi);
 
   // active route の POI 名集合を組み立てる純関数 (#143 / #148)。
-  // waypoints と landmarks の両方を 1 つの set にマージし、radius_check の
+  // waypoints と landmarks の両方を 1 つの set にマージし、tolerance_check の
   // pause 発火条件 (active route POI に含まれるか) を判定する用に使う。
   // 同名の重複は set 性質で自動的に 1 つに集約される。
   static std::unordered_set<std::string> build_route_poi_names(
@@ -205,7 +238,7 @@ private:
     const geometry_msgs::msg::Pose & pose, const std::string & source);
 
   // /initialpose subscriber (主に AMCL) が後起動した場合の async retry 機構 (#152)。
-  // single-thread executor で blocking wait すると radius_check 等が止まる回帰があるため、
+  // single-thread executor で blocking wait すると tolerance_check 等が止まる回帰があるため、
   // wall timer ベースで polling する。subscriber 検知で 1 回再 publish + timer cancel。
   void schedule_initialpose_retry(
     const geometry_msgs::msg::Pose & pose, const std::string & source);
@@ -238,6 +271,11 @@ private:
   FRIEND_TEST(NavServerTestFixture, IsPauseEligibleGoalMode);
   FRIEND_TEST(NavServerTestFixture, IsPauseEligibleIdleMode);
   FRIEND_TEST(NavServerTestFixture, ResetNavStateClearsRouteContext);
+  FRIEND_TEST(NavServerTestFixture, ComputeStoppedTransitionNoOutside);
+  FRIEND_TEST(NavServerTestFixture, ComputeStoppedTransitionEnterStopped);
+  FRIEND_TEST(NavServerTestFixture, ComputeStoppedTransitionEnterMoving);
+  FRIEND_TEST(NavServerTestFixture, ComputeStoppedTransitionResumeOnVelocity);
+  FRIEND_TEST(NavServerTestFixture, ComputeStoppedTransitionStaysStopped);
 #endif
 };
 

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -70,10 +70,16 @@ MapoiNavServer::MapoiNavServer(const rclcpp::NodeOptions & options)
   this->declare_parameter<double>("hysteresis_exit_multiplier", 1.15);
   this->declare_parameter<std::string>("map_frame", "map");
   this->declare_parameter<std::string>("base_frame", "base_link");
-  // STOPPED/RESUMED 判定 (#140): cmd_vel 速度閾値 (m/s 換算) と継続時間閾値、購読 topic 名。
+  // STOPPED/RESUMED 判定 (#140): 線速ノルムと角速度絶対値の両方が ``stopped_speed_threshold``
+  // 未満の状態が ``stopped_dwell_time_sec`` 続いたら EVENT_STOPPED publish。線速 (m/s) と角速
+  // (rad/s) に同一閾値を使う割り切りで「その場旋回も停止扱いしない」用途を表現する。
   this->declare_parameter<double>("stopped_speed_threshold", 0.01);
   this->declare_parameter<double>("stopped_dwell_time_sec", 1.0);
   this->declare_parameter<std::string>("cmd_vel_topic", "cmd_vel");
+  // パラメータを cmd_vel_callback / tolerance_check_callback の hot path で毎回取得すると
+  // lock コストが高いため、起動時にキャッシュして以降は member を読む (#176 review low #4)。
+  stopped_speed_threshold_ = this->get_parameter("stopped_speed_threshold").as_double();
+  stopped_dwell_time_sec_ = this->get_parameter("stopped_dwell_time_sec").as_double();
 
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
@@ -610,9 +616,10 @@ void MapoiNavServer::result_callback(std::string target, size_t nav_generation,
       reset_nav_state();
       publish_nav_status("succeeded", target);
       RCLCPP_INFO(this->get_logger(), "Navigation SUCCEEDED!");
-      // Nav2 SUCCEEDED 時点で robot は goal で停止している。現在 inside の POI に対して
-      // STOPPED publish (#140)。cmd_vel ベースの dwell 待ちを経由せず即時に発火する。
-      stop_all_inside_pois("Nav2 FollowWaypoints succeeded");
+      // Nav2 SUCCEEDED 時点で robot は goal で停止している。target POI に対して強制 publish
+      // (inside check skip で取りこぼし防止) + 他の inside POI にも STOPPED publish (#140)。
+      // cmd_vel ベースの dwell 待ちを経由せず即時発火。
+      stop_all_inside_pois("Nav2 FollowWaypoints succeeded", target);
       break;
     case rclcpp_action::ResultCode::ABORTED:
       reset_nav_state();
@@ -674,7 +681,7 @@ void MapoiNavServer::ntp_result_callback(std::string target, size_t nav_generati
       reset_nav_state();
       publish_nav_status("succeeded", target);
       RCLCPP_INFO(this->get_logger(), "NavigateToPose SUCCEEDED!");
-      stop_all_inside_pois("Nav2 NavigateToPose succeeded");
+      stop_all_inside_pois("Nav2 NavigateToPose succeeded", target);
       break;
     case rclcpp_action::ResultCode::ABORTED:
       reset_nav_state();
@@ -954,15 +961,13 @@ void MapoiNavServer::tolerance_check_callback()
   double rx = transform.transform.translation.x;
   double ry = transform.transform.translation.y;
   double hysteresis = this->get_parameter("hysteresis_exit_multiplier").as_double();
-  // STOPPED 判定の dwell threshold (#140)。zero_velocity が dwell 以上続いたら停止扱い。
-  const double dwell_threshold_sec =
-    this->get_parameter("stopped_dwell_time_sec").as_double();
-  // 現在 cmd_vel が閾値以下で dwell threshold 経過済か (timer tick 内で 1 回計算して使い回す)。
+  // STOPPED 判定: zero_velocity が dwell threshold 以上続いたら停止扱い (#140)。
+  // 全 POI 共通の判定なので timer tick 内で 1 回計算して使い回す。
   bool zero_velocity_dwelled = false;
   if (zero_velocity_active_) {
     const double dwell = std::chrono::duration<double>(
       std::chrono::steady_clock::now() - last_zero_velocity_start_).count();
-    zero_velocity_dwelled = (dwell >= dwell_threshold_sec);
+    zero_velocity_dwelled = (dwell >= stopped_dwell_time_sec_);
   }
 
   // pause タグ POI の ENTER を収集（mutex 外で処理するため）
@@ -1065,16 +1070,16 @@ double MapoiNavServer::distance_2d(const geometry_msgs::msg::Pose & poi_pose, do
 
 void MapoiNavServer::cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg)
 {
-  // 線速 (3D) と角速 (yaw 軸) の両方が閾値以下のとき「停止」とみなす。撮影シナリオでは
-  // その場旋回もしない前提のため、angular.z も判定に含める。
-  const double threshold = this->get_parameter("stopped_speed_threshold").as_double();
+  // 線速ノルム (3D) と角速度絶対値 (yaw 軸) の両方が閾値以下のとき「停止」とみなす。
+  // 撮影シナリオでは「その場旋回も停止扱いしない」前提のため、angular.z も判定に含める。
+  // 単位が異なるが同一閾値を使う割り切り (param 説明参照、#140)。
   const double linear_norm = std::sqrt(
     msg->linear.x * msg->linear.x +
     msg->linear.y * msg->linear.y +
     msg->linear.z * msg->linear.z);
   const double angular_norm = std::abs(msg->angular.z);
-  last_cmd_vel_speed_ = linear_norm + angular_norm;
-  const bool zero_now = (linear_norm < threshold) && (angular_norm < threshold);
+  const bool zero_now =
+    (linear_norm < stopped_speed_threshold_) && (angular_norm < stopped_speed_threshold_);
   if (zero_now) {
     if (!zero_velocity_active_) {
       zero_velocity_active_ = true;
@@ -1104,18 +1109,29 @@ MapoiNavServer::StoppedTransition MapoiNavServer::compute_stopped_transition(
   return in.zero_velocity_dwelled ? StoppedTransition::NONE : StoppedTransition::TO_RESUMED;
 }
 
-void MapoiNavServer::stop_all_inside_pois(const std::string & reason)
+void MapoiNavServer::stop_all_inside_pois(
+  const std::string & reason, const std::string & target_poi_name)
 {
   // Nav2 SUCCEEDED 受信時に呼ぶ: 現在 inside の全 POI に対して STOPPED publish
   // (既に STOPPED state の POI は idempotent に skip)。
+  // ``target_poi_name`` が指定された場合は、その POI は inside check を skip して
+  // 強制的に STOPPED publish する (SUCCEEDED と tolerance_check tick の非同期による
+  // 取りこぼし防止、#176 review medium #1)。
   // event_pois_ / poi_inside_state_ / poi_stopped_state_ を lock で守って snapshot を
   // 取り、publish は lock 外で実行 (既存 tolerance_check の pattern と整合)。
   std::vector<mapoi_interfaces::msg::PointOfInterest> to_stop;
   {
     std::lock_guard<std::mutex> lock(data_mutex_);
     for (const auto & poi : event_pois_) {
-      if (poi_inside_state_[poi.name] && !poi_stopped_state_[poi.name]) {
+      const bool is_target = !target_poi_name.empty() && poi.name == target_poi_name;
+      const bool eligible = is_target || poi_inside_state_[poi.name];
+      if (eligible && !poi_stopped_state_[poi.name]) {
         poi_stopped_state_[poi.name] = true;
+        // target POI は SUCCEEDED で確実に到達済なので、念のため inside_state も true に
+        // 同期させる (まだ TF が tick で観測されていないケース対応)。
+        if (is_target) {
+          poi_inside_state_[poi.name] = true;
+        }
         to_stop.push_back(poi);
       }
     }

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -1117,24 +1117,39 @@ void MapoiNavServer::stop_all_inside_pois(
   // ``target_poi_name`` が指定された場合は、その POI は inside check を skip して
   // 強制的に STOPPED publish する (SUCCEEDED と tolerance_check tick の非同期による
   // 取りこぼし防止、#176 review medium #1)。
+  // target POI でまだ ENTER 未発火の場合、lifecycle invariant ``ENTER → STOPPED → EXIT`` を
+  // 守るため ENTER を先に publish してから STOPPED を発火する (#176 review r2 high #1)。
   // event_pois_ / poi_inside_state_ / poi_stopped_state_ を lock で守って snapshot を
   // 取り、publish は lock 外で実行 (既存 tolerance_check の pattern と整合)。
+  std::vector<mapoi_interfaces::msg::PointOfInterest> to_enter;
   std::vector<mapoi_interfaces::msg::PointOfInterest> to_stop;
   {
     std::lock_guard<std::mutex> lock(data_mutex_);
     for (const auto & poi : event_pois_) {
       const bool is_target = !target_poi_name.empty() && poi.name == target_poi_name;
-      const bool eligible = is_target || poi_inside_state_[poi.name];
-      if (eligible && !poi_stopped_state_[poi.name]) {
+      const bool was_inside = poi_inside_state_[poi.name];
+      const bool eligible = is_target || was_inside;
+      if (!eligible) continue;
+      // target POI で inside_state がまだ false なら ENTER 先行 publish (lifecycle 整合)。
+      if (is_target && !was_inside) {
+        poi_inside_state_[poi.name] = true;
+        to_enter.push_back(poi);
+      }
+      if (!poi_stopped_state_[poi.name]) {
         poi_stopped_state_[poi.name] = true;
-        // target POI は SUCCEEDED で確実に到達済なので、念のため inside_state も true に
-        // 同期させる (まだ TF が tick で観測されていないケース対応)。
-        if (is_target) {
-          poi_inside_state_[poi.name] = true;
-        }
         to_stop.push_back(poi);
       }
     }
+  }
+  // ENTER → STOPPED の順で publish (subscriber 側の handler 設計が ENTER を前提にできる)。
+  for (const auto & poi : to_enter) {
+    mapoi_interfaces::msg::PoiEvent event;
+    event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_ENTER;
+    event.poi = poi;
+    event.stamp = this->now();
+    poi_event_pub_->publish(event);
+    RCLCPP_INFO(this->get_logger(),
+      "POI ENTER (forced by %s): %s", reason.c_str(), poi.name.c_str());
   }
   for (const auto & poi : to_stop) {
     mapoi_interfaces::msg::PoiEvent event;

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -66,10 +66,14 @@ MapoiNavServer::MapoiNavServer(const rclcpp::NodeOptions & options)
   this->route_client_ = this->create_client<mapoi_interfaces::srv::GetRoutePois>("get_route_pois");
 
   // --- POI radius event detection ---
-  this->declare_parameter<double>("radius_check_hz", 5.0);
+  this->declare_parameter<double>("tolerance_check_hz", 5.0);
   this->declare_parameter<double>("hysteresis_exit_multiplier", 1.15);
   this->declare_parameter<std::string>("map_frame", "map");
   this->declare_parameter<std::string>("base_frame", "base_link");
+  // STOPPED/RESUMED 判定 (#140): cmd_vel 速度閾値 (m/s 換算) と継続時間閾値、購読 topic 名。
+  this->declare_parameter<double>("stopped_speed_threshold", 0.01);
+  this->declare_parameter<double>("stopped_dwell_time_sec", 1.0);
+  this->declare_parameter<std::string>("cmd_vel_topic", "cmd_vel");
 
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
@@ -80,14 +84,21 @@ MapoiNavServer::MapoiNavServer(const rclcpp::NodeOptions & options)
     "mapoi_config_path", rclcpp::QoS(1).transient_local(),
     std::bind(&MapoiNavServer::on_config_path_changed, this, _1));
 
+  // cmd_vel subscribe (#140): STOPPED 判定の source の一つ (もう一つは Nav2 SUCCEEDED)。
+  // QoS は Nav2 の cmd_vel publisher と同じ default (reliable, depth=10)。
+  const std::string cmd_vel_topic = this->get_parameter("cmd_vel_topic").as_string();
+  cmd_vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+    cmd_vel_topic, 10,
+    std::bind(&MapoiNavServer::cmd_vel_callback, this, _1));
+
   tag_defs_client_ = this->create_client<mapoi_interfaces::srv::GetTagDefinitions>("get_tag_definitions");
   fetch_system_tags();
 
-  double hz = this->get_parameter("radius_check_hz").as_double();
+  double hz = this->get_parameter("tolerance_check_hz").as_double();
   auto period = std::chrono::duration<double>(1.0 / hz);
-  radius_check_timer_ = this->create_wall_timer(
+  tolerance_check_timer_ = this->create_wall_timer(
     std::chrono::duration_cast<std::chrono::nanoseconds>(period),
-    std::bind(&MapoiNavServer::radius_check_callback, this));
+    std::bind(&MapoiNavServer::tolerance_check_callback, this));
 
   RCLCPP_INFO(this->get_logger(), "MapoiNavServer initialized.");
 }
@@ -165,6 +176,10 @@ void MapoiNavServer::mapoi_goal_pose_poi_cb(const std_msgs::msg::String::SharedP
 {
   std::string poi_name = msg->data;
   RCLCPP_INFO(this->get_logger(), "Received POI name for goal pose: %s", poi_name.c_str());
+  // 新規 goal 受信時に現在 STOPPED 状態の POI を全て RESUMED publish する (#140)。
+  // 以降 Nav2 への goal 送信で robot が動き始めるため、STOPPED 中の subscriber が
+  // 「停止解除」を即時に検知できる (cmd_vel callback で観測する前に publish)。
+  resume_all_stopped_pois();
   // target は send_goal_options に lambda capture で bind し、callback 側で
   // goal 固有の target を使って publish_nav_status する (#104 race fix)。
   // current_target_name_ は acceptance 時 (goal_response_callback) に更新され、
@@ -253,6 +268,9 @@ void MapoiNavServer::mapoi_goal_pose_poi_cb(const std_msgs::msg::String::SharedP
 void MapoiNavServer::mapoi_route_cb(const std_msgs::msg::String::SharedPtr msg)
 {
   RCLCPP_INFO(this->get_logger(), "Received route name: %s", msg->data.c_str());
+  // 新規 route 受信時に現在 STOPPED 状態の POI を全て RESUMED publish (#140)。
+  // 以降の send_goal で robot が動き始めるため、即時に「停止解除」通知する。
+  resume_all_stopped_pois();
   // target は on_route_received → send_goal_options に lambda capture で bind し、
   // callback 側で goal 固有の target を使って publish_nav_status する (#104 race fix)。
   // current_target_name_ は acceptance 時 (goal_response_callback) に更新される。
@@ -481,7 +499,7 @@ void MapoiNavServer::on_route_received(
     return;
   }
 
-  // active route の POI 名 set を構築 (waypoints + landmarks 両方を radius_check で
+  // active route の POI 名 set を構築 (waypoints + landmarks 両方を tolerance_check で
   // pause 発火対象として扱う)。lock 下で書き込み (#143)。
   // 構築ロジックは pure helper に切り出し、unit test で検証する (#148)。
   {
@@ -592,6 +610,9 @@ void MapoiNavServer::result_callback(std::string target, size_t nav_generation,
       reset_nav_state();
       publish_nav_status("succeeded", target);
       RCLCPP_INFO(this->get_logger(), "Navigation SUCCEEDED!");
+      // Nav2 SUCCEEDED 時点で robot は goal で停止している。現在 inside の POI に対して
+      // STOPPED publish (#140)。cmd_vel ベースの dwell 待ちを経由せず即時に発火する。
+      stop_all_inside_pois("Nav2 FollowWaypoints succeeded");
       break;
     case rclcpp_action::ResultCode::ABORTED:
       reset_nav_state();
@@ -653,6 +674,7 @@ void MapoiNavServer::ntp_result_callback(std::string target, size_t nav_generati
       reset_nav_state();
       publish_nav_status("succeeded", target);
       RCLCPP_INFO(this->get_logger(), "NavigateToPose SUCCEEDED!");
+      stop_all_inside_pois("Nav2 NavigateToPose succeeded");
       break;
     case rclcpp_action::ResultCode::ABORTED:
       reset_nav_state();
@@ -844,7 +866,7 @@ void MapoiNavServer::fetch_system_tags()
 {
   if (!tag_defs_client_->service_is_ready()) {
     RCLCPP_INFO(this->get_logger(), "get_tag_definitions service not available yet, waiting...");
-    return;  // radius_check_callback will retry via guard check
+    return;  // tolerance_check_callback will retry via guard check
   }
   auto request = std::make_shared<mapoi_interfaces::srv::GetTagDefinitions::Request>();
   tag_defs_client_->async_send_request(
@@ -911,7 +933,7 @@ void MapoiNavServer::rebuild_event_pois()
   RCLCPP_INFO(this->get_logger(), "Monitoring %zu POIs for radius events.", event_pois_.size());
 }
 
-void MapoiNavServer::radius_check_callback()
+void MapoiNavServer::tolerance_check_callback()
 {
   if (!system_tags_loaded_) {
     fetch_system_tags();
@@ -932,6 +954,16 @@ void MapoiNavServer::radius_check_callback()
   double rx = transform.transform.translation.x;
   double ry = transform.transform.translation.y;
   double hysteresis = this->get_parameter("hysteresis_exit_multiplier").as_double();
+  // STOPPED 判定の dwell threshold (#140)。zero_velocity が dwell 以上続いたら停止扱い。
+  const double dwell_threshold_sec =
+    this->get_parameter("stopped_dwell_time_sec").as_double();
+  // 現在 cmd_vel が閾値以下で dwell threshold 経過済か (timer tick 内で 1 回計算して使い回す)。
+  bool zero_velocity_dwelled = false;
+  if (zero_velocity_active_) {
+    const double dwell = std::chrono::duration<double>(
+      std::chrono::steady_clock::now() - last_zero_velocity_start_).count();
+    zero_velocity_dwelled = (dwell >= dwell_threshold_sec);
+  }
 
   // pause タグ POI の ENTER を収集（mutex 外で処理するため）
   std::string pause_triggered_poi;
@@ -967,6 +999,10 @@ void MapoiNavServer::radius_check_callback()
       } else if (was_inside && dist > poi.tolerance.xy * hysteresis) {
         // EXIT event: 全POIでPoiEvent発行
         poi_inside_state_[poi.name] = false;
+        // STOPPED state も EXIT で clear (#140)。RESUMED publish は EXIT で兼ねる扱いとする
+        // (ライフサイクル: ENTER → STOPPED → (RESUMED |) EXIT。EXIT 時に明示 RESUMED を出すと
+        // 同 tick で 2 イベントが連続発火して subscriber 側の handler 設計が複雑化するため見送り)。
+        poi_stopped_state_[poi.name] = false;
         mapoi_interfaces::msg::PoiEvent event;
         event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_EXIT;
         event.poi = poi;
@@ -974,6 +1010,30 @@ void MapoiNavServer::radius_check_callback()
         poi_event_pub_->publish(event);
         RCLCPP_INFO(this->get_logger(), "POI EXIT: %s (dist=%.2f, tolerance.xy=%.2f)",
                     poi.name.c_str(), dist, poi.tolerance.xy);
+        continue;  // STOPPED/RESUMED 判定不要 (今 tick で OUTSIDE 化)
+      }
+
+      // STOPPED / RESUMED 判定 (#140): inside (新規 ENTER 含む) かつ velocity / RESUMED 条件。
+      if (!poi_inside_state_[poi.name]) continue;
+      const bool was_stopped = poi_stopped_state_[poi.name];
+      const StoppedDetectionInputs in{true, was_stopped, zero_velocity_dwelled};
+      const auto trans = compute_stopped_transition(in);
+      if (trans == StoppedTransition::TO_STOPPED) {
+        poi_stopped_state_[poi.name] = true;
+        mapoi_interfaces::msg::PoiEvent event;
+        event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_STOPPED;
+        event.poi = poi;
+        event.stamp = this->now();
+        poi_event_pub_->publish(event);
+        RCLCPP_INFO(this->get_logger(), "POI STOPPED: %s", poi.name.c_str());
+      } else if (trans == StoppedTransition::TO_RESUMED) {
+        poi_stopped_state_[poi.name] = false;
+        mapoi_interfaces::msg::PoiEvent event;
+        event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_RESUMED;
+        event.poi = poi;
+        event.stamp = this->now();
+        poi_event_pub_->publish(event);
+        RCLCPP_INFO(this->get_logger(), "POI RESUMED: %s", poi.name.c_str());
       }
     }
   }  // data_mutex_ をここで解放
@@ -999,6 +1059,99 @@ double MapoiNavServer::distance_2d(const geometry_msgs::msg::Pose & poi_pose, do
   double dx = poi_pose.position.x - rx;
   double dy = poi_pose.position.y - ry;
   return std::sqrt(dx * dx + dy * dy);
+}
+
+// --- STOPPED / RESUMED 判定 (#140) ---
+
+void MapoiNavServer::cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg)
+{
+  // 線速 (3D) と角速 (yaw 軸) の両方が閾値以下のとき「停止」とみなす。撮影シナリオでは
+  // その場旋回もしない前提のため、angular.z も判定に含める。
+  const double threshold = this->get_parameter("stopped_speed_threshold").as_double();
+  const double linear_norm = std::sqrt(
+    msg->linear.x * msg->linear.x +
+    msg->linear.y * msg->linear.y +
+    msg->linear.z * msg->linear.z);
+  const double angular_norm = std::abs(msg->angular.z);
+  last_cmd_vel_speed_ = linear_norm + angular_norm;
+  const bool zero_now = (linear_norm < threshold) && (angular_norm < threshold);
+  if (zero_now) {
+    if (!zero_velocity_active_) {
+      zero_velocity_active_ = true;
+      last_zero_velocity_start_ = std::chrono::steady_clock::now();
+    }
+  } else {
+    zero_velocity_active_ = false;
+  }
+}
+
+// 純関数 (副作用なし、unit test 用)。inside / was_stopped / zero_velocity / zero_velocity_dwelled
+// の組み合わせから次の遷移を返す。
+//
+// 仕様:
+//   - !inside: NONE (EXIT 側で stopped state は別途 reset する)
+//   - !was_stopped + zero_velocity_dwelled (停止が dwell_time 続いた): TO_STOPPED
+//   - was_stopped + !zero_velocity (動き始めた): TO_RESUMED (dwell 不要、即時)
+//   - それ以外: NONE
+MapoiNavServer::StoppedTransition MapoiNavServer::compute_stopped_transition(
+  const StoppedDetectionInputs & in)
+{
+  if (!in.inside) return StoppedTransition::NONE;
+  if (!in.was_stopped) {
+    return in.zero_velocity_dwelled ? StoppedTransition::TO_STOPPED : StoppedTransition::NONE;
+  }
+  // was_stopped == true
+  return in.zero_velocity_dwelled ? StoppedTransition::NONE : StoppedTransition::TO_RESUMED;
+}
+
+void MapoiNavServer::stop_all_inside_pois(const std::string & reason)
+{
+  // Nav2 SUCCEEDED 受信時に呼ぶ: 現在 inside の全 POI に対して STOPPED publish
+  // (既に STOPPED state の POI は idempotent に skip)。
+  // event_pois_ / poi_inside_state_ / poi_stopped_state_ を lock で守って snapshot を
+  // 取り、publish は lock 外で実行 (既存 tolerance_check の pattern と整合)。
+  std::vector<mapoi_interfaces::msg::PointOfInterest> to_stop;
+  {
+    std::lock_guard<std::mutex> lock(data_mutex_);
+    for (const auto & poi : event_pois_) {
+      if (poi_inside_state_[poi.name] && !poi_stopped_state_[poi.name]) {
+        poi_stopped_state_[poi.name] = true;
+        to_stop.push_back(poi);
+      }
+    }
+  }
+  for (const auto & poi : to_stop) {
+    mapoi_interfaces::msg::PoiEvent event;
+    event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_STOPPED;
+    event.poi = poi;
+    event.stamp = this->now();
+    poi_event_pub_->publish(event);
+    RCLCPP_INFO(this->get_logger(), "POI STOPPED (%s): %s", reason.c_str(), poi.name.c_str());
+  }
+}
+
+void MapoiNavServer::resume_all_stopped_pois()
+{
+  // 新規 goal 受信時に呼ぶ: 現在 STOPPED 状態の全 POI に RESUMED publish。
+  // event_pois_ と poi_stopped_state_ を lock で守って snapshot を取り、publish は lock 外。
+  std::vector<mapoi_interfaces::msg::PointOfInterest> to_resume;
+  {
+    std::lock_guard<std::mutex> lock(data_mutex_);
+    for (const auto & poi : event_pois_) {
+      if (poi_stopped_state_[poi.name]) {
+        poi_stopped_state_[poi.name] = false;
+        to_resume.push_back(poi);
+      }
+    }
+  }
+  for (const auto & poi : to_resume) {
+    mapoi_interfaces::msg::PoiEvent event;
+    event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_RESUMED;
+    event.poi = poi;
+    event.stamp = this->now();
+    poi_event_pub_->publish(event);
+    RCLCPP_INFO(this->get_logger(), "POI RESUMED (new goal): %s", poi.name.c_str());
+  }
 }
 
 #ifndef UNIT_TEST

--- a/mapoi_server/test/test_nav_server_unit.cpp
+++ b/mapoi_server/test/test_nav_server_unit.cpp
@@ -237,6 +237,53 @@ TEST_F(NavServerTestFixture, ResetNavStateClearsRouteContext)
   EXPECT_DOUBLE_EQ(node_->paused_goal_pose_.pose.position.x, 0.0);
 }
 
+// --- compute_stopped_transition (#140) ---
+// STOPPED/RESUMED 判定の純関数 state machine の test。副作用なしで inside / was_stopped /
+// zero_velocity_dwelled の組み合わせから次の遷移を返すだけなので Node 不要 (TEST で十分)。
+
+TEST_F(NavServerTestFixture, ComputeStoppedTransitionNoOutside)
+{
+  using S = MapoiNavServer::StoppedDetectionInputs;
+  using T = MapoiNavServer::StoppedTransition;
+  // !inside の場合は state に関わらず NONE (EXIT で別途 stopped state を reset する規約)。
+  EXPECT_EQ(MapoiNavServer::compute_stopped_transition(S{false, false, false}), T::NONE);
+  EXPECT_EQ(MapoiNavServer::compute_stopped_transition(S{false, false, true}),  T::NONE);
+  EXPECT_EQ(MapoiNavServer::compute_stopped_transition(S{false, true, false}),  T::NONE);
+  EXPECT_EQ(MapoiNavServer::compute_stopped_transition(S{false, true, true}),   T::NONE);
+}
+
+TEST_F(NavServerTestFixture, ComputeStoppedTransitionEnterStopped)
+{
+  using S = MapoiNavServer::StoppedDetectionInputs;
+  using T = MapoiNavServer::StoppedTransition;
+  // inside + !was_stopped + dwelled → TO_STOPPED
+  EXPECT_EQ(MapoiNavServer::compute_stopped_transition(S{true, false, true}), T::TO_STOPPED);
+}
+
+TEST_F(NavServerTestFixture, ComputeStoppedTransitionEnterMoving)
+{
+  using S = MapoiNavServer::StoppedDetectionInputs;
+  using T = MapoiNavServer::StoppedTransition;
+  // inside + !was_stopped + !dwelled → NONE (停止が dwell 経過するまで何もしない)
+  EXPECT_EQ(MapoiNavServer::compute_stopped_transition(S{true, false, false}), T::NONE);
+}
+
+TEST_F(NavServerTestFixture, ComputeStoppedTransitionResumeOnVelocity)
+{
+  using S = MapoiNavServer::StoppedDetectionInputs;
+  using T = MapoiNavServer::StoppedTransition;
+  // inside + was_stopped + !dwelled (動き始めた) → TO_RESUMED (即時、dwell 不要)
+  EXPECT_EQ(MapoiNavServer::compute_stopped_transition(S{true, true, false}), T::TO_RESUMED);
+}
+
+TEST_F(NavServerTestFixture, ComputeStoppedTransitionStaysStopped)
+{
+  using S = MapoiNavServer::StoppedDetectionInputs;
+  using T = MapoiNavServer::StoppedTransition;
+  // inside + was_stopped + dwelled (停止継続) → NONE (重複 STOPPED 発火しない)
+  EXPECT_EQ(MapoiNavServer::compute_stopped_transition(S{true, true, true}), T::NONE);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/mapoi_server/test/test_poi_event_integration.py
+++ b/mapoi_server/test/test_poi_event_integration.py
@@ -36,7 +36,7 @@ def generate_test_description():
         executable='mapoi_nav_server',
         name='mapoi_nav_server',
         parameters=[{
-            'radius_check_hz': 10.0,
+            'tolerance_check_hz': 10.0,
             'map_frame': 'map',
             'base_frame': 'base_link',
         }],
@@ -57,10 +57,10 @@ class TestPoiEventIntegration(unittest.TestCase):
     取りこぼしを防ぐ。
     """
 
-    # event 待ちの timeout。CI の CPU 負荷時にも `radius_check_hz=10` × 数周期分の
+    # event 待ちの timeout。CI の CPU 負荷時にも `tolerance_check_hz=10` × 数周期分の
     # マージンが取れる長さ。低めにすると nav_server の初期 fetch race で flaky 化する。
     EVENT_WAIT_TIMEOUT = 5.0
-    # dynamic TF publish 周期。radius_check_hz=10 (=100ms) より十分速くして取りこぼしを防ぐ。
+    # dynamic TF publish 周期。tolerance_check_hz=10 (=100ms) より十分速くして取りこぼしを防ぐ。
     TF_PUBLISH_INTERVAL = 0.05
 
     @classmethod
@@ -146,7 +146,7 @@ class TestPoiEventIntegration(unittest.TestCase):
         現在 inside と推定される POI を列挙し、pose を全 POI から十分遠い
         `(100, 100)` に動かしてから、各 POI の EVENT_EXIT を bounded timeout で
         待つ。fixed sleep ではなく完了条件付き待機にすることで、TF 反映や
-        radius_check 遅延時にも tearDown 側で fail を検出できる (#165)。
+        tolerance_check 遅延時にも tearDown 側で fail を検出できる (#165)。
 
         tearDown と test 内 (順序非依存な isolation 検証) で共有する。
         """


### PR DESCRIPTION
## Summary

- ``PoiEvent.msg`` の ``EVENT_STOPPED`` / ``EVENT_RESUMED`` (#87 で定数追加済) の judgement logic を実装
- 判定 source は OR で 2 系統 (Nav2 action SUCCEEDED + cmd_vel ベース dwell)
- 旧 param ``radius_check_hz`` を ``tolerance_check_hz`` にリネーム (#87 の tolerance.xy 化に伴う命名整合、breaking)

## 判定仕様

### EVENT_STOPPED

robot が POI ``tolerance.xy`` 内に居て、いずれかを満たすとき:

- **Nav2 action SUCCEEDED**: ``FollowWaypoints`` / ``NavigateToPose`` の ``result_callback`` で SUCCEEDED 検知 → 現在 inside の全 POI に即時 publish (``stop_all_inside_pois``)
- **cmd_vel dwell**: 線速 + 角速の両方が ``stopped_speed_threshold`` (default 0.01) 未満の状態が ``stopped_dwell_time_sec`` (default 1.0 秒) 続く → ``tolerance_check_callback`` で判定

### EVENT_RESUMED

- **速度復活**: STOPPED 状態の POI で速度が閾値超に戻った瞬間 → ``tolerance_check_callback`` で即時 publish (dwell 不要)
- **新規 goal 受信**: ``mapoi_goal_pose_poi`` / ``mapoi_route`` cb 冒頭で ``resume_all_stopped_pois`` を呼び、現在 STOPPED の全 POI に publish

### EXIT 時

- ``poi_inside_state_`` → false と同時に ``poi_stopped_state_`` も reset
- EVENT_EXIT を「停止解除」を兼ねる扱いとして、追加で EVENT_RESUMED を publish しない (ライフサイクル: ENTER → STOPPED → EXIT に整理、subscriber handler の二重発火を防ぐ)

## 実装

| 領域 | 変更 |
|---|---|
| ``mapoi_nav_server.hpp`` | ``cmd_vel`` subscriber、``poi_stopped_state_`` map、state machine 純関数 (``compute_stopped_transition``)、``stop_all_inside_pois`` / ``resume_all_stopped_pois`` helper、新パラメータ追加 |
| ``mapoi_nav_server.cpp`` | constructor に param + cmd_vel subscribe、``cmd_vel_callback``、``tolerance_check_callback`` に STOPPED/RESUMED 判定追加、``result_callback`` / ``ntp_result_callback`` の SUCCEEDED hook、``mapoi_goal_pose_poi_cb`` / ``mapoi_route_cb`` の新規 goal hook |
| ``test_nav_server_unit.cpp`` | ``compute_stopped_transition`` の TEST_F (FRIEND_TEST) 5 件追加 (NoOutside / EnterStopped / EnterMoving / ResumeOnVelocity / StaysStopped) |
| ``test_poi_event_integration.py`` | ``radius_check_hz`` → ``tolerance_check_hz`` rename 反映 |
| ``CHANGELOG.rst`` | Breaking changes (param rename) + Navigation server セクション (本機能) |

## state machine

純関数 ``compute_stopped_transition(inside, was_stopped, zero_velocity_dwelled)`` で次の遷移を返す:

| inside | was_stopped | dwelled | transition |
|---|---|---|---|
| false | * | * | NONE (EXIT で stopped state は別途 reset) |
| true | false | true | TO_STOPPED |
| true | false | false | NONE (停止が dwell 経過するまで何もしない) |
| true | true | false | TO_RESUMED (即時、dwell 不要) |
| true | true | true | NONE (重複 STOPPED 発火しない) |

## Breaking change

- ROS parameter ``radius_check_hz`` → ``tolerance_check_hz`` (default 5.0 維持)
- ``PointOfInterest.radius`` field 廃止 (#87) → ``tolerance.xy`` に統一する流れの命名整合
- launch / yaml で ``radius_check_hz`` を指定している場合は置換が必要 (本リポジトリ内では launch ファイル指定なし、test の override のみ)

## test

- ``test_mapoi_server_unit`` (gtest 純関数 11 件): pass
- ``test_nav_server_unit`` (gtest 純関数 + Fixture、5 件追加で 22 件): pass
- ``test_poi_event_integration.py`` (launch_test): pass
- ``test_reload_clears_initialpose.py`` (launch_test): pass
- 合計 **43 tests, 0 errors, 0 failures**

## 動作確認

| distro | bridge | 結果 |
|---|---|---|
| humble | ``mapoi_gazebo_bridge`` (Gazebo Classic) | build OK / test 43 件 pass |
| jazzy | ``mapoi_gz_bridge`` (gz-sim) | build OK |

## 関連

- #87 (前提、PR #137 で msg 定数追加)
- #138 (前提、tolerance struct 整備)
- #88 (consumer 側の想定: ``mapoi_task_scheduler`` が STOPPED/RESUMED を消費)

Close #140