### PR TITLE
chore: cut v0.3.0 changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ For releases prior to v0.2.0, see the
 Unreleased
 ==========
 
+
+0.3.0 (2026-05-02)
+==================
+
 Breaking changes
 ----------------
 


### PR DESCRIPTION
## Summary
- move the accumulated release notes from Unreleased to 0.3.0 (2026-05-02)
- keep an empty Unreleased section for follow-up development

## Test
```sh
ROS_DISTRO=jazzy docker compose run --rm dev bash -lc "cd /ros2_ws/src/mapoi && source /opt/ros/jazzy/setup.bash && colcon --log-base /tmp/mapoi-v030-log build --symlink-install --build-base /tmp/mapoi-v030-build --install-base /tmp/mapoi-v030-install && source /tmp/mapoi-v030-install/setup.bash && colcon --log-base /tmp/mapoi-v030-log-test test --event-handlers console_direct+ --build-base /tmp/mapoi-v030-build --install-base /tmp/mapoi-v030-install"
```

## Release after merge
- create tag `v0.3.0` on the merge commit
- publish GitHub Release `v0.3.0` using the 0.3.0 changelog section