### PR TITLE
test(rviz_plugins): ConfigPathCallback の分岐契約を unit test 化

### DIFF
--- a/mapoi_rviz_plugins/CMakeLists.txt
+++ b/mapoi_rviz_plugins/CMakeLists.txt
@@ -34,6 +34,11 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_poi_editor_helpers
     test/test_poi_editor_helpers.cpp
   )
+
+  # ConfigPathCallback の分岐 policy は Qt / ROS 非依存の純関数として固定検証する (#169)。
+  ament_auto_add_gtest(test_config_path_update_policy
+    test/test_config_path_update_policy.cpp
+  )
 endif()
 
 # 将来のROS 2（Kilted Kaiju以降）と互換性を持たせるため

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/config_path_update_policy.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/config_path_update_policy.hpp
@@ -17,16 +17,22 @@ enum class ConfigPathUpdateAction
 inline ConfigPathUpdateAction decide_poi_editor_config_path_action(
   const std::string & current_map,
   const std::string & new_map,
-  const std::string & current_config_path,
-  bool suppress_content_update)
+  const std::string & current_config_path)
 {
   if (current_config_path.empty() || current_map != new_map) {
     return ConfigPathUpdateAction::ReinitializeMap;
   }
-  if (suppress_content_update) {
+  return ConfigPathUpdateAction::RefreshCurrentMap;
+}
+
+inline ConfigPathUpdateAction apply_poi_editor_content_update_suppression(
+  ConfigPathUpdateAction action,
+  bool suppress_content_update)
+{
+  if (action == ConfigPathUpdateAction::RefreshCurrentMap && suppress_content_update) {
     return ConfigPathUpdateAction::Noop;
   }
-  return ConfigPathUpdateAction::RefreshCurrentMap;
+  return action;
 }
 
 inline ConfigPathUpdateAction decide_mapoi_panel_config_path_action(

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/config_path_update_policy.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/config_path_update_policy.hpp
@@ -1,0 +1,41 @@
+// Pure decision helpers for mapoi/config_path callbacks (#169).
+// Qt / ROS 依存を持たせず、Panel callback はこの判定結果を UI 更新関数へ写像するだけにする。
+#pragma once
+
+#include <string>
+
+namespace mapoi_rviz_plugins::detail
+{
+
+enum class ConfigPathUpdateAction
+{
+  ReinitializeMap,
+  RefreshCurrentMap,
+  Noop,
+};
+
+inline ConfigPathUpdateAction decide_poi_editor_config_path_action(
+  const std::string & current_map,
+  const std::string & new_map,
+  const std::string & current_config_path,
+  bool suppress_content_update)
+{
+  if (current_config_path.empty() || current_map != new_map) {
+    return ConfigPathUpdateAction::ReinitializeMap;
+  }
+  if (suppress_content_update) {
+    return ConfigPathUpdateAction::Noop;
+  }
+  return ConfigPathUpdateAction::RefreshCurrentMap;
+}
+
+inline ConfigPathUpdateAction decide_mapoi_panel_config_path_action(
+  const std::string & current_map,
+  const std::string & new_map)
+{
+  return current_map != new_map
+    ? ConfigPathUpdateAction::ReinitializeMap
+    : ConfigPathUpdateAction::RefreshCurrentMap;
+}
+
+}  // namespace mapoi_rviz_plugins::detail

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <set>
 
+#include "mapoi_rviz_plugins/config_path_update_policy.hpp"
 #include "ui_mapoi_panel.h"
 
 using namespace std::chrono_literals;
@@ -241,15 +242,15 @@ void MapoiPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
 {
   std::filesystem::path config_path(msg->data);
   std::string map_name = config_path.parent_path().filename().string();
-  bool map_changed = (current_map_ != map_name);
+  const auto action = detail::decide_mapoi_panel_config_path_action(current_map_, map_name);
   current_map_ = map_name;
 
   // 同じ map で path も同じ場合 (= save 後の reload_map_info で再 publish される flow) でも
   // POI / route list が変わっている可能性があるため Nav2GoalComboBox / MapoiRouteComboBox を
   // 再 fetch する (#135)。map 切替時は highlight クリア + MapComboBox 同期も必要なので
   // SetMapComboBox を呼ぶ。
-  QMetaObject::invokeMethod(this, [this, map_name, map_changed]() {
-    if (map_changed) {
+  QMetaObject::invokeMethod(this, [this, map_name, action]() {
+    if (action == detail::ConfigPathUpdateAction::ReinitializeMap) {
       SetMapComboBox(map_name);
     } else {
       SetNav2GoalComboBox();

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -1,4 +1,5 @@
 #include "mapoi_rviz_plugins/poi_editor.hpp"
+#include "mapoi_rviz_plugins/config_path_update_policy.hpp"
 #include "mapoi_rviz_plugins/poi_editor_helpers.hpp"
 #include <class_loader/class_loader.hpp>
 #include <cctype>
@@ -576,8 +577,8 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
 
   std::filesystem::path resolved_p(resolved_path);
   std::string map_name = resolved_p.parent_path().filename().string();
-  bool first_config = config_path_.empty();
-  bool map_changed = (current_map_ != map_name);
+  const auto action = detail::decide_poi_editor_config_path_action(
+    current_map_, map_name, config_path_, suppress_config_callback_update_);
   config_path_ = resolved_path;
   current_map_ = map_name;
 
@@ -586,10 +587,10 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
   // map 切替 / 初回受信時は MapComboBox 同期 + FileComboBox 再構築も必要なので InitConfigs を呼ぶ。
   // 自分自身が save 直後 (suppress_config_callback_update_) は 1.5 秒の SAVED! feedback を
   // 守るため UpdatePoiTable を skip する (QTimer 末尾で rebuild + flag クリアされる)。
-  QMetaObject::invokeMethod(this, [this, map_name, map_changed, first_config]() {
-    if (map_changed || first_config) {
+  QMetaObject::invokeMethod(this, [this, map_name, action]() {
+    if (action == detail::ConfigPathUpdateAction::ReinitializeMap) {
       InitConfigs(map_name);
-    } else if (!suppress_config_callback_update_) {
+    } else if (action == detail::ConfigPathUpdateAction::RefreshCurrentMap) {
       UpdatePoiTable();
     }
   }, Qt::QueuedConnection);

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -577,8 +577,8 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
 
   std::filesystem::path resolved_p(resolved_path);
   std::string map_name = resolved_p.parent_path().filename().string();
-  const auto action = detail::decide_poi_editor_config_path_action(
-    current_map_, map_name, config_path_, suppress_config_callback_update_);
+  const auto base_action = detail::decide_poi_editor_config_path_action(
+    current_map_, map_name, config_path_);
   config_path_ = resolved_path;
   current_map_ = map_name;
 
@@ -586,8 +586,10 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
   // でも POI 内容が変わっている可能性があるため UpdatePoiTable で table を再 fetch する (#135)。
   // map 切替 / 初回受信時は MapComboBox 同期 + FileComboBox 再構築も必要なので InitConfigs を呼ぶ。
   // 自分自身が save 直後 (suppress_config_callback_update_) は 1.5 秒の SAVED! feedback を
-  // 守るため UpdatePoiTable を skip する (QTimer 末尾で rebuild + flag クリアされる)。
-  QMetaObject::invokeMethod(this, [this, map_name, action]() {
+  // 守るため UpdatePoiTable を skip する。旧挙動と同じく queued lambda 実行時の flag を見る。
+  QMetaObject::invokeMethod(this, [this, map_name, base_action]() {
+    const auto action = detail::apply_poi_editor_content_update_suppression(
+      base_action, suppress_config_callback_update_);
     if (action == detail::ConfigPathUpdateAction::ReinitializeMap) {
       InitConfigs(map_name);
     } else if (action == detail::ConfigPathUpdateAction::RefreshCurrentMap) {

--- a/mapoi_rviz_plugins/test/test_config_path_update_policy.cpp
+++ b/mapoi_rviz_plugins/test/test_config_path_update_policy.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include "mapoi_rviz_plugins/config_path_update_policy.hpp"
+
+using mapoi_rviz_plugins::detail::ConfigPathUpdateAction;
+using mapoi_rviz_plugins::detail::decide_mapoi_panel_config_path_action;
+using mapoi_rviz_plugins::detail::decide_poi_editor_config_path_action;
+
+// --- PoiEditorPanel::ConfigPathCallback policy (#169) ---
+
+TEST(PoiEditorConfigPathAction, FirstConfigReinitializesEvenWhenMapNameMatches)
+{
+  EXPECT_EQ(
+    decide_poi_editor_config_path_action("map_a", "map_a", "", false),
+    ConfigPathUpdateAction::ReinitializeMap);
+}
+
+TEST(PoiEditorConfigPathAction, MapSwitchReinitializesConfigs)
+{
+  EXPECT_EQ(
+    decide_poi_editor_config_path_action("map_a", "map_b", "/maps/map_a/mapoi_config.yaml", false),
+    ConfigPathUpdateAction::ReinitializeMap);
+}
+
+TEST(PoiEditorConfigPathAction, SameMapContentChangeRefreshesTableOnly)
+{
+  EXPECT_EQ(
+    decide_poi_editor_config_path_action("map_a", "map_a", "/maps/map_a/mapoi_config.yaml", false),
+    ConfigPathUpdateAction::RefreshCurrentMap);
+}
+
+TEST(PoiEditorConfigPathAction, SameMapSaveFeedbackSuppressionSkipsRefresh)
+{
+  EXPECT_EQ(
+    decide_poi_editor_config_path_action("map_a", "map_a", "/maps/map_a/mapoi_config.yaml", true),
+    ConfigPathUpdateAction::Noop);
+}
+
+TEST(PoiEditorConfigPathAction, SuppressionDoesNotHideMapSwitch)
+{
+  EXPECT_EQ(
+    decide_poi_editor_config_path_action("map_a", "map_b", "/maps/map_a/mapoi_config.yaml", true),
+    ConfigPathUpdateAction::ReinitializeMap);
+}
+
+// --- MapoiPanel::ConfigPathCallback policy (#169) ---
+
+TEST(MapoiPanelConfigPathAction, MapSwitchReinitializesComboBoxesAndHighlight)
+{
+  EXPECT_EQ(
+    decide_mapoi_panel_config_path_action("map_a", "map_b"),
+    ConfigPathUpdateAction::ReinitializeMap);
+}
+
+TEST(MapoiPanelConfigPathAction, SameMapContentChangeRefreshesGoalAndRouteOnly)
+{
+  EXPECT_EQ(
+    decide_mapoi_panel_config_path_action("map_a", "map_a"),
+    ConfigPathUpdateAction::RefreshCurrentMap);
+}
+
+TEST(MapoiPanelConfigPathAction, EmptyCurrentMapTreatsFirstCallbackAsMapSwitch)
+{
+  EXPECT_EQ(
+    decide_mapoi_panel_config_path_action("", "map_a"),
+    ConfigPathUpdateAction::ReinitializeMap);
+}

--- a/mapoi_rviz_plugins/test/test_config_path_update_policy.cpp
+++ b/mapoi_rviz_plugins/test/test_config_path_update_policy.cpp
@@ -3,6 +3,7 @@
 #include "mapoi_rviz_plugins/config_path_update_policy.hpp"
 
 using mapoi_rviz_plugins::detail::ConfigPathUpdateAction;
+using mapoi_rviz_plugins::detail::apply_poi_editor_content_update_suppression;
 using mapoi_rviz_plugins::detail::decide_mapoi_panel_config_path_action;
 using mapoi_rviz_plugins::detail::decide_poi_editor_config_path_action;
 
@@ -11,35 +12,45 @@ using mapoi_rviz_plugins::detail::decide_poi_editor_config_path_action;
 TEST(PoiEditorConfigPathAction, FirstConfigReinitializesEvenWhenMapNameMatches)
 {
   EXPECT_EQ(
-    decide_poi_editor_config_path_action("map_a", "map_a", "", false),
+    decide_poi_editor_config_path_action("map_a", "map_a", ""),
     ConfigPathUpdateAction::ReinitializeMap);
 }
 
 TEST(PoiEditorConfigPathAction, MapSwitchReinitializesConfigs)
 {
   EXPECT_EQ(
-    decide_poi_editor_config_path_action("map_a", "map_b", "/maps/map_a/mapoi_config.yaml", false),
+    decide_poi_editor_config_path_action("map_a", "map_b", "/maps/map_a/mapoi_config.yaml"),
     ConfigPathUpdateAction::ReinitializeMap);
 }
 
 TEST(PoiEditorConfigPathAction, SameMapContentChangeRefreshesTableOnly)
 {
   EXPECT_EQ(
-    decide_poi_editor_config_path_action("map_a", "map_a", "/maps/map_a/mapoi_config.yaml", false),
+    decide_poi_editor_config_path_action("map_a", "map_a", "/maps/map_a/mapoi_config.yaml"),
     ConfigPathUpdateAction::RefreshCurrentMap);
 }
 
 TEST(PoiEditorConfigPathAction, SameMapSaveFeedbackSuppressionSkipsRefresh)
 {
   EXPECT_EQ(
-    decide_poi_editor_config_path_action("map_a", "map_a", "/maps/map_a/mapoi_config.yaml", true),
+    apply_poi_editor_content_update_suppression(
+      ConfigPathUpdateAction::RefreshCurrentMap, true),
     ConfigPathUpdateAction::Noop);
+}
+
+TEST(PoiEditorConfigPathAction, UnsuppressedRefreshStaysRefresh)
+{
+  EXPECT_EQ(
+    apply_poi_editor_content_update_suppression(
+      ConfigPathUpdateAction::RefreshCurrentMap, false),
+    ConfigPathUpdateAction::RefreshCurrentMap);
 }
 
 TEST(PoiEditorConfigPathAction, SuppressionDoesNotHideMapSwitch)
 {
   EXPECT_EQ(
-    decide_poi_editor_config_path_action("map_a", "map_b", "/maps/map_a/mapoi_config.yaml", true),
+    apply_poi_editor_content_update_suppression(
+      ConfigPathUpdateAction::ReinitializeMap, true),
     ConfigPathUpdateAction::ReinitializeMap);
 }
 


### PR DESCRIPTION
## 概要

- `PoiEditorPanel::ConfigPathCallback` / `MapoiPanel::ConfigPathCallback` の分岐判定を Qt / ROS 非依存の pure helper に切り出しました。
- map 切替 / 初回 config / 同 map 内容変更 / save 直後抑制の action contract を gtest で固定しました。
- callback 本体は判定済み action を既存 UI 更新関数へ写像する thin wrapper に寄せました。

## 検証

- Docker compose 環境: `ROS_DISTRO=humble docker compose run --rm -T dev ...` で `mapoi_rviz_plugins` build + `test_config_path_update_policy|test_poi_editor_helpers`
- `git diff --check`

Close #169
