### PR TITLE
feat(webui): Navigation 検出とスマホ向け focus UI を追加

### DIFF
--- a/mapoi_webui/README.md
+++ b/mapoi_webui/README.md
@@ -10,6 +10,8 @@ mapoi の Web UI パッケージです。
 - **POI 編集**: POI の追加・編集・削除・保存（mapoi_server に自動リロード通知）
 - **ルート表示**: ルートのポリライン表示、矢印マーカー、表示/非表示の切り替え
 - **ナビゲーション操作**: POI へのゴール走行、ルート走行、一時停止・再開、停止
+- **スマホ表示**: Navigation を優先して開き、地図は画面の半分程度を確保
+- **ナビゲーション backend 検出**: command topic の subscriber 数から navigation 機能の有効/無効を UI に表示
 - **自己位置推定リセット**: POI 選択による Initial Pose の設定
 - **ロボット位置表示**: TF (`map` → `base_link`) によるリアルタイムのロボット位置マーカー表示
 - **タグシステム**: システムタグ・ユーザータグの表示、タグによる POI 色分け
@@ -42,6 +44,7 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 | `mapoi/nav/pause` | `std_msgs/String` | ナビゲーションの一時停止 |
 | `mapoi/nav/resume` | `std_msgs/String` | ナビゲーションの再開 |
 | `mapoi/nav/cancel` | `std_msgs/String` | ナビゲーションのキャンセル |
+| `mapoi/nav/switch_map` | `std_msgs/String` | Navigation map switch 指示。`mapoi_nav_server` 等の navigation backend が受信して地図切り替えを実行 |
 | `mapoi/initialpose_poi` | `mapoi_interfaces/InitialPoseRequest` | 初期位置に採用する POI 名 (`{map_name, poi_name}`)、transient_local QoS |
 
 #### サブスクライバー
@@ -75,6 +78,8 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 | POST | `/api/nav/resume` | ナビゲーションの再開 |
 | POST | `/api/nav/cancel` | ナビゲーションの停止 |
 | POST | `/api/nav/initialpose` | 自己位置推定のリセット |
+| POST | `/api/nav/switch-map` | Navigation map switch。`mapoi/nav/switch_map` に map 名を publish |
+| GET | `/api/mode` | navigation 機能の検出結果 (`navigation_available`, topic subscriber 数) |
 
 ## 起動方法 (3 つのシナリオ)
 
@@ -111,12 +116,14 @@ ros2 launch mapoi_webui mapoi_editor.launch.yaml maps_path:=/path/to/maps map_na
 | `POST /api/pois` `/api/routes` `/api/custom_tags` | **必要** | YAML 書き込み後に `reload_map_info` service を呼ぶ |
 | `GET /api/tag_definitions` | **必要** | `get_tag_definitions` service 経由 |
 | `POST /api/nav/{goal,route,cancel,pause,resume,initialpose}` | **必要 (mapoi_nav_server)** | publisher → nav_server が listener、subscriber 0 件なら warning を返す |
+| `POST /api/nav/switch-map` | **必要 (mapoi_nav_server 等)** | `mapoi/nav/switch_map` publisher → navigation backend が listener、subscriber 0 件なら warning を返す |
 | `GET /api/nav/status` | 不要 (subscriber 経由で受信値返却) | nav_server がいなければ default 値 |
+| `GET /api/mode` | 不要 | command topic の subscriber 数から best-effort で検出 |
 
 server / nav_server 不在時の挙動 (endpoint カテゴリ別):
 - `GET /api/tag_definitions`: `503 Service Unavailable` (service 必須、unavailable / timeout 時)
 - `POST /api/pois` / `/api/routes` / `/api/custom_tags`: `200 OK` + `warning` フィールド (YAML 書き込み自体は成功するため、`reload_map_info` の unavailable / timeout / failure は warning として通知)
