### PR TITLE
refactor(rviz_publisher): legacy event tag elif 分岐削除 + 旧仕様整理 (Close #180)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -225,6 +225,18 @@ WebUI / rviz_plugins
     本 PR で同 UI を ``show_tolerance_sector`` の CheckBox に置換 (display layer の
     runtime トグルが Panel から可能に)
 
+* ``mapoi_rviz2_publisher`` から legacy ``event`` tag elif 分岐を削除 (#180)。
+
+  - ``event`` tag は元々 system tag だったが #89 段階 1 で system tag から外れて custom tag 扱いに
+    なっていた。RViz publisher 側に hardcode で青色 arrow + label を描画する分岐が残っており、
+    PR #178 の cursor review で「legacy 残置」として high 指摘された follow-up
+  - 本 PR で elif 分岐を削除。``event`` tag を持つ POI は他の system tag (``waypoint`` /
+    ``landmark``) があれば従来通り扇形 + arrow が描画され、それらが無ければ visualization に
+    出ない (custom tag 共通の挙動と一致)
+  - ``hazard_south`` のような複合 tag POI は ``[landmark, hazard]`` に整理 (sample 側変更、
+    Samples セクション参照)
+  - 色 / glyph の整理は #70 で扱う
+
 Samples
 -------
 
@@ -240,7 +252,8 @@ Samples
     (waypoints + landmarks 両方持ち) と ``tour_short`` (landmarks 省略) の対比。
     custom tag ``capture_trigger`` / ``capture_target`` を追加。
   - ``turtlebot3_dqn_stage1`` (障害物 sandbox での回避): POI 5 → 7 に拡張。
-    複合 tag (``event + landmark + hazard``) のハザード、``tolerance.yaw=π`` で
+    複合 tag (``landmark + hazard``、当初 ``[event, landmark, hazard]`` だったが #180 で
+    ``event`` tag 削除に伴い ``[landmark, hazard]`` に整理) のハザード、``tolerance.yaw=π`` で
     yaw 不問の通過点 (= pass_through 代替) として ``checkpoint_west/east``、
     pause 中継 (``pause_intersection``)、route ``avoidance_a``
     (waypoints + landmarks) と ``avoidance_b`` (waypoints のみ)。custom tag

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -561,26 +561,6 @@ void MapoiRviz2Publisher::timer_callback(){
           id += 1;
         }
       }
-      else if(tag == "event"){
-        visualization_msgs::msg::Marker m_event = default_arrow_marker;
-        m_event.pose = pose;
-        m_event.pose.position.z = 0.1;
-        m_event.color.r = 0.0; m_event.color.g = 0.0; m_event.color.b = 1.0; m_event.color.a = 0.7;
-        m_event.id = id;
-        ma_events.markers.push_back(m_event);
-        id += 1;
-
-        const std::string label_text = build_label(poi_index_one_based, poi.name);
-        if (!label_text.empty()) {
-          visualization_msgs::msg::Marker m_text = default_text_marker;
-          m_text.text = label_text;
-          m_text.pose = pose;
-          m_text.pose.position.z = 0.1;
-          m_text.id = id;
-          ma_events.markers.push_back(m_text);
-          id += 1;
-        }
-      }
       else if(tag == "landmark"){
         // landmark POI も矢印 + label を描画する (#85)。reference 専用なので
         // ma_events 側に置く。color は default gray、tag 別 color の整理は #70 で扱う。

--- a/mapoi_server/test/test_nav_server_unit.cpp
+++ b/mapoi_server/test/test_nav_server_unit.cpp
@@ -101,7 +101,7 @@ TEST_F(NavServerTestFixture, HasLandmarkTagDetection)
   EXPECT_TRUE(MapoiNavServer::has_landmark_tag(
     make_poi("landmark_only", 0.0, 0.0, 0.5, {"landmark"})));
   EXPECT_TRUE(MapoiNavServer::has_landmark_tag(
-    make_poi("landmark_combo", 0.0, 0.0, 0.5, {"event", "landmark", "hazard"})));
+    make_poi("landmark_combo", 0.0, 0.0, 0.5, {"landmark", "hazard"})));
 }
 
 // --- build_route_poi_names (#143 / #148) ---

--- a/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml
@@ -1,5 +1,5 @@
 # シナリオ: 障害物 sandbox での回避走行 (ハザード回避 + 観察 + 通過点)。
-# 検証カバレッジ (#146): 複合 tag (event + landmark + custom hazard)、tolerance.yaw=π で
+# 検証カバレッジ (#146): 複合 tag (landmark + custom hazard)、tolerance.yaw=π で
 # yaw 不問の通過点 (= pass_through 代替)、pause 中継、route の landmarks 利用。
 custom_tags:
 - {name: hazard, description: Hazard zone (avoidance target)}
