### PR TITLE
test(nav_server): STOPPED / RESUMED の integration test を追加

### DIFF
--- a/mapoi_server/test/test_poi_event_integration.py
+++ b/mapoi_server/test/test_poi_event_integration.py
@@ -11,8 +11,13 @@ import launch_testing.markers
 import rclpy
 from tf2_ros import TransformBroadcaster
 from geometry_msgs.msg import TransformStamped
+from geometry_msgs.msg import Twist
 from mapoi_interfaces.msg import PoiEvent
 from ament_index_python.packages import get_package_share_directory
+from std_msgs.msg import String
+
+
+STOPPED_DWELL_TIME_SEC = 0.3
 
 
 @launch_testing.markers.keep_alive
@@ -39,6 +44,7 @@ def generate_test_description():
             'tolerance_check_hz': 10.0,
             'map_frame': 'map',
             'base_frame': 'base_link',
+            'stopped_dwell_time_sec': STOPPED_DWELL_TIME_SEC,
         }],
     )
 
@@ -62,27 +68,37 @@ class TestPoiEventIntegration(unittest.TestCase):
     EVENT_WAIT_TIMEOUT = 5.0
     # dynamic TF publish 周期。tolerance_check_hz=10 (=100ms) より十分速くして取りこぼしを防ぐ。
     TF_PUBLISH_INTERVAL = 0.05
+    # cmd_vel も timer publish にして discovery / callback timing の取りこぼしを避ける。
+    CMD_VEL_PUBLISH_INTERVAL = 0.05
 
     @classmethod
     def setUpClass(cls):
         rclpy.init()
         cls.node = rclpy.create_node('test_poi_event_node')
         cls.received_events = []
+        cls.inside_state = {}
         cls.sub = cls.node.create_subscription(
             PoiEvent, 'mapoi/events',
-            lambda msg: cls.received_events.append(msg), 10)
+            cls._event_callback, 10)
         cls.tf_broadcaster = TransformBroadcaster(cls.node)
         cls._robot_xy = (100.0, 100.0)  # 初期は全 POI から十分遠い座標
+        cls.cmd_vel_pub = cls.node.create_publisher(Twist, 'cmd_vel', 10)
+        cls.goal_pose_poi_pub = cls.node.create_publisher(String, 'mapoi/nav/goal_pose_poi', 1)
+        cls._cmd_vel_linear_x = 0.2
+        cls._cmd_vel_angular_z = 0.0
         # rclpy timer で周期 publish。別 thread で sendTransform を呼ぶと
         # rclpy publisher の thread safety 制約に違反し、jazzy 環境で TF buffer
         # の反映が時々壊れて test_exit_event が flaky 化していた (#165 検証時に観測)。
         # executor 内 (spin_once 経由) で publish することで安全側に倒す。
         cls._tf_timer = cls.node.create_timer(
             cls.TF_PUBLISH_INTERVAL, cls._tf_publish_callback)
+        cls._cmd_vel_timer = cls.node.create_timer(
+            cls.CMD_VEL_PUBLISH_INTERVAL, cls._cmd_vel_publish_callback)
 
     @classmethod
     def tearDownClass(cls):
         try:
+            cls.node.destroy_timer(cls._cmd_vel_timer)
             cls.node.destroy_timer(cls._tf_timer)
             cls.node.destroy_node()
         finally:
@@ -103,8 +119,24 @@ class TestPoiEventIntegration(unittest.TestCase):
         t.transform.rotation.w = 1.0
         cls.tf_broadcaster.sendTransform(t)
 
+    @classmethod
+    def _cmd_vel_publish_callback(cls):
+        msg = Twist()
+        msg.linear.x = cls._cmd_vel_linear_x
+        msg.angular.z = cls._cmd_vel_angular_z
+        cls.cmd_vel_pub.publish(msg)
+
+    @classmethod
+    def _event_callback(cls, msg):
+        cls.received_events.append(msg)
+        if msg.event_type == PoiEvent.EVENT_ENTER:
+            cls.inside_state[msg.poi.name] = True
+        elif msg.event_type == PoiEvent.EVENT_EXIT:
+            cls.inside_state[msg.poi.name] = False
+
     def setUp(self):
         self.received_events.clear()
+        self._set_cmd_vel(0.2, 0.0)
 
     def tearDown(self):
         """各 test 後に nav_server の poi_inside_state_ をリセットする (#165)。
@@ -113,6 +145,10 @@ class TestPoiEventIntegration(unittest.TestCase):
         依存を切るため、明示的に隔離する。実体は :meth:`_reset_inside_state` 側。
         """
         self._reset_inside_state()