-- `POST /api/nav/{goal,route,cancel,pause,resume,initialpose}`: `200 OK` + `warning` フィールド (publish 自体は成功扱い、subscriber 不在を best-effort で検出して通知)
+- `POST /api/nav/{goal,route,cancel,pause,resume,initialpose}` / `/api/nav/switch-map`: `200 OK` + `warning` フィールド (publish 自体は成功扱い、subscriber 不在を best-effort で検出して通知)
 
 ## 開発者規約
 

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -155,6 +155,7 @@ class MapoiWebNode(Node):
         self.cancel_pub_ = self.create_publisher(String, 'mapoi/nav/cancel', 10)
         self.pause_pub_  = self.create_publisher(String, 'mapoi/nav/pause',  10)
         self.resume_pub_ = self.create_publisher(String, 'mapoi/nav/resume', 10)
+        self.switch_map_pub_ = self.create_publisher(String, 'mapoi/nav/switch_map', 1)
         # mapoi/initialpose_poi は #149 round 8 で {map_name, poi_name} 型に変更。
         # transient_local QoS で後起動 subscriber (bridge / nav_server) も latched 値を拾える。
         initialpose_poi_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
@@ -248,7 +249,7 @@ class MapoiWebNode(Node):
                 # loadPois / loadRoutes / loadTagDefinitions を再実行させる (#135 (B))。
                 # map 名が正しく解釈できた時のみ broadcast: 期待形式に部分一致するが map 特定でき
                 # ないケースで無駄な reload を避ける (#173 Round 1 / 2 medium)。
-                self._broadcast_sse_event('config_changed')
+                self._broadcast_sse_event('config_changed', {'map_name': map_name_parsed})
         except Exception as e:
             self.get_logger().warn(f'Failed to parse config path: {e}')
 
@@ -324,6 +325,38 @@ class MapoiWebNode(Node):
             self.get_logger().warn(warning)
             return True, warning
         return True, None
+
+    def get_navigation_capabilities(self):
+        """Return best-effort navigation backend availability from command subscribers."""
+        publishers = {
+            'switch_map': (self.switch_map_pub_, 'mapoi/nav/switch_map'),
+            'goal': (self.goal_poi_pub_, 'mapoi/nav/goal_pose_poi'),
+            'route': (self.route_pub_, 'mapoi/nav/route'),
+            'cancel': (self.cancel_pub_, 'mapoi/nav/cancel'),
+            'pause': (self.pause_pub_, 'mapoi/nav/pause'),
+            'resume': (self.resume_pub_, 'mapoi/nav/resume'),
+            'initialpose': (self.initialpose_poi_pub_, 'mapoi/initialpose_poi'),
+        }
+        topics = {}
+        for key, (pub, topic_name) in publishers.items():
+            count = pub.get_subscription_count()
+            topics[key] = {
+                'topic': topic_name,
+                'subscribers': count,
+                'available': count > 0,
+            }
+        # `mapoi/initialpose_poi` may still have simulator / localization bridge
+        # subscribers after mapoi_nav_server stops. Treat only navigation command
+        # topics as evidence that a navigation backend is available.
+        command_keys = ('goal', 'route', 'cancel', 'pause', 'resume')
+        command_available = any(topics[key]['available'] for key in command_keys)
+        switch_map_available = topics['switch_map']['available']
+        return {
+            'navigation_available': switch_map_available or command_available,
+            'switch_map_available': switch_map_available,
+            'command_available': command_available,
+            'topics': topics,
+        }
 
     def _call_service_sync(self, client, request, service_name, timeout_sec=3.0,
                            wait_for_service_sec=2.0):
@@ -467,6 +500,33 @@ class MapoiWebNode(Node):
                 'map_name': map_name,
                 'config_path': response.config_path,
                 'initial_poi_name': response.initial_poi_name,