@@ -61,10 +61,10 @@ poi:
 # 以下 landmark 群: Nav2 navigation 不可な reference 点 (#85, #143)。
 # avoidance_a の landmarks: [...] で route 走行中だけ radius event 監視対象。
 - name: hazard_south
-  description: 南側ハザード (event + landmark + custom hazard、Nav2 goal 不可な複合 tag)
+  description: 南側ハザード (landmark + custom hazard、Nav2 goal 不可な複合 tag)
   pose: {x: 0.5, y: -1.3, yaw: 0.0}
   tolerance: {xy: 0.45, yaw: 0.785}
-  tags: [event, landmark, hazard]
+  tags: [landmark, hazard]
 - name: observation_point
   description: 観察対象 (landmark + observation、route 走行中の参照点)
   pose: {x: -1.0, y: -0.6, yaw: 0.0}

--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -2,7 +2,6 @@
 # 検証カバレッジ (#146): system tag 単独 / 複合、tolerance.yaw 厳密 ↔ 緩い、route の
 # waypoints + landmarks 両方持ち、連続 pause、撮影 / 音声 / 観察対象の custom tag。
 custom_tags:
-- {name: event, description: Event trigger area}
 - {name: destination, description: General destination point}
 - {name: audio_info, description: Audio guide trigger (POI 進入で音声再生)}
 - {name: capture_trigger, description: Capture action trigger (POI 進入で撮影起動)}


### PR DESCRIPTION
## Summary
- ``mapoi_rviz2_publisher.cpp`` の legacy ``else if(tag == \"event\")`` 分岐を削除 (PR #178 cursor review high 指摘の follow-up)
- sample yaml の event tag 残置を整理 (dqn_stage1 ``hazard_south`` の tags / turtlebot3_world の未使用 custom_tags 定義)
- nav_server unit test の event tag 使用を整理

## 背景
`event` tag は元々 system tag だったが #89 段階 1 で system tag から外れて custom tag 扱いになっていた。RViz publisher 側に hardcode で青色 arrow + label を描画する分岐が残っており、PR #178 の cursor review で「legacy 残置」として high 指摘されていた follow-up。

## 主な変更点

### `mapoi_server/src/mapoi_rviz2_publisher.cpp`
- `else if(tag == "event")` 分岐 (line 564-583) を削除
- waypoint / landmark を持たない event のみ POI は visualization に出ないが、custom tag 共通の挙動と一致するため許容
- waypoint / landmark を併せ持つ event POI (例: dqn_stage1 の `hazard_south` 旧 `[event, landmark, hazard]`) は landmark の経路で従来通り扇形 + arrow 描画される

### `mapoi_turtlebot3_example/maps/turtlebot3_dqn_stage1/mapoi_config.yaml`
- `hazard_south` の `tags: [event, landmark, hazard]` → `[landmark, hazard]` に整理
- 関連 description / コメントの「event + landmark + hazard」表記を「landmark + hazard」に更新

### `mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml`
- 未使用 `custom_tags: event` 定義を削除 (実際の POI で使用されていない dead def)

### `mapoi_server/test/test_nav_server_unit.cpp`
- `HasLandmarkTagDetection` test の `landmark_combo` POI tags から `event` 削除
- `{"event", "landmark", "hazard"}` → `{"landmark", "hazard"}` (複合 tag の意図は `hazard` で維持)

### `CHANGELOG.rst`
- WebUI / rviz_plugins セクションに #180 エントリ追加
- Samples セクションの既存 #146 エントリ内 `event + landmark + hazard` 表記を更新

## 影響
- 既存環境で `tags: [event]` のみを持つ POI があれば arrow + text 描画が消える (default 経路で fallback なし)
- waypoint / landmark を併せ持つ POI は従来通りの visualization 挙動
- 動作 (PoiEvent.msg の event_type 通知) には影響しない (radius event は別軸の概念)

## Test plan
- [x] Docker build (humble) で clean colcon build 成功
- [x] colcon test 59 tests pass (test_nav_server_unit 含む)
- [ ] sample yaml の RViz/WebUI sanity check (user 確認、特に dqn_stage1 の `hazard_south` が landmark 経路で描画されること)

## 関連
- #178 (元々の sector 化、本 PR は cursor review high 指摘 follow-up)
- #136 (本 issue の親 issue)
- #70 (visualization 仕様再整理 / custom tag 全体の color 整理、本 PR scope 外)

Close #180