### PR TITLE
feat(visualization): POI tolerance を 円 + 扇形 重ね描き + pause dot 形式 (Close #179)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -190,13 +190,26 @@ WebUI / rviz_plugins
 * ``mapoi_rviz2_publisher`` / ``mapoi_webui`` で POI tolerance を扇形 (sector) で描画 (#136)。
 
   - 半径 = ``tolerance.xy``、扇角 = ``2 * tolerance.yaw``、中心線 = ``pose.yaw``
-  - ``waypoint`` = 塗り扇形、``landmark`` = 中抜き扇形、``pause`` = 太い点線 outline
+  - ``waypoint`` = 塗り扇形、``landmark`` = 中抜き扇形、``pause`` = 点線 outline
     の重ね描き (主 glyph は細い実線で対比)
   - ``tolerance.yaw == 0`` または ``>= π`` → 完全円 (yaw 不問、``pass_through`` 表現可能)
   - ``mapoi_rviz2_publisher`` に ``show_tolerance_sector`` parameter (bool, default true)
-    を追加 — 扇形描画を runtime トグル
-  - follow-up: ロボットの tolerance 判定は xy のみなので、円 (xy 判定領域) + 扇形
-    (yaw 制約) の重ね描きへの分解を別 issue (#179) で検討中
+    を追加 — tolerance visualization を runtime トグル
+  - 続く #179 で 円 (xy 判定領域) + 扇形 (yaw 制約) の重ね描きに分解 (下記参照)
+
+* ``mapoi_rviz2_publisher`` / ``mapoi_webui`` で POI tolerance を 円 + 扇形 の重ね描きに
+  分解 + pause overlay を dot 形式に変更 (#179、#178 user feedback 対応)。
+
+  - 円 outline (細実線・薄め): ロボットの ``tolerance.xy`` 進入判定領域を常時表示。
+    判定 logic (Euclidean < ``tolerance.xy``) の視覚的根拠として yaw 不問で描画
+  - 扇形 (塗り or 中抜き): yaw 制約を強調。``0 < tolerance.yaw < π`` の時のみ
+    重ね描き (完全円との情報冗長を回避、yaw 不問なら円のみ表示)
+  - pause overlay: 旧 dash (``dashArray: '6, 4'`` / RViz segment 0.05m, 1:1 比率) は
+    「点と感じない、潰れて見える」user feedback (#178 PR コメント) を受け、
+    dot 形式 (WebUI ``dashArray: '2, 6'`` + ``lineCap: round`` / RViz dot 長 0.02m +
+    間隔 0.10m, 1:4 比率) に変更。pause 発火条件 (xy 円内) と境界が一致する xy 円沿いに重畳
+  - ``show_tolerance_sector`` parameter は名称据え置きで制御対象を 円 + 扇形 + pause overlay
+    全体に拡張 (backward compat 維持)
 
 Samples
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -206,9 +206,10 @@ WebUI / rviz_plugins
   - 扇形 (塗り or 中抜き): yaw 制約を強調。``0 < tolerance.yaw < π`` の時のみ
     重ね描き (完全円との情報冗長を回避)
   - **見た目の変化点**: 旧 (#178) では yaw 不問 POI (``tolerance.yaw == 0`` または ``>= π``)
-    も塗り扇形 = 完全円塗り (waypoint なら緑塗り) として描画されていた。本 PR では
-    yaw 不問なら**円アウトラインのみ**表示 (塗りなし)。判定 semantics と一致するが、
-    旧表示に慣れた利用者には印象変化あり
+    も扇形 = 完全円として描画されていた (waypoint = 緑塗り完全円、landmark = 灰
+    中抜き完全円)。本 PR では yaw 不問なら **円アウトライン (細実線・薄め) のみ**表示で、
+    塗り / 中抜き strokeは描画しない。判定 semantics (xy のみ) と一致するが、
+    旧表示に慣れた利用者には印象変化あり (デモ・スクリーンショット用途は要確認)
   - pause overlay: 旧 dash (``dashArray: '6, 4'`` / RViz segment 0.05m, 1:1 比率) は
     「点と感じない、潰れて見える」user feedback (#178 PR コメント) を受け、
     sparse dot 形式に変更。WebUI ``dashArray: '2, 6'`` + ``lineCap: round`` (cycle 比

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -208,7 +208,7 @@ WebUI / rviz_plugins
   - **見た目の変化点**: 旧 (#178) では yaw 不問 POI (``tolerance.yaw == 0`` または ``>= π``)
     も扇形 = 完全円として描画されていた (waypoint = 緑塗り完全円、landmark = 灰
     中抜き完全円)。本 PR では yaw 不問なら **円アウトライン (細実線・薄め) のみ**表示で、
-    塗り / 中抜き strokeは描画しない。判定 semantics (xy のみ) と一致するが、
+    塗り / 中抜き stroke は描画しない。判定 semantics (xy のみ) と一致するが、
     旧表示に慣れた利用者には印象変化あり (デモ・スクリーンショット用途は要確認)
   - pause overlay: 旧 dash (``dashArray: '6, 4'`` / RViz segment 0.05m, 1:1 比率) は
     「点と感じない、潰れて見える」user feedback (#178 PR コメント) を受け、

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -219,6 +219,11 @@ WebUI / rviz_plugins
     全体に拡張 (backward compat 維持)
   - **保守注**: 描画仕様は ``mapoi_rviz2_publisher.cpp`` (RViz) / ``map-viewer.js`` (WebUI)
     で二重実装。仕様変更時はペアで更新する (#136 から継続、共通化は #70 と合わせて検討)
+  - **POI Editor Panel の Display Settings UI 改修**: PR #178 で ``arrow_size_ratio``
+    parameter を publisher から削除した際、Panel の DoubleSpinBox UI が取り残されており
+    ``get_parameters / set_parameters`` 呼び出しが失敗する regression があった。
+    本 PR で同 UI を ``show_tolerance_sector`` の CheckBox に置換 (display layer の
+    runtime トグルが Panel から可能に)
 
 Samples
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -204,13 +204,20 @@ WebUI / rviz_plugins
   - 円 outline (細実線・薄め): ロボットの ``tolerance.xy`` 進入判定領域を常時表示。
     判定 logic (Euclidean < ``tolerance.xy``) の視覚的根拠として yaw 不問で描画
   - 扇形 (塗り or 中抜き): yaw 制約を強調。``0 < tolerance.yaw < π`` の時のみ
-    重ね描き (完全円との情報冗長を回避、yaw 不問なら円のみ表示)
+    重ね描き (完全円との情報冗長を回避)
+  - **見た目の変化点**: 旧 (#178) では yaw 不問 POI (``tolerance.yaw == 0`` または ``>= π``)
+    も塗り扇形 = 完全円塗り (waypoint なら緑塗り) として描画されていた。本 PR では
+    yaw 不問なら**円アウトラインのみ**表示 (塗りなし)。判定 semantics と一致するが、
+    旧表示に慣れた利用者には印象変化あり
   - pause overlay: 旧 dash (``dashArray: '6, 4'`` / RViz segment 0.05m, 1:1 比率) は
     「点と感じない、潰れて見える」user feedback (#178 PR コメント) を受け、
-    dot 形式 (WebUI ``dashArray: '2, 6'`` + ``lineCap: round`` / RViz dot 長 0.02m +
-    間隔 0.10m, 1:4 比率) に変更。pause 発火条件 (xy 円内) と境界が一致する xy 円沿いに重畳
+    sparse dot 形式に変更。WebUI ``dashArray: '2, 6'`` + ``lineCap: round`` (cycle 比
+    25% on)、RViz dot 長 0.02m + 間隔 0.10m + line 0.04m (cycle 比 20% on)。
+    pause 発火条件 (xy 円内) と境界が一致する xy 円沿いに重畳
   - ``show_tolerance_sector`` parameter は名称据え置きで制御対象を 円 + 扇形 + pause overlay
     全体に拡張 (backward compat 維持)
+  - **保守注**: 描画仕様は ``mapoi_rviz2_publisher.cpp`` (RViz) / ``map-viewer.js`` (WebUI)
+    で二重実装。仕様変更時はペアで更新する (#136 から継続、共通化は #70 と合わせて検討)
 
 Samples
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -192,7 +192,8 @@ WebUI / rviz_plugins
   - 半径 = ``tolerance.xy``、扇角 = ``2 * tolerance.yaw``、中心線 = ``pose.yaw``
   - ``waypoint`` = 塗り扇形、``landmark`` = 中抜き扇形、``pause`` = 点線 outline
     の重ね描き (主 glyph は細い実線で対比)
-  - ``tolerance.yaw == 0`` または ``>= π`` → 完全円 (yaw 不問、``pass_through`` 表現可能)
+  - ``0 < tolerance.yaw < π`` の時のみ扇形描画、それ以外 (yaw 不問) は完全円扱い
+    (``pass_through`` 表現可能)
   - ``mapoi_rviz2_publisher`` に ``show_tolerance_sector`` parameter (bool, default true)
     を追加 — tolerance visualization を runtime トグル
   - 続く #179 で 円 (xy 判定領域) + 扇形 (yaw 制約) の重ね描きに分解 (下記参照)

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -27,7 +27,7 @@
 #include <QMessageBox>
 #include <QLabel>
 #include <QRadioButton>
-#include <QDoubleSpinBox>
+#include <QCheckBox>
 
 namespace Ui {
 class PoiEditorUi;
@@ -97,13 +97,13 @@ protected:
   QRadioButton * label_radio_name_ = nullptr;
   QRadioButton * label_radio_both_ = nullptr;
   QRadioButton * label_radio_none_ = nullptr;
-  QDoubleSpinBox * arrow_size_spin_ = nullptr;
+  QCheckBox * tolerance_sector_check_ = nullptr;
 
   // 最後に publisher と一致が確認できた値の cache。SetParameters 失敗時に UI を revert する元になる。
   // 初期値は publisher の declare_parameter default と一致 (sync 成功すればその値で更新される)。
   std::string cached_route_mode_ = "selected";
   std::string cached_label_fmt_ = "index";
-  double cached_arrow_size_ = 1.0;
+  bool cached_tolerance_sector_ = true;
 
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr poi_pose_sub_;
   void PoiPoseCallback(geometry_msgs::msg::PoseStamped::SharedPtr msg);

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -104,7 +104,8 @@ void PoiEditorPanel::onInitialize()
   // Display Settings group: mapoi_rviz2_publisher の表示系 parameter を Panel から制御 (#99)
   // - route_display_mode (all / selected / none): RadioButton
   // - poi_label_format (index / name / both / none): RadioButton
-  // - arrow_size_ratio (double 0.0〜5.0): DoubleSpinBox
+  // - show_tolerance_sector (bool): CheckBox (#179: 旧 arrow_size_ratio UI を置換、
+  //   PR #178 で publisher 側 parameter は廃止済だったが Panel UI が取り残されていた regression を修正)
   rviz2_pub_param_client_ =
     std::make_shared<rclcpp::AsyncParametersClient>(service_node_, "/mapoi_rviz2_publisher");
 
@@ -149,15 +150,10 @@ void PoiEditorPanel::onInitialize()
   label_h->addStretch();
   display_form->addRow("POI label:", label_h);
 
-  // Arrow size ratio
-  arrow_size_spin_ = new QDoubleSpinBox(this);
-  arrow_size_spin_->setRange(0.0, 5.0);
-  arrow_size_spin_->setSingleStep(0.1);
-  arrow_size_spin_->setDecimals(2);
-  arrow_size_spin_->setValue(1.0);  // default in mapoi_rviz2_publisher
-  // keyboard 入力中は valueChanged を発火させず、Enter / focus loss / stepper 操作のみで反応 (Codex round 1 低)
-  arrow_size_spin_->setKeyboardTracking(false);
-  display_form->addRow("Arrow size:", arrow_size_spin_);
+  // Tolerance visualization toggle (#179: 旧 arrow_size_ratio UI を置換)
+  tolerance_sector_check_ = new QCheckBox(this);
+  tolerance_sector_check_->setChecked(true);  // default in mapoi_rviz2_publisher
+  display_form->addRow("Tolerance:", tolerance_sector_check_);
 
   // Display Settings group を verticalLayout に append (Save 行の下)
   if (auto * panel_layout = qobject_cast<QVBoxLayout *>(this->layout())) {
@@ -199,14 +195,14 @@ void PoiEditorPanel::onInitialize()
       cached_route_mode_ = value.get<std::string>();
     } else if (name == "poi_label_format") {
       cached_label_fmt_ = value.get<std::string>();
-    } else if (name == "arrow_size_ratio") {
-      cached_arrow_size_ = value.get<double>();
+    } else if (name == "show_tolerance_sector") {
+      cached_tolerance_sector_ = value.get<bool>();
     }
   };
   auto send_string_param = [send_param](const std::string & name, const std::string & value) {
     send_param(name, rclcpp::ParameterValue(value));
   };
-  auto send_double_param = [send_param](const std::string & name, double value) {
+  auto send_bool_param = [send_param](const std::string & name, bool value) {
     send_param(name, rclcpp::ParameterValue(value));
   };
 
@@ -228,9 +224,9 @@ void PoiEditorPanel::onInitialize()
   connect(label_radio_none_, &QRadioButton::toggled,
     [send_string_param](bool checked) { if (checked) send_string_param("poi_label_format", "none"); });
 
-  // arrow_size_ratio
-  connect(arrow_size_spin_, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
-    [send_double_param](double value) { send_double_param("arrow_size_ratio", value); });
+  // show_tolerance_sector (#179)
+  connect(tolerance_sector_check_, &QCheckBox::toggled,
+    [send_bool_param](bool checked) { send_bool_param("show_tolerance_sector", checked); });
 
   // 初期同期: publisher から現在 parameter 値を読んで UI に反映
   SyncDisplaySettingsFromPublisher();
@@ -245,7 +241,7 @@ void PoiEditorPanel::SyncDisplaySettingsFromPublisher()
     return;  // 短い wait、ready でなければ skip
   }
   auto fut = rviz2_pub_param_client_->get_parameters(
-    {"route_display_mode", "poi_label_format", "arrow_size_ratio"});
+    {"route_display_mode", "poi_label_format", "show_tolerance_sector"});
   if (rclcpp::spin_until_future_complete(service_node_, fut, 200ms) !=
       rclcpp::FutureReturnCode::SUCCESS) {
     RCLCPP_WARN(LOGGER, "Sync of Display Settings parameters timed out");
@@ -257,12 +253,12 @@ void PoiEditorPanel::SyncDisplaySettingsFromPublisher()
   }
   const std::string route_mode = params[0].as_string();
   const std::string label_fmt = params[1].as_string();
-  const double arrow_size = params[2].as_double();
+  const bool tolerance_sector = params[2].as_bool();
 
   // cache 更新 (publisher 真値が記憶される、次回 SetParameters 失敗時の revert 元として使用)
   cached_route_mode_ = route_mode;
   cached_label_fmt_ = label_fmt;
-  cached_arrow_size_ = arrow_size;
+  cached_tolerance_sector_ = tolerance_sector;
 
   // QSignalBlocker で setChecked / setValue が SetParameters を再発火させないようにする
   QSignalBlocker b1(route_radio_all_);
@@ -272,7 +268,7 @@ void PoiEditorPanel::SyncDisplaySettingsFromPublisher()
   QSignalBlocker b5(label_radio_name_);
   QSignalBlocker b6(label_radio_both_);
   QSignalBlocker b7(label_radio_none_);
-  QSignalBlocker b8(arrow_size_spin_);
+  QSignalBlocker b8(tolerance_sector_check_);
 
   if (route_mode == "all") route_radio_all_->setChecked(true);
   else if (route_mode == "none") route_radio_none_->setChecked(true);
@@ -283,7 +279,7 @@ void PoiEditorPanel::SyncDisplaySettingsFromPublisher()
   else if (label_fmt == "none") label_radio_none_->setChecked(true);
   else label_radio_index_->setChecked(true);  // default fallback
 
-  arrow_size_spin_->setValue(arrow_size);
+  tolerance_sector_check_->setChecked(tolerance_sector);
 }
 
 void PoiEditorPanel::RevertDisplaySettingsUiFromCache()
@@ -299,7 +295,7 @@ void PoiEditorPanel::RevertDisplaySettingsUiFromCache()
   QSignalBlocker b5(label_radio_name_);
   QSignalBlocker b6(label_radio_both_);
   QSignalBlocker b7(label_radio_none_);
-  QSignalBlocker b8(arrow_size_spin_);
+  QSignalBlocker b8(tolerance_sector_check_);
 
   if (cached_route_mode_ == "all") route_radio_all_->setChecked(true);
   else if (cached_route_mode_ == "none") route_radio_none_->setChecked(true);
@@ -310,7 +306,7 @@ void PoiEditorPanel::RevertDisplaySettingsUiFromCache()
   else if (cached_label_fmt_ == "none") label_radio_none_->setChecked(true);
   else label_radio_index_->setChecked(true);
 
-  arrow_size_spin_->setValue(cached_arrow_size_);
+  tolerance_sector_check_->setChecked(cached_tolerance_sector_);
 }
 
 void PoiEditorPanel::onEnable()

--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -149,7 +149,7 @@ RViz2 上に POI のマーカーを表示するためのノードです。
 
 | パラメータ名 | 型 | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `show_tolerance_sector` | `bool` | `true` | POI tolerance visualization (#136 / #179) を表示するか。対象 layer = xy 判定円 outline + yaw 制約扇形 (`0 < tolerance.yaw < π` の時のみ重ね描き) + pause overlay (xy 円沿いの dot pattern)。`false` で全 POI のこれら 3 layer を抑制 (Editor 中心の使い方や RViz が情報過多な時の用途) |
+| `show_tolerance_sector` | `bool` | `true` | POI tolerance visualization (#136 / #179) を表示するか。対象 layer = xy 判定円 outline + yaw 制約扇形 (`0 < tolerance.yaw < π` の時のみ重ね描き) + pause overlay (xy 円沿いの dot pattern)。`false` で全 POI のこれら 3 layer を抑制 (Editor 中心の使い方や RViz が情報過多な時の用途)。WebUI 側にも同等の描画仕様 (`mapoi_webui/web/js/map-viewer.js`) があるため、仕様変更時はペアで更新する |
 | `poi_label_format` | `string` | `"index"` | POI label の表示形式: `"index"` = POI Editor 行番号 (1-based 通し、tag フィルタ非依存) / `"name"` = POI 名 / `"both"` = `"<index>: <name>"` / `"none"` = 非表示 |
 | `route_display_mode` | `string` | `"selected"` | Route polyline の表示形式: `"all"` = 全 route 表示 (active route は太線 + 不透明で強調) / `"selected"` = active route のみ表示 / `"none"` = 表示しない |
 

--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -149,8 +149,9 @@ RViz2 上に POI のマーカーを表示するためのノードです。
 
 | パラメータ名 | 型 | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `arrow_size_ratio` | `double` | `1.0` | POI 矢印の scale を tolerance.xy に対する比率で指定 (`arrow_length = tolerance.xy × ratio`)。Route 矢印 (waypoint 間) は tolerance 概念を持たないので対象外。`ros2 param set` で runtime 変更も次周期に反映 |
+| `show_tolerance_sector` | `bool` | `true` | POI tolerance visualization (#136 / #179) を表示するか。対象 layer = xy 判定円 outline + yaw 制約扇形 (`0 < tolerance.yaw < π` の時のみ重ね描き) + pause overlay (xy 円沿いの dot pattern)。`false` で全 POI のこれら 3 layer を抑制 (Editor 中心の使い方や RViz が情報過多な時の用途) |
 | `poi_label_format` | `string` | `"index"` | POI label の表示形式: `"index"` = POI Editor 行番号 (1-based 通し、tag フィルタ非依存) / `"name"` = POI 名 / `"both"` = `"<index>: <name>"` / `"none"` = 非表示 |
+| `route_display_mode` | `string` | `"selected"` | Route polyline の表示形式: `"all"` = 全 route 表示 (active route は太線 + 不透明で強調) / `"selected"` = active route のみ表示 / `"none"` = 表示しない |
 
 #### サブスクライバー
 

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -432,7 +432,9 @@ void MapoiRviz2Publisher::timer_callback(){
                                 visualization_msgs::msg::MarkerArray & target) {
     if (radius <= 0.0) return;
 
-    // dot 中心間隔 0.10m、dot 長 0.02m → 1:4 の on:off (WebUI dashArray '2, 6' 相当の dot 比率)。
+    // dot 中心間隔 0.10m、dot 長 0.02m → cycle 比 20% on (1:4 on:off)。
+    // WebUI 側 (dashArray '2, 6') は 25% on (1:3 on:off) で厳密には僅差あるが、
+    // どちらも sparse dot pattern として視覚的に同方向で整合 (#179 cursor review round 2)。
     // typical radius (0.1-2m) で dot として識別可能な粒度。
     constexpr double DOT_STEP = 0.10;
     constexpr double DOT_LENGTH = 0.02;

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -11,7 +11,7 @@ MapoiRviz2Publisher::MapoiRviz2Publisher() : Node("mapoi_rviz2_publisher") {
   // POI tolerance visualization (#136 / #179) を表示するか。
   // 描画 layer (false で全 POI 抑制):
   //   - xy 判定円 outline (細い実線、薄め): tolerance.xy = ロボット進入判定の境界
-  //   - yaw 制約扇形 (塗り or 中抜き): tolerance.yaw < π の時のみ重ね描き
+  //   - yaw 制約扇形 (塗り or 中抜き): 0 < tolerance.yaw < π の時のみ重ね描き
   //   - pause overlay (点線 dot): pause tag POI の xy 円沿いに dot pattern
   // Editor 中心の使い方や RViz が情報過多な時に false にする想定。default true。
   this->declare_parameter<bool>("show_tolerance_sector", true);
@@ -337,8 +337,8 @@ void MapoiRviz2Publisher::timer_callback(){
 
   // 扇形 (sector) marker を描画する helper (#136 / #179)。
   // - radius = tolerance.xy、扇角 = 2 * yaw_tolerance、中心線 = pose.yaw
-  // - 完全円 (yaw_tolerance <= 0 または >= π) は呼び出し側で add_radius_circle に分岐させ、
-  //   この helper は yaw 制約あり (0 < yaw_tolerance < π) のみ扱う (#179: 円 + 扇形重ね描き)
+  // - 0 < yaw_tolerance < π の時のみ描画。yaw 不問 (それ以外の値) は呼び出し側で
+  //   add_radius_circle に分岐させる (#179: 円 + 扇形重ね描き)
   // - fill_alpha > 0 → TRIANGLE_LIST で塗り (waypoint 用)
   // - stroke_alpha > 0 → LINE_STRIP で境界線 (中心 → 弧 → 中心、yaw 範囲を半径線で強調)
   // 戻り値: target.markers に push した marker 数 (id 消費数、yaw 不問入力は 0)
@@ -438,7 +438,11 @@ void MapoiRviz2Publisher::timer_callback(){
     constexpr double DOT_LENGTH = 0.02;
     const double total_arc_len = 2.0 * M_PI * radius;
     const int n_dots = std::max(12, static_cast<int>(std::ceil(total_arc_len / DOT_STEP)));
-    const double dot_angle_span = DOT_LENGTH / radius;  // dot 1 個分の弧角度
+    // dot 1 個分の弧角度。極小半径 (Tolerance min 0.001m など) で DOT_LENGTH/radius が
+    // セル角を超えると dot が連結して dash 化するため、cell の 40% を cap として保つ
+    // (1:4 比率を維持できなくなる場合でも dot 識別性 ≧ on:off 分離を優先)。
+    const double cell_angle = (2.0 * M_PI) / n_dots;
+    const double dot_angle_span = std::min(DOT_LENGTH / radius, 0.4 * cell_angle);
 
     visualization_msgs::msg::Marker m;
     m.header.frame_id = "map";
@@ -508,7 +512,7 @@ void MapoiRviz2Publisher::timer_callback(){
         id += 1;
 
         // 扇形 (yaw 制約、#136): 0 < yaw < π の時のみ重ね描き。
-        // yaw 不問 (yaw_tolerance == 0 または >= π) の場合、扇形 = 円となり情報冗長なため省略。
+        // それ以外 (yaw 不問、扇形 = 円となり情報冗長) は円 outline のみで表現。
         const bool has_yaw_constraint =
           (poi.tolerance.yaw > 0.0 && poi.tolerance.yaw < M_PI);
         if (has_yaw_constraint) {

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -8,9 +8,12 @@ using std::placeholders::_2;
 MapoiRviz2Publisher::MapoiRviz2Publisher() : Node("mapoi_rviz2_publisher") {
   id_buf_ = 0;
 
-  // POI tolerance (xy + yaw) の扇形 visualization (#136) を表示するか。
-  // false: 主 glyph (扇形) と pause overlay を全 POI で抑制。Editor 中心の使い方や
-  // RViz が情報過多な時に false にする想定。default true。
+  // POI tolerance visualization (#136 / #179) を表示するか。
+  // 描画 layer (false で全 POI 抑制):
+  //   - xy 判定円 outline (細い実線、薄め): tolerance.xy = ロボット進入判定の境界
+  //   - yaw 制約扇形 (塗り or 中抜き): tolerance.yaw < π の時のみ重ね描き
+  //   - pause overlay (点線 dot): pause tag POI の xy 円沿いに dot pattern
+  // Editor 中心の使い方や RViz が情報過多な時に false にする想定。default true。
   this->declare_parameter<bool>("show_tolerance_sector", true);
 
   // POI label の表示形式: "index" (POI Editor 行番号、1-based) / "name" / "both" (= "<index>: <name>") / "none"。
@@ -259,7 +262,9 @@ void MapoiRviz2Publisher::timer_callback(){
   default_arrow_marker.color.r = 0.0; default_arrow_marker.color.g = 1.0; default_arrow_marker.color.b = 0.0; default_arrow_marker.color.a = 0.7;
   default_arrow_marker.lifetime.sec = 2.0;
 
-  // 扇形 visualization (#136) の表示制御。false で全 POI の主 glyph + pause overlay を抑制。
+  // tolerance visualization (#136 / #179) の表示制御。false で全 POI の円 + 扇形 + pause overlay を抑制。
+  // parameter 名は backward compat のため `show_tolerance_sector` のまま (制御対象は scope 拡張、
+  // CHANGELOG 参照)。
   const bool show_sector = this->get_parameter("show_tolerance_sector").as_bool();
 
   // POI label の format ("index" / "name" / "both" / "none") を runtime parameter で切替。
@@ -298,12 +303,45 @@ void MapoiRviz2Publisher::timer_callback(){
     return std::atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z));
   };
 
-  // 扇形 (sector) marker を描画する helper (#136)。
+  // xy 判定円 outline を細い実線で描画する helper (#179)。
+  // - radius = tolerance.xy = ロボット進入判定の境界 (yaw 不問)
+  // - 扇形 (yaw 制約) と重ね描きする前提で、薄めの alpha + 細い実線で控えめに
+  // - LINE_STRIP の頂点列で 36 角形 (10 度刻み) を構成
+  auto add_radius_circle = [&](const geometry_msgs::msg::Pose & pose, double radius,
+                               float r, float g, float b, float a,
+                               int marker_id,
+                               visualization_msgs::msg::MarkerArray & target) {
+    if (radius <= 0.0) return;
+    constexpr int N_SEG = 36;
+    visualization_msgs::msg::Marker m;
+    m.header.frame_id = "map";
+    m.header.stamp = rclcpp::Clock().now();
+    m.action = visualization_msgs::msg::Marker::ADD;
+    m.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    m.id = marker_id;
+    m.pose.orientation.w = 1.0;
+    m.scale.x = 0.02;  // 細い実線 (扇形 stroke と同じ太さ)
+    m.color.r = r; m.color.g = g; m.color.b = b; m.color.a = a;
+    m.lifetime.sec = 2;
+    m.points.reserve(N_SEG + 1);
+    for (int i = 0; i <= N_SEG; ++i) {
+      const double angle = 2.0 * M_PI * i / N_SEG;
+      geometry_msgs::msg::Point p;
+      p.x = pose.position.x + radius * std::cos(angle);
+      p.y = pose.position.y + radius * std::sin(angle);
+      p.z = SECTOR_Z;
+      m.points.push_back(p);
+    }
+    target.markers.push_back(m);
+  };
+
+  // 扇形 (sector) marker を描画する helper (#136 / #179)。
   // - radius = tolerance.xy、扇角 = 2 * yaw_tolerance、中心線 = pose.yaw
-  // - yaw_tolerance == 0 (未指定) または yaw_tolerance >= π → 完全円 (yaw 不問)
+  // - 完全円 (yaw_tolerance <= 0 または >= π) は呼び出し側で add_radius_circle に分岐させ、
+  //   この helper は yaw 制約あり (0 < yaw_tolerance < π) のみ扱う (#179: 円 + 扇形重ね描き)
   // - fill_alpha > 0 → TRIANGLE_LIST で塗り (waypoint 用)
-  // - stroke_alpha > 0 → LINE_STRIP で境界線 (landmark の中抜き用 / 塗りの輪郭強調用)
-  // 戻り値: target.markers に push した marker 数 (id 消費数)
+  // - stroke_alpha > 0 → LINE_STRIP で境界線 (中心 → 弧 → 中心、yaw 範囲を半径線で強調)
+  // 戻り値: target.markers に push した marker 数 (id 消費数、yaw 不問入力は 0)
   auto add_sector = [&](const geometry_msgs::msg::Pose & pose,
                         double radius, double yaw_tolerance,
                         float r, float g, float b,
@@ -311,17 +349,15 @@ void MapoiRviz2Publisher::timer_callback(){
                         int marker_id_base,
                         visualization_msgs::msg::MarkerArray & target) -> int {
     if (radius <= 0.0) return 0;
+    if (yaw_tolerance <= 0.0 || yaw_tolerance >= M_PI) return 0;
 
-    const double half_angle = (yaw_tolerance <= 0.0 || yaw_tolerance >= M_PI)
-      ? M_PI : yaw_tolerance;
-    const bool is_full_circle = (half_angle >= M_PI);
+    const double half_angle = yaw_tolerance;
     const double yaw_center = get_yaw_from_pose(pose);
-
-    const double total_angle = is_full_circle ? 2.0 * M_PI : 2.0 * half_angle;
+    const double total_angle = 2.0 * half_angle;
     // 弧の頂点数: 0.1 rad 刻み相当 (約 5.7 度)、最低 8 (扇形でも視認可能)
     const int n_seg = std::max(8, static_cast<int>(std::ceil(total_angle / 0.1)));
 
-    const double start_angle = is_full_circle ? 0.0 : (yaw_center - half_angle);
+    const double start_angle = yaw_center - half_angle;
     std::vector<geometry_msgs::msg::Point> arc_pts;
     arc_pts.reserve(n_seg + 1);
     for (int i = 0; i <= n_seg; ++i) {
@@ -369,20 +405,14 @@ void MapoiRviz2Publisher::timer_callback(){
       m.type = visualization_msgs::msg::Marker::LINE_STRIP;
       m.id = marker_id_base + n_added;
       m.pose.orientation.w = 1.0;
-      m.scale.x = 0.02;  // line width (m)、pause overlay (太い点線) との対比で細め (#136)
+      m.scale.x = 0.02;  // line width (m)、xy 円 outline と同じ太さ
       m.color.r = r; m.color.g = g; m.color.b = b; m.color.a = stroke_alpha;
       m.lifetime.sec = 2;
-      if (is_full_circle) {
-        // 円の境界: 弧点列のみ (arc_pts の最初と最後が一致するので閉じる)
-        m.points.reserve(arc_pts.size());
-        for (const auto & p : arc_pts) m.points.push_back(p);
-      } else {
-        // 扇形の境界: 中心 → 弧端 → 弧上 → 弧端 → 中心
-        m.points.reserve(arc_pts.size() + 2);
-        m.points.push_back(center);
-        for (const auto & p : arc_pts) m.points.push_back(p);
-        m.points.push_back(center);
-      }
+      // 扇形の境界: 中心 → 弧端 → 弧上 → 弧端 → 中心 (半径線で yaw 範囲を強調)
+      m.points.reserve(arc_pts.size() + 2);
+      m.points.push_back(center);
+      for (const auto & p : arc_pts) m.points.push_back(p);
+      m.points.push_back(center);
       target.markers.push_back(m);
       n_added += 1;
     }
@@ -390,26 +420,25 @@ void MapoiRviz2Publisher::timer_callback(){
     return n_added;
   };
 
-  // 扇形/円の弧を破線 outline で重ね描きする helper (pause tag overlay 用、#136)。
-  // LINE_LIST で偶数番 segment だけ描画して dash pattern を表現。
-  // 主 glyph (add_sector) より僅かに上 (z + 0.001) に置いて隠れ防止。
-  auto add_dashed_outline = [&](const geometry_msgs::msg::Pose & pose,
-                                double radius, double yaw_tolerance,
+  // pause overlay を xy 円沿いに点線 (dot 形式) で重ね描き (#179)。
+  // LINE_LIST で短い segment + 長い gap で dot 表現:
+  //   旧 add_dashed_outline (#136) は segment 長 0.05m + 1:1 比率の dash で「点と感じない、
+  //   潰れて見える」user feedback (#178 PR コメント) を受け、dot 長を短くし on:off 比率を 1:4 に拡大。
+  // pause 発火条件は xy 円内 (#84 hysteresis) なので xy 境界 (= add_radius_circle と同じ円) に重畳する。
+  // 主 glyph より僅かに上 (z + 0.001) に置いて隠れ防止。
+  auto add_dotted_outline = [&](const geometry_msgs::msg::Pose & pose, double radius,
                                 float r, float g, float b, float a,
                                 int marker_id,
                                 visualization_msgs::msg::MarkerArray & target) {
     if (radius <= 0.0) return;
 
-    const double half_angle = (yaw_tolerance <= 0.0 || yaw_tolerance >= M_PI)
-      ? M_PI : yaw_tolerance;
-    const bool is_full_circle = (half_angle >= M_PI);
-    const double yaw_center = get_yaw_from_pose(pose);
-    const double total_angle = is_full_circle ? 2.0 * M_PI : 2.0 * half_angle;
-
-    // segment 長 = 0.05m を目安。typical radius (0.1-2m) で識別できる粒度。
-    const double total_arc_len = total_angle * radius;
-    int n_total = std::max(16, static_cast<int>(std::ceil(total_arc_len / 0.05)));
-    if (n_total % 2 != 0) n_total += 1;  // ON/OFF 交互で偶数必要
+    // dot 中心間隔 0.10m、dot 長 0.02m → 1:4 の on:off (WebUI dashArray '2, 6' 相当の dot 比率)。
+    // typical radius (0.1-2m) で dot として識別可能な粒度。
+    constexpr double DOT_STEP = 0.10;
+    constexpr double DOT_LENGTH = 0.02;
+    const double total_arc_len = 2.0 * M_PI * radius;
+    const int n_dots = std::max(12, static_cast<int>(std::ceil(total_arc_len / DOT_STEP)));
+    const double dot_angle_span = DOT_LENGTH / radius;  // dot 1 個分の弧角度
 
     visualization_msgs::msg::Marker m;
     m.header.frame_id = "map";
@@ -418,15 +447,14 @@ void MapoiRviz2Publisher::timer_callback(){
     m.type = visualization_msgs::msg::Marker::LINE_LIST;
     m.id = marker_id;
     m.pose.orientation.w = 1.0;
-    m.scale.x = 0.06;  // 太い点線 (主 glyph 細い実線との対比、#136 user feedback)
+    m.scale.x = 0.04;  // dot 線幅 (旧 dash の 0.06m から短縮、dot として丸みを出す)
     m.color.r = r; m.color.g = g; m.color.b = b; m.color.a = a;
     m.lifetime.sec = 2;
 
-    const double start_angle = is_full_circle ? 0.0 : (yaw_center - half_angle);
-    m.points.reserve(static_cast<size_t>(n_total));
-    for (int i = 0; i < n_total; i += 2) {
-      const double a1 = start_angle + total_angle * i / n_total;
-      const double a2 = start_angle + total_angle * (i + 1) / n_total;
+    m.points.reserve(static_cast<size_t>(n_dots) * 2);
+    for (int i = 0; i < n_dots; ++i) {
+      const double a1 = (2.0 * M_PI) * i / n_dots;
+      const double a2 = a1 + dot_angle_span;
       geometry_msgs::msg::Point p1, p2;
       p1.x = pose.position.x + radius * std::cos(a1);
       p1.y = pose.position.y + radius * std::sin(a1);
@@ -445,13 +473,14 @@ void MapoiRviz2Publisher::timer_callback(){
     poi_index_one_based += 1;  // POI Editor (mapoi_config.yaml の poi: 順) 行番号、1-based、tag フィルタ非依存
     geometry_msgs::msg::Pose pose = poi.pose;
 
-    // POI tolerance (xy + yaw) を扇形 (sector) で描画 (#136、全 POI 共通)。
-    // 主 glyph は waypoint > landmark の優先順で 1 つだけ:
+    // POI tolerance を 円 (xy 判定領域) + 扇形 (yaw 制約) で重ね描き (#136 / #179、全 POI 共通)。
+    // 主 glyph は waypoint > landmark の優先順:
     //   - waypoint: 塗り扇形 (緑)
     //   - landmark: 中抜き扇形 (灰)
     //   - その他 (旧 event 等): scope 外 (色 / glyph 整理は #70)
-    // pause tag があれば主 glyph の上に破線 outline を重ね描きする。
-    // 色は本 PR では既存 hardcode を継承 (整理は #70)。
+    // 円 outline は判定 semantics (xy 境界) を控えめに常時表示し、扇形は yaw 制約あり時のみ
+    // 重ね描きする。pause tag があれば xy 円沿いに dot pattern overlay を追加。
+    // 色は既存 hardcode を継承 (整理は #70)。
     if (show_sector && poi.tolerance.xy > 0.0) {
       const auto has_tag = [&poi](const std::string & target) {
         for (const auto & t : poi.tags) {
@@ -474,13 +503,25 @@ void MapoiRviz2Publisher::timer_callback(){
       }
 
       if (sector_target != nullptr) {
-        id += add_sector(pose, poi.tolerance.xy, poi.tolerance.yaw,
-                         sr, sg, sb,
-                         fill_a, stroke_a,
-                         id, *sector_target);
+        // 円 outline (xy 判定領域、#179): 常時描画。半透明 + 細実線で控えめに「進入判定境界」を示す。
+        add_radius_circle(pose, poi.tolerance.xy, sr, sg, sb, 0.4f, id, *sector_target);
+        id += 1;
+
+        // 扇形 (yaw 制約、#136): 0 < yaw < π の時のみ重ね描き。
+        // yaw 不問 (yaw_tolerance == 0 または >= π) の場合、扇形 = 円となり情報冗長なため省略。
+        const bool has_yaw_constraint =
+          (poi.tolerance.yaw > 0.0 && poi.tolerance.yaw < M_PI);
+        if (has_yaw_constraint) {
+          id += add_sector(pose, poi.tolerance.xy, poi.tolerance.yaw,
+                           sr, sg, sb,
+                           fill_a, stroke_a,
+                           id, *sector_target);
+        }
 
         if (has_tag("pause")) {
-          add_dashed_outline(pose, poi.tolerance.xy, poi.tolerance.yaw,
+          // pause overlay は xy 円沿いに dot pattern (#179)。
+          // pause 発火条件 (xy 円内) と境界が一致するため自然な視覚的根拠になる。
+          add_dotted_outline(pose, poi.tolerance.xy,
                              sr, sg, sb, 0.9f,
                              id, *sector_target);
           id += 1;

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -504,7 +504,7 @@ void MapoiRviz2Publisher::timer_callback(){
         sector_target = &ma_waypoints;
       } else if (has_tag("landmark")) {
         sr = 0.5f; sg = 0.5f; sb = 0.5f;
-        fill_a = 0.0f; stroke_a = 0.7f;  // 中抜き
+        fill_a = 0.15f; stroke_a = 0.7f;  // 透過度高めの薄塗り (#179 ユーザー確認 2: 中抜きから薄塗りに変更)
         sector_target = &ma_events;
       }
 

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -486,8 +486,9 @@ class MapViewer {
     }
 
     // pause overlay: xy 円沿いに dot pattern を重ね描き (#179)。
-    // 旧 dashArray '6, 4' (1.5:1 dash) は dot として識別しづらく潰れて見える feedback (#178 PR コメント)
-    // を受け、'2, 6' (1:3 dot) で短い dot + 大きい gap に変更。
+    // 旧 dashArray '6, 4' (cycle 比 60% on, 1.5:1 dash) は dot として識別しづらく潰れて見える feedback
+    // (#178 PR コメント) を受け、'2, 6' (cycle 比 25% on, 1:3 on:off) で短い dot + 大きい gap に変更。
+    // RViz 側 (dot 0.02m / step 0.10m, 20% on / 1:4) と厳密比率は僅差だが共に sparse dot で整合。
     if (isPause) {
       const pauseOutline = L.polyline(circlePoints, {
         color,

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -478,7 +478,7 @@ class MapViewer {
         weight: 1,
         opacity: 0.7,
         fillColor: color,
-        fillOpacity: isWaypoint ? 0.25 : 0,  // waypoint=塗り、landmark=中抜き
+        fillOpacity: isWaypoint ? 0.25 : 0.10,  // waypoint=塗り、landmark=薄塗り (#179 ユーザー確認 2)
         interactive: false,
       }).addTo(this.map);
       sector.bringToBack();

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -406,17 +406,21 @@ class MapViewer {
   }
 
   /**
-   * POI の tolerance (xy + yaw) を扇形 (sector) で描画する (#136)。
+   * POI の tolerance を 円 (xy 判定領域) + 扇形 (yaw 制約) の重ね描きで描画する (#136 / #179)。
    *
-   * - 半径 = `tolerance.xy`、扇角 = `2 × tolerance.yaw`、中心線 = `pose.yaw`
-   * - `tolerance.yaw == 0` (未指定) または `tolerance.yaw >= π` → 完全円 (yaw 不問)
-   * - 主 glyph: waypoint > landmark の優先順で 1 つ
+   * - 円 outline: 半径 = `tolerance.xy` (xy 進入判定の境界、yaw 不問)、
+   *   `L.polyline` で 36 角形を構成して常時描画 (細実線・薄め)
+   * - 扇形: `tolerance.yaw` が `0 < yaw < π` の時のみ重ね描き (`L.polygon`)
    *   - waypoint: 塗り扇形 (`fillOpacity` 高)
    *   - landmark: 中抜き扇形 (`fillOpacity = 0`、stroke のみ)
    *   - その他 (旧 event 等): 描画しない (#70 で別途整理)
-   * - pause tag があれば主 glyph の上に dashed outline を重ね描き
+   * - pause tag があれば xy 円沿いに dot pattern overlay (#179: 旧 dash → dot 形式)
    *
    * `tolerance.xy <= 0` または対象 tag 無しなら no-op。
+   *
+   * `L.circle` ではなく polyline で実装するのは、`L.circle` の radius が pixel/meter 換算に
+   * `crs` 依存の挙動を持つ一方、扇形は world 座標を `worldToLatLng` で変換して描画するため。
+   * 同じ計算式で円と扇形の弧を生成すれば視覚的整合 (両者の弧が完全一致) が保証される。
    */
   _drawSectorForPoi(poi) {
     if (!poi.pose) return;
@@ -428,55 +432,73 @@ class MapViewer {
     const isPause = tags.includes('pause');
     if (!isWaypoint && !isLandmark) return;
 
+    const r = poi.tolerance.xy;
     const yawCenter = poi.pose.yaw || 0;
     const yawTol = (typeof poi.tolerance.yaw === 'number') ? poi.tolerance.yaw : 0;
-    const halfAngle = (yawTol <= 0 || yawTol >= Math.PI) ? Math.PI : yawTol;
-    const isFullCircle = halfAngle >= Math.PI;
-    const r = poi.tolerance.xy;
-    const totalAngle = isFullCircle ? (2 * Math.PI) : (2 * halfAngle);
-    const N = Math.max(8, Math.ceil(totalAngle / 0.1));
-    const startAngle = isFullCircle ? 0 : (yawCenter - halfAngle);
-
-    const points = [];
-    if (!isFullCircle) {
-      points.push(this.worldToLatLng(poi.pose.x, poi.pose.y));  // 扇形の中心点
-    }
-    for (let i = 0; i <= N; i += 1) {
-      const a = startAngle + (totalAngle * i) / N;
-      const wx = poi.pose.x + r * Math.cos(a);
-      const wy = poi.pose.y + r * Math.sin(a);
-      points.push(this.worldToLatLng(wx, wy));
-    }
+    const hasYawConstraint = yawTol > 0 && yawTol < Math.PI;
 
     const color = this.getPoiColor(poi);
 
-    // 主 glyph: waypoint = 塗り、landmark = 中抜き
-    // 細い実線で pause overlay (太い点線) との対比を強める (#136 user feedback)。
-    const polygon = L.polygon(points, {
+    // 円の頂点列 (36 角形 = 10 度刻み)。i = N_CIRCLE で起点に戻り polyline が自然に閉じる。
+    const N_CIRCLE = 36;
+    const circlePoints = [];
+    for (let i = 0; i <= N_CIRCLE; i += 1) {
+      const a = (2 * Math.PI * i) / N_CIRCLE;
+      const wx = poi.pose.x + r * Math.cos(a);
+      const wy = poi.pose.y + r * Math.sin(a);
+      circlePoints.push(this.worldToLatLng(wx, wy));
+    }
+
+    // xy 判定領域 (円 outline): 控えめな細実線で常時表示 (#179)
+    const circle = L.polyline(circlePoints, {
       color,
       weight: 1,
-      opacity: 0.7,
-      fillColor: color,
-      fillOpacity: isWaypoint ? 0.25 : 0,
+      opacity: 0.4,
       interactive: false,
     }).addTo(this.map);
-    polygon.bringToBack();
-    this.sectorLayers.push(polygon);
+    circle.bringToBack();
+    this.sectorLayers.push(circle);
 
-    // pause overlay: 主 glyph と同色で太い点線 outline を重ね描き
-    // 主 glyph (細い実線) と weight + dashArray の両軸で区別する (#136 user feedback)。
-    if (isPause) {
-      const outlinePoints = points.slice();
-      outlinePoints.push(points[0]);  // 閉じる
-      const outline = L.polyline(outlinePoints, {
+    // 扇形 (yaw 制約): 0 < yaw < π の時のみ重ね描き (#179)。
+    // 完全円 (yaw 不問) なら扇形 = 円で情報冗長になるため省略。
+    if (hasYawConstraint) {
+      const totalAngle = 2 * yawTol;
+      const N = Math.max(8, Math.ceil(totalAngle / 0.1));
+      const startAngle = yawCenter - yawTol;
+      const centerLatLng = this.worldToLatLng(poi.pose.x, poi.pose.y);
+      const sectorPoints = [centerLatLng];  // 中心点 → 弧 → 中心 (polygon で自動閉じる)
+      for (let i = 0; i <= N; i += 1) {
+        const a = startAngle + (totalAngle * i) / N;
+        const wx = poi.pose.x + r * Math.cos(a);
+        const wy = poi.pose.y + r * Math.sin(a);
+        sectorPoints.push(this.worldToLatLng(wx, wy));
+      }
+      const sector = L.polygon(sectorPoints, {
         color,
-        weight: 5,
-        opacity: 0.9,
-        dashArray: '6, 4',
+        weight: 1,
+        opacity: 0.7,
+        fillColor: color,
+        fillOpacity: isWaypoint ? 0.25 : 0,  // waypoint=塗り、landmark=中抜き
         interactive: false,
       }).addTo(this.map);
-      outline.bringToBack();
-      this.sectorLayers.push(outline);
+      sector.bringToBack();
+      this.sectorLayers.push(sector);
+    }
+
+    // pause overlay: xy 円沿いに dot pattern を重ね描き (#179)。
+    // 旧 dashArray '6, 4' (1.5:1 dash) は dot として識別しづらく潰れて見える feedback (#178 PR コメント)
+    // を受け、'2, 6' (1:3 dot) で短い dot + 大きい gap に変更。
+    if (isPause) {
+      const pauseOutline = L.polyline(circlePoints, {
+        color,
+        weight: 4,
+        opacity: 0.9,
+        dashArray: '2, 6',
+        lineCap: 'round',  // dot を丸く描画して角ばった dash 感を消す
+        interactive: false,
+      }).addTo(this.map);
+      pauseOutline.bringToBack();
+      this.sectorLayers.push(pauseOutline);
     }
   }
 


### PR DESCRIPTION
## Summary
- POI tolerance visualization (#136) を 判定 semantics に沿って 円 (xy 判定領域) + 扇形 (yaw 制約) の重ね描きに分解
- pause overlay を旧 dash (1:1 比率、潰れて見える feedback) → dot 形式 (1:4 比率) に変更
- `show_tolerance_sector` parameter は名称据え置きで制御対象を 円 + 扇形 + pause overlay 全体に拡張

## 主な変更点

### `mapoi_server/src/mapoi_rviz2_publisher.cpp`
- 新 helper `add_radius_circle`: LINE_STRIP の 36 角形で xy 円を細実線描画 (常時、`alpha=0.4` で控えめ)
- `add_sector` を簡略化: 完全円分岐を削除し、yaw 制約あり (`0 < yaw < π`) のみ扱う
- `add_dashed_outline` → `add_dotted_outline` に置換: dot 長 0.02m / 間隔 0.10m / line 0.04m (旧 0.05m segment + 0.06m line から短縮)
- 描画呼び出し順: 円 outline → 扇形 (yaw 制約あり時) → pause overlay (pause tag 時、xy 円沿いに重畳)

### `mapoi_webui/web/js/map-viewer.js`
- `_drawSectorForPoi` を 3-layer 構成に再編
  - 円 outline: `L.polyline` で 36 角形 (`weight: 1, opacity: 0.4`)
  - 扇形: `L.polygon` で `0 < yaw < π` 時のみ
  - pause overlay: `L.polyline` で `dashArray: '2, 6'` + `lineCap: 'round'` (旧 `'6, 4'` から短縮)
- `L.circle` ではなく polyline で実装: `worldToLatLng` 経由の world 座標計算で扇形と弧を完全一致させるため

### `CHANGELOG.rst`
- WebUI / rviz_plugins セクションに #179 エントリ追加 (#136 エントリも follow-up 文言を更新)

## 設計判断

- **完全円 (yaw_tolerance == 0 または >= π) では扇形を省略**: 扇形 = 円で情報冗長になるため、円 outline のみ表示。yaw 制約の有無が visual で即判別できる
- **pause overlay の重畳先を xy 円に固定**: pause 発火条件 (xy 円内 #84) と境界が一致するため自然な視覚的根拠になる。旧 #136 では扇形の弧に沿わせていたが、「pause = xy 領域への進入」というロジックと整合性を取る
- **dot 比率 1:4 (on:off)**: WebUI `'2, 6'` ≈ 25% on、RViz dot 0.02m / step 0.10m = 20% on。旧 1:1 比率の「潰れて見える」feedback (#178 PR コメント) を解消

## Test plan
- [x] Docker build (humble + jazzy) で clean colcon build 成功 (warning 0)
- [x] colcon test (humble) 59 tests pass
- [x] map-viewer.js syntax check OK
- [ ] RViz 起動で 円 + 扇形 + pause dot の sanity check (user 確認、yaw 不問 / yaw 制約あり / pause 各パターンの sample POI で見比べ)
- [ ] WebUI で同じく sanity check (`turtlebot3_world` の `corridor_a/b` / `conference_room` / `entrance` などで対比)

## Notes
- 色は #70 で別途整理予定。本 PR は visualization 形状のみ
- `show_tolerance_sector` parameter は backward compat のため名称据え置き (制御対象 scope のみ拡張)
- 別件で気付いた regression: `mapoi_rviz_plugins/src/poi_editor.cpp` に `arrow_size_ratio` UI が残存 (PR #178 で publisher 側のみ削除)。本 PR scope 外、別 issue で対応予定

Close #179