+            })
+
+        @app.route('/api/nav/switch-map', methods=['POST'])
+        def api_nav_switch_map():
+            data = request.get_json()
+            if not isinstance(data, dict) or 'map_name' not in data:
+                return jsonify({'error': 'map_name required'}), 400
+            map_name = str(data['map_name']).strip()
+            if not map_name:
+                return jsonify({'error': 'map_name required'}), 400
+            maps = node.get_maps_list()
+            if maps and map_name not in maps:
+                return jsonify({'error': f'unknown map: {map_name}'}), 404
+            msg = String()
+            msg.data = map_name
+            _, warning = node.publish_with_subscriber_check(
+                node.switch_map_pub_, msg, 'mapoi/nav/switch_map')
+            node.get_logger().info(f'Navigation map switch requested: {map_name}')
+            payload = {'success': True, 'map_name': map_name}
+            if warning:
+                payload['warning'] = warning
+            return jsonify(payload)
+
+        @app.route('/api/mode')
+        def api_mode():
+            return jsonify({
+                'navigation': node.get_navigation_capabilities(),
             })
 
         @app.route('/api/pois')
@@ -644,6 +704,7 @@ class MapoiWebNode(Node):
                 # 別 endpoint を叩かなくて済むよう poll 結果に相乗りさせる。
                 # 値は float (m)、payload size 影響は無視できる (#117)。
                 'robot_radius': node.robot_radius_,
+                'navigation': node.get_navigation_capabilities(),
             })
 
         @app.route('/api/nav/initialpose', methods=['POST'])

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -43,6 +43,10 @@ header h1 {
   font-size: 0.9rem;
 }
 
