### PR TITLE
fix(gazebo_bridge): operator map switch 後の AMCL drift 解消 (#91)

### DIFF
--- a/mapoi_server/include/mapoi_server/mapoi_gazebo_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_gazebo_bridge.hpp
@@ -68,11 +68,11 @@ private:
   // parameters
   std::string robot_name_;
   std::string robot_sdf_path_;
-  // /initialpose late publish parameters (#91)
+  // /initialpose late publish parameters (#91)。default は declare_parameter (cpp) 側を SSOT。
+  // delay のみ parameter 化 (環境依存: PC スペック / Gazebo spawn 速度で調整余地)。
+  // publish 回数 / 間隔は AMCL の covariance 拡散ぶれ抑制に必要な最小構成として cpp 側 constexpr で固定。
   std::string initial_pose_topic_;
-  int respawn_initialpose_delay_ms_{0};
-  int respawn_initialpose_publish_count_{0};
-  int respawn_initialpose_publish_interval_ms_{0};
+  int respawn_initialpose_delay_ms_;
 
   // state (worker thread のみが touch)
   std::string current_map_name_;

--- a/mapoi_server/include/mapoi_server/mapoi_gazebo_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_gazebo_bridge.hpp
@@ -10,6 +10,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/string.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <gazebo_msgs/srv/spawn_entity.hpp>
 #include <gazebo_msgs/srv/delete_entity.hpp>
 
@@ -57,10 +58,21 @@ private:
   bool delete_entity(const std::string & name);
   bool spawn_entity_from_uri(const std::string & name, const std::string & uri);
   bool respawn_robot(double x, double y, double yaw);
+  // Classic 固有 (#91 仮説 A): respawn_robot の delete + spawn 中に robot がシーンから一時消失 →
+  // AMCL の laser scan が新 map と不整合な過渡状態で誤った peak に収束する問題への対策。
+  // spawn 完了後に短い delay を挟んで bridge から /initialpose を late publish し、AMCL に
+  // 「正しい spawn 位置」を最後の権威として教える。gz-sim 経路 (mapoi_gz_bridge) は SetEntityPose で
+  // atomic teleport なので不要、本対策は Classic 専用。
+  void publish_initialpose_after_respawn(double x, double y, double yaw);
 
   // parameters
   std::string robot_name_;
   std::string robot_sdf_path_;
+  // /initialpose late publish parameters (#91)
+  std::string initial_pose_topic_;
+  int respawn_initialpose_delay_ms_{0};
+  int respawn_initialpose_publish_count_{0};
+  int respawn_initialpose_publish_interval_ms_{0};
 
   // state (worker thread のみが touch)
   std::string current_map_name_;
@@ -71,6 +83,9 @@ private:
   rclcpp::CallbackGroup::SharedPtr cb_group_;
   rclcpp::Client<gazebo_msgs::srv::SpawnEntity>::SharedPtr spawn_client_;
   rclcpp::Client<gazebo_msgs::srv::DeleteEntity>::SharedPtr delete_client_;
+
+  // /initialpose late publisher (#91)
+  rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr initialpose_pub_;
 
   // subscription
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr config_path_sub_;

--- a/mapoi_server/src/mapoi_gazebo_bridge.cpp
+++ b/mapoi_server/src/mapoi_gazebo_bridge.cpp
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <thread>
 
 #include "mapoi_server/initial_pose_resolver.hpp"
 #include <filesystem>
@@ -35,9 +36,27 @@ MapoiGazeboBridge::MapoiGazeboBridge()
 {
   this->declare_parameter<std::string>("robot_entity_name", "burger");
   this->declare_parameter<std::string>("robot_sdf_path", "");
+  // /initialpose late publish parameters (#91 仮説 A 対策、Classic 専用)。
+  // - delay: spawn 完了から最初の /initialpose publish までの待ち時間。Nav2 LoadMap 完了 + AMCL の
+  //   新 map 反映を待つ目的。短い delay だと AMCL の laser scan が新 map と整合する前に publish
+  //   して再 drift する事象が #91 検証で観測された (delay=300ms で過渡 drift 1-2m)。
+  // - count: publish 回数。複数回にすると AMCL が誤った peak に再収束した場合の引き戻し保険になる。
+  // - interval: count > 1 のときの publish 間隔。
+  // default 値 (1000 / 3 / 700) は #91 検証で過渡 drift 解消を確認した組み合わせ。
+  this->declare_parameter<std::string>("initial_pose_topic", "/initialpose");
+  this->declare_parameter<int>("respawn_initialpose_delay_ms", 1000);
+  this->declare_parameter<int>("respawn_initialpose_publish_count", 3);
+  this->declare_parameter<int>("respawn_initialpose_publish_interval_ms", 700);
 
   robot_name_ = this->get_parameter("robot_entity_name").as_string();
   robot_sdf_path_ = this->get_parameter("robot_sdf_path").as_string();
+  initial_pose_topic_ = this->get_parameter("initial_pose_topic").as_string();
+  respawn_initialpose_delay_ms_ =
+    this->get_parameter("respawn_initialpose_delay_ms").as_int();
+  respawn_initialpose_publish_count_ =
+    this->get_parameter("respawn_initialpose_publish_count").as_int();
+  respawn_initialpose_publish_interval_ms_ =
+    this->get_parameter("respawn_initialpose_publish_interval_ms").as_int();
 
   // Reentrant callback group + MultiThreadedExecutor で worker thread から
   // async_send_request().future.wait_for() が executor の別 thread で resolve される。
@@ -46,6 +65,13 @@ MapoiGazeboBridge::MapoiGazeboBridge()
     "spawn_entity", rmw_qos_profile_services_default, cb_group_);
   delete_client_ = this->create_client<gazebo_msgs::srv::DeleteEntity>(
     "delete_entity", rmw_qos_profile_services_default, cb_group_);
+
+  // /initialpose late publisher (#91): mapoi_nav_server::nav2_initialpose_pub_ と同 topic に
+  // bridge からも publish する。AMCL は最後に到着した /initialpose で particle を再 init するため、
+  // bridge の spawn 完了後に late publish することで「spawn 中の laser scan 不整合」による誤収束を
+  // 上書きできる。QoS は nav_server 側 publisher と同じ default (depth=1)。
+  initialpose_pub_ = this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    initial_pose_topic_, 1);
 
   auto sub_opts = rclcpp::SubscriptionOptions();
   sub_opts.callback_group = cb_group_;