+        # 次 test が inside した瞬間に前 test の zero velocity dwell を拾わないよう、
+        # moving cmd_vel を nav_server に届けて stopped detector を reset する。
+        self._set_cmd_vel(0.2, 0.0)
+        self._spin_for(0.2)
 
     def _set_robot_pose(self, x, y):
         """publish callback が次周期から拾う robot 位置を更新する。
@@ -124,21 +160,35 @@ class TestPoiEventIntegration(unittest.TestCase):
         """
         type(self)._robot_xy = (x, y)
 
+    def _set_cmd_vel(self, linear_x, angular_z):
+        type(self)._cmd_vel_linear_x = linear_x
+        type(self)._cmd_vel_angular_z = angular_z
+
+    def _spin_for(self, duration_sec):
+        end_time = time.monotonic() + duration_sec
+        while time.monotonic() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+
+    def _wait_for_subscriber(self, topic_name, timeout_sec=3.0):
+        end_time = time.monotonic() + timeout_sec
+        while time.monotonic() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+            if self.node.count_subscribers(topic_name) > 0:
+                return True
+        return False
+
+    def _count_events(self, predicate):
+        return sum(1 for e in self.received_events if predicate(e))
+
     def _compute_inside_pois(self):
-        """`received_events` の履歴から、現時点で inside と推定される POI 名集合
-        を返す。EVENT_ENTER で True、EVENT_EXIT で False に更新した最終状態。
+        """subscriber が観測した ENTER / EXIT から、現時点で inside と推定される
+        POI 名集合を返す。
 
         nav_server 側の `poi_inside_state_` を直接覗けないため、subscriber 視点の
-        近似として使う。test 中に発生した event のみを見るので、setUp で必ず
-        `received_events.clear()` した状態で開始する前提。
+        近似として使う。STOPPED/RESUMED test は途中で `received_events.clear()` する
+        ため、event assertion 用履歴とは独立した state tracker を使う。
         """
-        state = {}
-        for ev in self.received_events:
-            if ev.event_type == PoiEvent.EVENT_ENTER:
-                state[ev.poi.name] = True
-            elif ev.event_type == PoiEvent.EVENT_EXIT:
-                state[ev.poi.name] = False
-        return {name for name, inside in state.items() if inside}
+        return {name for name, inside in type(self).inside_state.items() if inside}
 
     def _reset_inside_state(self, exit_timeout_sec=3.0):
         """nav_server 側の `poi_inside_state_` を全 false に戻す helper。
@@ -184,6 +234,25 @@ class TestPoiEventIntegration(unittest.TestCase):
             if any(predicate(e) for e in self.received_events):
                 return True
         return False
+
+    def _enter_poi(self, poi_name, x, y):
+        self._set_cmd_vel(0.2, 0.0)
+        self._spin_for(0.2)
+        self._set_robot_pose(x, y)
+        found = self._wait_for_event(
+            lambda e: (e.event_type == PoiEvent.EVENT_ENTER
+                       and e.poi.name == poi_name))
+        self.assertTrue(found, f"{poi_name} に ENTER できるべき")
+
+    def _enter_and_stop_poi(self, poi_name='poi_goal_only', x=1.0, y=0.0):
+        self._enter_poi(poi_name, x, y)
+        self.received_events.clear()
+        self._set_cmd_vel(0.0, 0.0)
+        found = self._wait_for_event(
+            lambda e: (e.event_type == PoiEvent.EVENT_STOPPED
+                       and e.poi.name == poi_name),
+            timeout_sec=self.EVENT_WAIT_TIMEOUT)
+        self.assertTrue(found, f"{poi_name} の EVENT_STOPPED が発行されるべき")
 
     def test_enter_event_goal_only_poi(self):
         """goalタグのみのPOI (1.0, 0.0) 付近 → ENTER イベント発行"""
@@ -256,3 +325,69 @@ class TestPoiEventIntegration(unittest.TestCase):
                        and e.poi.name == 'poi_goal_only'))
         self.assertTrue(exit_found,
                         "poi_goal_only の EXIT イベントが発行されるべき")