+.hidden {
+  display: none !important;
+}
+
 main {
   display: flex;
   flex-direction: row;
@@ -1026,6 +1030,74 @@ main {
 .nav-status-map_switch_succeeded { background: #27ae60; }
 .nav-status-map_switch_failed { background: #e74c3c; }
 
+.navigation-availability {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  background: #eef2f4;
+  color: #667;
+}
+
+.navigation-availability-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #95a5a6;
+  flex-shrink: 0;
+}
+
+.navigation-available {
+  background: #eafaf1;
+  color: #1e7e44;
+}
+
+.navigation-available .navigation-availability-dot {
+  background: #27ae60;
+}
+
+.navigation-unavailable {
+  background: #f7eeee;
+  color: #9b2d22;
+}
+
+.navigation-unavailable .navigation-availability-dot {
+  background: #e74c3c;
+}
+
+.navigation-warning {
+  padding: 6px 8px;
+  border-radius: 4px;
+  background: #fff4d6;
+  color: #7a4b00;
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
+.navigation-map-switch {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.navigation-map-switch label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #666;
+}
+
+.nav-body.navigation-unavailable-state .navigation-map-switch,
+.nav-body.navigation-unavailable-state .nav-control-group,
+.nav-body.navigation-unavailable-state .nav-pause-resume-row,
+.nav-body.navigation-unavailable-state .nav-btn-stop,
+.nav-body.navigation-unavailable-state .nav-control-label,
+.nav-body.navigation-unavailable-state .nav-control-label + .nav-control-row {
+  display: none;
+}
+
 .nav-control-group {
   display: flex;
   flex-direction: column;
@@ -1066,12 +1138,12 @@ main {
 }
 
 .nav-btn-go { background: #27ae60; }
-.nav-btn-go:hover { background: #219a52; }
+.nav-btn-go:hover:not(:disabled) { background: #219a52; }
 .nav-btn-run { background: #3498db; }
-.nav-btn-run:hover { background: #2980b9; }
+.nav-btn-run:hover:not(:disabled) { background: #2980b9; }
 
 .nav-btn-initialpose { background: #9b59b6; }
-.nav-btn-initialpose:hover { background: #8e44ad; }
+.nav-btn-initialpose:hover:not(:disabled) { background: #8e44ad; }
 
 .nav-control-label {
   font-size: 0.8rem;
@@ -1092,16 +1164,27 @@ main {
 }
 
 .nav-btn-pause { background: #f39c12; }
-.nav-btn-pause:hover { background: #d68910; }
+.nav-btn-pause:hover:not(:disabled) { background: #d68910; }
 .nav-btn-resume { background: #27ae60; }
-.nav-btn-resume:hover { background: #219a52; }
+.nav-btn-resume:hover:not(:disabled) { background: #219a52; }
 
 .nav-btn-stop {
   background: #e74c3c;
   width: 100%;
   min-height: 40px;
 }
-.nav-btn-stop:hover { background: #c0392b; }
+.nav-btn-stop:hover:not(:disabled) { background: #c0392b; }
+
+.nav-btn-go:disabled,
+.nav-btn-run:disabled,
+.nav-btn-initialpose:disabled,
+.nav-btn-pause:disabled,
+.nav-btn-resume:disabled,
+.nav-btn-stop:disabled,
+.nav-select:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
 
 /* Mobile adjustments */
 @media (max-width: 768px) {
@@ -1135,6 +1218,46 @@ main {
 
   header h1 {
     font-size: 1rem;
+  }
+
+  #map-selector {
+    display: none;
+  }
+
+  .nav-body {
+    gap: 10px;
+    padding: 10px 12px 12px;
+  }
+
+  .nav-status {
+    font-size: 1rem;
+    padding: 6px 0;
+  }
+
+  .navigation-availability,
+  .navigation-warning {
+    font-size: 0.88rem;
+  }
+
+  .nav-control-row,
+  .nav-pause-resume-row {
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .nav-select {
+    min-height: 44px;
+    font-size: 0.95rem;
+  }
+
+  .nav-btn-go,
+  .nav-btn-run,
+  .nav-btn-initialpose,
+  .nav-btn-pause,
+  .nav-btn-resume,
+  .nav-btn-stop {
+    min-height: 44px;
+    font-size: 0.95rem;
   }
 
   .form-row {

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -11,7 +11,7 @@
   <header>
     <h1>mapoi Web UI</h1>
     <div id="map-selector">
-      <label for="map-select">Map:</label>
+      <label id="map-select-label" for="map-select">Map:</label>
       <select id="map-select"></select>
     </div>
   </header>
@@ -36,6 +36,19 @@
           <div class="nav-status">
             <span id="nav-status-dot" class="nav-status-dot nav-status-idle"></span>
             <span id="nav-status-text">Idle</span>
+          </div>
+          <div id="navigation-availability" class="navigation-availability navigation-unknown">
+            <span id="navigation-availability-dot" class="navigation-availability-dot"></span>
+            <span id="navigation-availability-text">Checking navigation</span>
+          </div>
+          <div id="navigation-warning" class="navigation-warning hidden"></div>
+          <div id="navigation-map-switch" class="navigation-map-switch">
+            <label for="navigation-map-select">Robot Map</label>
+            <div class="nav-control-row">
+              <select id="navigation-map-select" class="nav-select">
+                <option value="">-- Select Map --</option>
+              </select>
+            </div>
           </div>
           <div class="nav-control-group">
             <div class="nav-control-row">

--- a/mapoi_webui/web/js/api.js
+++ b/mapoi_webui/web/js/api.js
@@ -25,6 +25,15 @@ const MapoiApi = {
     return res.json();
   },
 
+  async navSwitchMap(mapName) {
+    const res = await fetch('/api/nav/switch-map', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ map_name: mapName }),
+    });
+    return res.json();
+  },
+
   async getPois() {
     const res = await fetch('/api/pois');
     return res.json();
@@ -111,6 +120,11 @@ const MapoiApi = {
 
   async navStatus() {
     const res = await fetch('/api/nav/status');
+    return res.json();
+  },
+
+  async mode() {
+    const res = await fetch('/api/mode');
     return res.json();
   },
 };

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -8,12 +8,18 @@
   const routeEditor = new RouteEditor();
 
   const mapSelect = document.getElementById('map-select');
+  const navigationMapSelect = document.getElementById('navigation-map-select');
   const navGoalSelect = document.getElementById('nav-goal-select');
   const navRouteSelect = document.getElementById('nav-route-select');
   const navInitialPoseSelect = document.getElementById('nav-initialpose-select');
   const navStatusDot = document.getElementById('nav-status-dot');
   const navStatusText = document.getElementById('nav-status-text');
+  const navigationAvailability = document.getElementById('navigation-availability');
+  const navigationAvailabilityText = document.getElementById('navigation-availability-text');
+  const navigationWarning = document.getElementById('navigation-warning');
+  const compactMediaQuery = window.matchMedia('(max-width: 768px)');
   let currentMap = '';
+  let currentNavigationCapabilities = null;
 
   // --- Tag editor state ---
   let tagDirty = false;
@@ -93,18 +99,27 @@
   });
 
   // --- Load maps list ---
-  async function loadMaps() {
-    const data = await MapoiApi.getMaps();
-    mapSelect.innerHTML = '';
-    data.maps.forEach((name) => {
+  function populateMapSelect(selectEl, maps, selectedMap) {
+    if (!selectEl) return;
+    selectEl.innerHTML = '';
+    maps.forEach((name) => {
       const opt = document.createElement('option');
       opt.value = name;
       opt.textContent = name;
-      if (name === data.current_map) opt.selected = true;
-      mapSelect.appendChild(opt);
+      if (name === selectedMap) opt.selected = true;
+      selectEl.appendChild(opt);
     });
+  }
+
+  async function loadMaps() {
+    const data = await MapoiApi.getMaps();
+    populateMapSelect(mapSelect, data.maps, data.current_map);
+    populateMapSelect(navigationMapSelect, data.maps, data.current_map);
     currentMap = data.current_map;
     await switchMap(currentMap, { selectBackend: false });
+    if (currentNavigationCapabilities) {
+      updateNavControlsAvailability(currentNavigationCapabilities);
+    }
   }
 
   // --- Switch map ---
@@ -117,10 +132,13 @@
       }
     }
     currentMap = mapName;
+    if (mapSelect) mapSelect.value = mapName;
+    if (navigationMapSelect) navigationMapSelect.value = mapName;
     await mapViewer.loadMap(mapName);
     await loadTagDefinitions();
     await loadPois();
     await loadRoutes();
+    refreshResponsiveLayout();
   }
 
   // --- Load tag definitions ---
@@ -187,6 +205,12 @@
       mapSelect.value = currentMap;
     });
   });
+
+  if (navigationMapSelect) {
+    navigationMapSelect.addEventListener('change', () => {
+      requestNavigationMapSwitch(navigationMapSelect.value);
+    });
+  }
 
   // --- Wire callbacks ---
 
@@ -330,6 +354,21 @@
   };
 
   // --- Section toggles ---
+  function refreshResponsiveLayout() {
+    const header = document.querySelector('header');
+    if (header) {
+      document.documentElement.style.setProperty(
+        '--header-height',
+        `${Math.ceil(header.getBoundingClientRect().height)}px`
+      );
+    }
+    window.requestAnimationFrame(() => {
+      if (mapViewer.map && typeof mapViewer.map.invalidateSize === 'function') {
+        mapViewer.map.invalidateSize();
+      }
+    });
+  }
+
   function setupSectionToggle(toggleBtnId, bodyEl, initialOpen = true) {
     const btn = document.getElementById(toggleBtnId);
     let open = initialOpen;
@@ -341,11 +380,19 @@
       open = !open;
       bodyEl.style.display = open ? '' : 'none';
       btn.innerHTML = open ? '&#9660;' : '&#9654;';
+      refreshResponsiveLayout();
     });
   }
-  setupSectionToggle('btn-route-toggle', document.getElementById('route-body'));
-  setupSectionToggle('btn-poi-toggle', document.getElementById('poi-body'));
+
+  const compactInitial = compactMediaQuery.matches;
+  setupSectionToggle('btn-route-toggle', document.getElementById('route-body'), !compactInitial);
+  setupSectionToggle('btn-poi-toggle', document.getElementById('poi-body'), !compactInitial);
   setupSectionToggle('btn-tag-toggle', document.getElementById('tag-body'), false);
+  if (typeof compactMediaQuery.addEventListener === 'function') {
+    compactMediaQuery.addEventListener('change', refreshResponsiveLayout);
+  }
+  window.addEventListener('resize', refreshResponsiveLayout);
+  refreshResponsiveLayout();
 
   // --- All / None buttons ---
   // Routes
@@ -426,6 +473,82 @@
     });
   }
 
+  function setNavigationWarning(message) {
+    if (!navigationWarning) return;
+    navigationWarning.textContent = message || '';
+    navigationWarning.classList.toggle('hidden', !message);
+    refreshResponsiveLayout();
+  }
+
+  function updateNavControlsAvailability(navigation) {
+    currentNavigationCapabilities = navigation || currentNavigationCapabilities;
+    const capabilities = currentNavigationCapabilities || {};
+    const commandAvailable = !!capabilities.command_available;
+    const switchMapAvailable = !!capabilities.switch_map_available;
+    const navigationAvailable = !!capabilities.navigation_available;
+    const navBody = document.getElementById('nav-body');
+    if (navBody) {
+      navBody.classList.toggle('navigation-unavailable-state', !navigationAvailable);
+    }
+
+    if (navigationAvailability && navigationAvailabilityText) {
+      navigationAvailability.className = 'navigation-availability '
+        + (navigationAvailable ? 'navigation-available' : 'navigation-unavailable');
+      navigationAvailabilityText.textContent = navigationAvailable
+        ? 'Navigation connected'
+        : 'Navigation unavailable';
+      const topics = capabilities.topics || {};
+      navigationAvailability.title = Object.values(topics)
+        .map((topic) => `${topic.topic}: ${topic.subscribers}`)
+        .join('\n');
+    }
+
+    [
+      document.getElementById('btn-nav-go'),
+      document.getElementById('btn-nav-run'),
+      document.getElementById('btn-nav-pause'),
+      document.getElementById('btn-nav-resume'),
+      document.getElementById('btn-nav-stop'),
+      document.getElementById('btn-nav-setpose'),
+    ].forEach((btn) => {
+      if (btn) btn.disabled = !commandAvailable;
+    });
+
+    if (navigationMapSelect) navigationMapSelect.disabled = !switchMapAvailable;
+    refreshResponsiveLayout();
+  }
+
+  function ensureNoUnsavedChangesBeforeNavigationCommand() {
+    if (!(poiEditor.dirty || routeEditor.dirty || tagDirty)) return true;
+    return confirm('Unsaved changes may be replaced by the robot map switch. Continue?');
+  }
+
+  async function requestNavigationMapSwitch(mapName) {
+    if (!mapName) return;
+    if (!ensureNoUnsavedChangesBeforeNavigationCommand()) {
+      if (navigationMapSelect) navigationMapSelect.value = currentMap;
+      if (mapSelect) mapSelect.value = currentMap;
+      return;
+    }
+    try {
+      setNavigationWarning('');
+      const result = await MapoiApi.navSwitchMap(mapName);
+      if (result.error) {
+        throw new Error(result.error);
+      }
+      if (result.warning) {
+        setNavigationWarning(result.warning);
+        if (navigationMapSelect) navigationMapSelect.value = currentMap;
+        return;
+      }
+      updateNavStatus('map_switching', mapName);
+    } catch (e) {
+      setNavigationWarning('Map switch failed: ' + e.message);
+      if (navigationMapSelect) navigationMapSelect.value = currentMap;
+      if (mapSelect) mapSelect.value = currentMap;
+    }
+  }
+
   const statusLabels = {
     idle: 'Idle',
     navigating: 'Navigating',
@@ -449,22 +572,26 @@
   }
 
   let navPollingTimer = null;
+  async function pollNavStatus() {
+    try {
+      const data = await MapoiApi.navStatus();
+      updateNavStatus(data.status, data.target);
+      updateNavControlsAvailability(data.navigation);
+      // robot_radius は launch param 由来 (#117)。古い backend では key
+      // 不在になるが setRobotRadius が型 check で no-op にする。値が来る
+      // 前に updateRobotMarker が走っても map-viewer の default 0.15 で
+      // 描画されるので safe。
+      mapViewer.setRobotRadius(data.robot_radius);
+      mapViewer.updateRobotMarker(data.robot_pose);
+    } catch (e) {
+      // ignore fetch errors
+    }
+  }
+
   function startNavStatusPolling() {
     if (navPollingTimer) return;
-    navPollingTimer = setInterval(async () => {
-      try {
-        const data = await MapoiApi.navStatus();
-        updateNavStatus(data.status, data.target);
-        // robot_radius は launch param 由来 (#117)。古い backend では key
-        // 不在になるが setRobotRadius が型 check で no-op にする。値が来る
-        // 前に updateRobotMarker が走っても map-viewer の default 0.15 で
-        // 描画されるので safe。
-        mapViewer.setRobotRadius(data.robot_radius);
-        mapViewer.updateRobotMarker(data.robot_pose);
-      } catch (e) {
-        // ignore fetch errors
-      }
-    }, 1000);
+    pollNavStatus();
+    navPollingTimer = setInterval(pollNavStatus, 1000);
   }
 
   document.getElementById('btn-nav-go').addEventListener('click', async () => {
@@ -519,7 +646,7 @@
     if (configChangedTimer) clearTimeout(configChangedTimer);
     configChangedTimer = setTimeout(() => {
       configChangedTimer = null;
-      Promise.all([loadTagDefinitions(), loadPois(), loadRoutes()])
+      loadMaps()
         .catch((err) => console.error('SSE reload failed:', err));
     }, 200);
   }


### PR DESCRIPTION
## 概要

#61 の仕様を現状の WebUI に合わせて調整し、Editor / Operator の専用画面分離ではなく、既存 WebUI 上で navigation backend の有無を検出して表示する形にしました。

- WebUI backend に `mapoi/nav/switch_map` publisher と `POST /api/nav/switch-map` を追加
- command topic の subscriber 数から navigation availability を返す `GET /api/mode` と `/api/nav/status.navigation` を追加
- 既存画面の Navigation UI に接続状態 badge と Robot Map select を追加
- Robot Map は `Switch` ボタンなしで、select 変更時に即 `mapoi/nav/switch_map` へ publish
- スマホ表示では `Navigation` を開き、`POIs` / `Tags` / `Routes` を閉じた初期状態に変更
- スマホでは header の `Map:` を隠し、地図は画面の半分程度を確保
- `Nav2 connected` 固有の文言をやめ、独自 navigation backend も想定して `Navigation connected` / `Navigation unavailable` に変更
- `mapoi_nav_server` 停止後も残り得る `mapoi/initialpose_poi` subscriber は navigation availability 判定から除外
- navigation unavailable 時は Navigation 操作 UI を非表示にし、POIs / Tags / Routes は editor 機能として使える状態を維持
- `mapoi/config_path` の SSE 受信時に map image / map selector も含めて再同期
- README に navigation 検出 / 新 endpoint / スマホ表示を追記

## 仕様判断

- Claude 作成の元仕様にあった「Editor ではナビ UI を隠す」は採用せず、現状の一体型 Editor+Navigation UI を維持しました。
- `/operator` 専用画面と header の Editor / Operator 切替は不要と判断して削除しました。
- topic 名は古い `/mapoi_switch_map` ではなく、現行実装の `mapoi/nav/switch_map` を使っています。
- frontend の追加 polling は増やさず、既存の `/api/nav/status` 1Hz polling に navigation availability を相乗りさせています。単体確認用に `/api/mode` も残しています。
- review の test gap は follow-up #199 で対応します。
- issue close はこの PR では行わず、まず `Refs #61` にしています。

## 動作確認

- `node --check mapoi_webui/web/js/app.js && node --check mapoi_webui/web/js/api.js && python3 -m py_compile mapoi_webui/mapoi_webui/mapoi_webui_node.py`
- `npm test` (`mapoi_webui/tests/web`, 41 tests passed)
- Docker: `docker compose run --rm -e ROS_DOMAIN_ID=91 dev bash -lc 'source /opt/ros/${ROS_DISTRO}/setup.bash && colcon build --symlink-install --packages-up-to mapoi_webui && colcon test --packages-up-to mapoi_webui && colcon test-result --verbose'`
  - error/warning/failure 抽出: `Summary: 52 tests, 0 errors, 0 failures, 0 skipped`

Refs #61