@@ -288,6 +314,12 @@ bool MapoiGazeboBridge::switch_world(
   if (info.has_initial_pose) {
     if (!respawn_robot(info.initial_x, info.initial_y, info.initial_yaw)) {
       all_ok = false;
+    } else {
+      // Classic 固有 (#91 仮説 A): respawn 成功直後に /initialpose を late publish して AMCL を
+      // spawn 位置に強制的に再 init する。delete + spawn 中に AMCL が誤収束しても、最後の
+      // /initialpose で particle を spawn 位置に戻せる。gz-sim 経路は SetEntityPose で atomic
+      // teleport なので不要 (mapoi_gz_bridge には実装しない)。
+      publish_initialpose_after_respawn(info.initial_x, info.initial_y, info.initial_yaw);
     }
   } else {
     RCLCPP_WARN(this->get_logger(),
@@ -418,6 +450,48 @@ bool MapoiGazeboBridge::respawn_robot(double x, double y, double yaw)
     "respawn_robot(%s, %.2f, %.2f, yaw=%.2f): success",
     robot_name_.c_str(), x, y, yaw);
   return true;
+}
+
+
+void MapoiGazeboBridge::publish_initialpose_after_respawn(double x, double y, double yaw)
+{
+  if (respawn_initialpose_publish_count_ <= 0) {
+    return;
+  }
+
+  // delay は worker thread の sleep。ROS executor (別 thread) は spin 継続するため OK。
+  // 目的: Nav2 LoadMap 完了 + AMCL の新 map 反映を待ってから /initialpose を流すことで、
+  // 古い map に対する AMCL の誤収束を「新 map + 正しい spawn 位置」で上書きする確率を上げる。
+  if (respawn_initialpose_delay_ms_ > 0) {
+    std::this_thread::sleep_for(
+      std::chrono::milliseconds(respawn_initialpose_delay_ms_));
+  }
+
+  geometry_msgs::msg::PoseWithCovarianceStamped msg;
+  msg.header.frame_id = "map";
+  msg.pose.pose.position.x = x;
+  msg.pose.pose.position.y = y;
+  msg.pose.pose.position.z = 0.0;
+  msg.pose.pose.orientation.z = std::sin(yaw / 2.0);
+  msg.pose.pose.orientation.w = std::cos(yaw / 2.0);
+  // covariance は mapoi_nav_server::publish_initial_pose と同じ default。
+  // 0.25 (m^2, x/y) と ~0.069 (rad^2, yaw、約 ±15deg) は AMCL の典型値。
+  msg.pose.covariance[0] = 0.25;
+  msg.pose.covariance[7] = 0.25;
+  msg.pose.covariance[35] = 0.06853891945200942;
+
+  for (int i = 0; i < respawn_initialpose_publish_count_; ++i) {
+    msg.header.stamp = this->now();
+    initialpose_pub_->publish(msg);
+    RCLCPP_INFO(this->get_logger(),
+      "Published late /initialpose after respawn (%d/%d): (%.2f, %.2f, yaw=%.2f) on '%s'",
+      i + 1, respawn_initialpose_publish_count_, x, y, yaw, initial_pose_topic_.c_str());
+    if (i + 1 < respawn_initialpose_publish_count_ &&
+        respawn_initialpose_publish_interval_ms_ > 0) {
+      std::this_thread::sleep_for(
+        std::chrono::milliseconds(respawn_initialpose_publish_interval_ms_));
+    }
+  }
 }
 
 

--- a/mapoi_server/src/mapoi_gazebo_bridge.cpp
+++ b/mapoi_server/src/mapoi_gazebo_bridge.cpp
@@ -16,6 +16,7 @@
 
 #include "mapoi_server/mapoi_gazebo_bridge.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <thread>
@@ -30,6 +31,17 @@
 using namespace std::chrono_literals;
 using std::placeholders::_1;
 
+namespace
+{
+// late /initialpose の publish 回数と間隔 (#91)。AMCL は /initialpose 受信時に particle を
+// covariance ± で gaussian 再分布するため、1 回 publish 直後の数 frame は particle が σ 範囲
+// (covariance 0.25 → σ=0.5m) に散ったままで /amcl_pose が一時的に ~0.5m ずれる (検証で 47-49cm 観測)。
+// 2 回 publish (間隔 500ms) で初回ぶれを上書きすると過渡 drift が消える (検証済)。
+// 環境非依存 (AMCL covariance 仕様で決まる) のため parameter 化せず constexpr 固定。
+constexpr int kRespawnInitialposePublishCount = 2;
+constexpr int kRespawnInitialposePublishIntervalMs = 500;
+}  // namespace
+
 
 MapoiGazeboBridge::MapoiGazeboBridge()
 : Node("mapoi_gazebo_bridge")
@@ -37,26 +49,20 @@ MapoiGazeboBridge::MapoiGazeboBridge()
   this->declare_parameter<std::string>("robot_entity_name", "burger");
   this->declare_parameter<std::string>("robot_sdf_path", "");
   // /initialpose late publish parameters (#91 仮説 A 対策、Classic 専用)。
-  // - delay: spawn 完了から最初の /initialpose publish までの待ち時間。Nav2 LoadMap 完了 + AMCL の
-  //   新 map 反映を待つ目的。短い delay だと AMCL の laser scan が新 map と整合する前に publish
-  //   して再 drift する事象が #91 検証で観測された (delay=300ms で過渡 drift 1-2m)。
-  // - count: publish 回数。複数回にすると AMCL が誤った peak に再収束した場合の引き戻し保険になる。
-  // - interval: count > 1 のときの publish 間隔。
-  // default 値 (1000 / 3 / 700) は #91 検証で過渡 drift 解消を確認した組み合わせ。
+  // delay は spawn 完了から最初の /initialpose publish までの待ち時間。Nav2 LoadMap 完了 + AMCL の
+  // 新 map 反映を待つ目的。短い delay だと AMCL の laser scan が新 map と整合する前に publish
+  // して再 drift する事象が #91 検証で観測された (delay=300ms で過渡 drift 1-2m)。default 500ms。
+  // 環境依存 (PC スペック / Gazebo spawn 速度) のため parameter 化。
   this->declare_parameter<std::string>("initial_pose_topic", "/initialpose");
-  this->declare_parameter<int>("respawn_initialpose_delay_ms", 1000);
-  this->declare_parameter<int>("respawn_initialpose_publish_count", 3);
-  this->declare_parameter<int>("respawn_initialpose_publish_interval_ms", 700);
+  this->declare_parameter<int>("respawn_initialpose_delay_ms", 500);
 
   robot_name_ = this->get_parameter("robot_entity_name").as_string();
   robot_sdf_path_ = this->get_parameter("robot_sdf_path").as_string();
   initial_pose_topic_ = this->get_parameter("initial_pose_topic").as_string();
+  // 負値は std::chrono::milliseconds の符号付き duration を不用意に渡すと長時間 sleep / UB の温床
+  // になるため 0 下限クランプ。
   respawn_initialpose_delay_ms_ =
-    this->get_parameter("respawn_initialpose_delay_ms").as_int();
-  respawn_initialpose_publish_count_ =
-    this->get_parameter("respawn_initialpose_publish_count").as_int();
-  respawn_initialpose_publish_interval_ms_ =
-    this->get_parameter("respawn_initialpose_publish_interval_ms").as_int();
+    std::max(0, static_cast<int>(this->get_parameter("respawn_initialpose_delay_ms").as_int()));
 
   // Reentrant callback group + MultiThreadedExecutor で worker thread から
   // async_send_request().future.wait_for() が executor の別 thread で resolve される。
@@ -455,10 +461,6 @@ bool MapoiGazeboBridge::respawn_robot(double x, double y, double yaw)
 
 void MapoiGazeboBridge::publish_initialpose_after_respawn(double x, double y, double yaw)
 {
-  if (respawn_initialpose_publish_count_ <= 0) {
-    return;
-  }
-
   // delay は worker thread の sleep。ROS executor (別 thread) は spin 継続するため OK。
   // 目的: Nav2 LoadMap 完了 + AMCL の新 map 反映を待ってから /initialpose を流すことで、
   // 古い map に対する AMCL の誤収束を「新 map + 正しい spawn 位置」で上書きする確率を上げる。
@@ -480,16 +482,15 @@ void MapoiGazeboBridge::publish_initialpose_after_respawn(double x, double y, do
   msg.pose.covariance[7] = 0.25;
   msg.pose.covariance[35] = 0.06853891945200942;
 
-  for (int i = 0; i < respawn_initialpose_publish_count_; ++i) {
+  for (int i = 0; i < kRespawnInitialposePublishCount; ++i) {
     msg.header.stamp = this->now();
     initialpose_pub_->publish(msg);
     RCLCPP_INFO(this->get_logger(),
       "Published late /initialpose after respawn (%d/%d): (%.2f, %.2f, yaw=%.2f) on '%s'",
-      i + 1, respawn_initialpose_publish_count_, x, y, yaw, initial_pose_topic_.c_str());
-    if (i + 1 < respawn_initialpose_publish_count_ &&
-        respawn_initialpose_publish_interval_ms_ > 0) {
+      i + 1, kRespawnInitialposePublishCount, x, y, yaw, initial_pose_topic_.c_str());
+    if (i + 1 < kRespawnInitialposePublishCount) {
       std::this_thread::sleep_for(
-        std::chrono::milliseconds(respawn_initialpose_publish_interval_ms_));
+        std::chrono::milliseconds(kRespawnInitialposePublishIntervalMs));
     }
   }
 }


### PR DESCRIPTION
## 概要

operator map switch 時に Classic Gazebo + AMCL で発生していた約 0.7-1.0m の位置 drift (#91) を、`mapoi_gazebo_bridge` から `/initialpose` を late publish して解消。修正は `mapoi_gazebo_bridge.cpp` / `.hpp` のみで、Jazzy / gz-sim 経路は無触。

Close #91.

## 背景 / 仮説

issue #91 仮説 A 通り、Classic は robot teleport が **delete + spawn の 2 段階**で行われ、その間に robot がシーンから一時消失する瞬間に AMCL particle filter が新 map と不整合な laser scan で誤った peak に収束する。gz-sim は `SetEntityPose` で atomic teleport なので再現しない → 対策は Classic 経路 (`mapoi_gazebo_bridge`) に閉じる。

## 試行錯誤の経緯

`respawn_robot` 成功直後に bridge から `/initialpose` を late publish する基本方針で、delay と publish 回数を切り分けて検証:

| 試行 | delay | count | total time | 過渡 drift | 評価 |
|---|---|---|---|---|---|
| 1 | 300ms | 1 | 0.3s | **1-2m (600ms)** | ✗ |
| 2a | 1000ms | 1 | 1.0s | 47cm (400ms) | ✗ |
| 2c | 2000ms | 1 | 2.0s | 49cm (400ms) | ✗ |
| (中間) | 1000ms | 3 (interval 700) | 2.4s | なし | ✓ overkill |
| **採用** | **500ms** | **2 (interval 500)** | **1.0s** | **なし** | **✓ 最小** |
| 2b (検証のみ、不採用) | 試行 2 + `reinitialize_global_localization` | | | 同上 | ✗ コード増のみで改善なし |

### 過渡 drift の正体 (考察)

count=1 の試行 (1, 2a, 2c) で観測した 47-49cm の過渡 drift は、AMCL の `/initialpose` 受信時の **covariance 拡散ぶれ** と推測される。

- nav_server が publish する covariance と同じ `[0]=0.25, [7]=0.25` (= σ²、つまり σ=0.5m) を渡している
- AMCL は受信時に particle を pose ± covariance の gaussian で再分布
- 再分布直後の数 frame は particle が σ 範囲 (~50cm) に散ったまま、weight 計算 + resample が完了するまで `/amcl_pose` (= particle 重み付け平均) が σ 付近に振れる
- 47-49cm という drift 量が σ=0.5m とほぼ一致するのが状況証拠
- 2 回 publish で初回ぶれを上書きすると過渡 drift が消える (= 検証済の最小構成)

つまり大本の issue #91 (delete+spawn 中の laser 不整合) と、late publish 自体の副作用 (covariance 拡散) の両方を 1 つの仕掛けで抑え込んでいる構造。

## 採用案

`mapoi_gazebo_bridge` に以下を追加:

- `geometry_msgs/PoseWithCovarianceStamped` publisher を `/initialpose` 用に作成
- `respawn_robot` 成功直後に `publish_initialpose_after_respawn(x, y, yaw)` を呼ぶ
- delay → 500ms 間隔で 2 回 publish (interval は内部 constexpr 固定)
- covariance は `mapoi_nav_server::publish_initial_pose` と同じ default (x/y: 0.25, yaw: ~0.069)

### parameters

| parameter | default | 用途 |
|---|---|---|
| `initial_pose_topic` | `/initialpose` | publish 先 topic (拡張性のため parameter 化) |
| `respawn_initialpose_delay_ms` | 500 | spawn 完了から最初の publish までの待ち。**PC スペック / Gazebo spawn 速度に依存**するため parameter 化 |

### 内部 constexpr (環境非依存、parameter 化せず)

| 定数 | 値 | 根拠 |
|---|---|---|
| `kRespawnInitialposePublishCount` | 2 | AMCL covariance 拡散ぶれ (σ=0.5m) を打ち消すための最小回数 |
| `kRespawnInitialposePublishIntervalMs` | 500 | 初回 publish のぶれが収束する前に上書きできる範囲。500ms / 700ms どちらでも過渡 drift 解消を確認、AMCL 仕様に sensitive ではない |

## スコープ / 影響範囲

- 変更: `mapoi_gazebo_bridge.cpp` / `.hpp` のみ
- `mapoi_gz_bridge` (Jazzy / gz-sim 経路) は**無触** (atomic teleport なので drift 再現せず、ただし API 一貫性は別 issue で検討)
- 共通コード (`mapoi_nav_server`, `mapoi_server`, `initial_pose_resolver`) も無触
- 新規依存パッケージなし (`geometry_msgs`, `<thread>`, `<algorithm>` の include 追加のみ、いずれも既存 depend)

## Test plan

- [x] Docker (Humble + Classic Gazebo) で colcon build 成功
- [x] `turtlebot3_navigation.launch.yaml` headless 起動 + `turtlebot3_world` ↔ `turtlebot3_dqn_stage1` を複数回 operator map switch
- [x] bridge log の `Published late /initialpose after respawn (1/2) ... (2/2)` と AMCL `Setting pose` で publish 受領を確認
- [x] POI ENTER/EXIT 距離で AMCL pose と Gazebo 実位置の drift を観測 (採用設定で過渡 drift 解消を確認)
- [ ] 実機 + RViz での視覚的最終確認 (Docker headless 検証まで完了、視覚確認は未実施)

## レビュー対応 (Cursor `auto` モデル)

- medium #1 (負値パラメータ): `std::max(0, ...)` で 0 下限クランプ追加 ✓
- medium #2 (依存追加): `geometry_msgs` は既に `package.xml` に `<depend>` 済 (build 成功済)、Cursor が patch のみ参照する仕様での false positive
- medium #3 (自動テスト): タイミング依存修正で gtest unit test 化が難しく、別 follow-up issue で integration test 追加検討
- medium #4 (worker thread sleep 占有): 採用設定で total 1.0s (delay 500 + interval 500) に短縮、queue は coalesce で latest 1 件のみ保持の既存設計を維持