+
+    def test_stopped_event_from_cmd_vel_dwell_once(self):
+        """cmd_vel=0 の dwell 継続で STOPPED が 1 回だけ発火する (#177)。"""
+        self._enter_poi('poi_goal_only', 1.0, 0.0)
+        self.received_events.clear()
+
+        self._set_cmd_vel(0.0, 0.0)
+        stopped_found = self._wait_for_event(
+            lambda e: (e.event_type == PoiEvent.EVENT_STOPPED
+                       and e.poi.name == 'poi_goal_only'))
+        self.assertTrue(stopped_found,
+                        "cmd_vel=0 dwell 後に EVENT_STOPPED が発行されるべき")
+        stopped_count = self._count_events(
+            lambda e: (e.event_type == PoiEvent.EVENT_STOPPED
+                       and e.poi.name == 'poi_goal_only'))
+
+        self._spin_for(STOPPED_DWELL_TIME_SEC + 0.5)
+        self.assertEqual(
+            self._count_events(
+                lambda e: (e.event_type == PoiEvent.EVENT_STOPPED
+                           and e.poi.name == 'poi_goal_only')),
+            stopped_count,
+            "停止継続中に EVENT_STOPPED が重複発行されるべきではない")
+
+    def test_resumed_event_when_cmd_vel_recovers(self):
+        """STOPPED 中に cmd_vel が復活すると dwell なしで RESUMED が発火する (#177)。"""
+        self._enter_and_stop_poi('poi_goal_only', 1.0, 0.0)
+        self.received_events.clear()
+
+        self._set_cmd_vel(0.2, 0.0)
+        resumed_found = self._wait_for_event(
+            lambda e: (e.event_type == PoiEvent.EVENT_RESUMED
+                       and e.poi.name == 'poi_goal_only'))
+        self.assertTrue(resumed_found,
+                        "cmd_vel 復活後に EVENT_RESUMED が発行されるべき")
+
+    def test_new_goal_resumes_stopped_poi_and_allows_next_stop_flow(self):
+        """STOPPED 中の新規 goal 受信で RESUMED し、次 POI でも STOPPED できる (#177)。"""
+        self._enter_and_stop_poi('poi_goal_only', 1.0, 0.0)
+        self.received_events.clear()
+
+        self.assertTrue(
+            self._wait_for_subscriber('mapoi/nav/goal_pose_poi'),
+            "mapoi_nav_server が mapoi/nav/goal_pose_poi を subscribe しているべき")
+        msg = String()
+        msg.data = 'poi_with_custom'
+        self.goal_pose_poi_pub.publish(msg)
+
+        resumed_found = self._wait_for_event(
+            lambda e: (e.event_type == PoiEvent.EVENT_RESUMED
+                       and e.poi.name == 'poi_goal_only'))
+        self.assertTrue(resumed_found,
+                        "新規 goal 受信で stopped POI の EVENT_RESUMED が発行されるべき")
+
+        # 新規 goal に向かって動き始めた状況を cmd_vel/TF で模擬し、次の POI でも
+        # ENTER → STOPPED flow が成立することを固定する。
+        self._set_cmd_vel(0.2, 0.0)
+        self._set_robot_pose(100.0, 100.0)
+        exit_found = self._wait_for_event(
+            lambda e: (e.event_type == PoiEvent.EVENT_EXIT
+                       and e.poi.name == 'poi_goal_only'))
+        self.assertTrue(exit_found,
+                        "新規 goal 走行開始後に旧 POI から EXIT できるべき")
+
+        self.received_events.clear()
+        self._enter_and_stop_poi('poi_with_custom', 3.0, 0.0)


### PR DESCRIPTION
## 概要

- `test_poi_event_integration.py` に `cmd_vel` timer publisher と `mapoi/nav/goal_pose_poi` publisher を追加しました。
- `cmd_vel=0` の dwell による `EVENT_STOPPED` 発火と、停止継続中に重複発火しないことを検証します。
- STOPPED 中に `cmd_vel` が復活したときの `EVENT_RESUMED` を検証します。
- STOPPED 中に新規 `mapoi/nav/goal_pose_poi` を受けたときの `EVENT_RESUMED` と、その後の次 POI の `ENTER -> STOPPED` flow を検証します。
- `received_events.clear()` 後も tearDown が inside state を戻せるよう、subscriber 側の inside state tracker を event assertion 履歴から分離しました。

## scope note

#177 の必須 3 経路をこの PR でカバーします。Nav2 `SUCCEEDED` hook / cmd_vel publish 停止 fallback / EXIT implicit RESUMED contract は残るため、#177 は open のまま残します。

## 検証

- Docker compose 環境: `ROS_DISTRO=humble docker compose run --rm -T dev ...` で `mapoi_server` build + `test_poi_event_integration`
  - `Ran 8 tests` / `OK`
  - 抽出 warning: Nav2 action server 未起動による fallback warning と、既存 initialpose subscriber 不在 warning のみ
- `git diff --check`

Refs #177
