### PR TITLE
feat(gz_bridge): teleport 後の late /initialpose を追加 (#202)

### DIFF
--- a/mapoi_server/include/mapoi_server/mapoi_gz_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_gz_bridge.hpp
@@ -10,6 +10,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/string.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <ros_gz_interfaces/srv/spawn_entity.hpp>
 #include <ros_gz_interfaces/srv/delete_entity.hpp>
 #include <ros_gz_interfaces/srv/set_entity_pose.hpp>
@@ -58,10 +59,20 @@ private:
   bool delete_model_entity(const std::string & name);
   bool spawn_model_from_uri(const std::string & name, const std::string & uri);
   bool teleport_robot(double x, double y, double yaw);
+  // teleport 後に bridge から /initialpose を late publish する (#202、Classic 側 #91 / #200 と API 一貫)。
+  // gz-sim は SetEntityPose で atomic teleport なので Classic のような laser scan 不整合 race は無いが、
+  // AMCL の /initialpose 受信時の covariance 拡散ぶれ (σ=0.5m) は両 simulator 共通の AMCL 仕様。
+  // teleport 後の AMCL 状態を「正解 pose」で確実に上書きする preventive measure として導入。
+  // gz-sim では teleport が atomic なので delay 不要 (即時 publish)、count/interval は Classic と同じ
+  // constexpr 固定。
+  void publish_initialpose_after_teleport(double x, double y, double yaw);
 
   // parameters
   std::string robot_name_;
   std::string init_world_name_;
+  // /initialpose late publish parameters (#202)。default は declare_parameter (cpp) 側を SSOT。
+  // gz-sim では delay parameter は持たない (atomic teleport で laser scan race 無し、即時 publish で十分)。
+  std::string initial_pose_topic_;
 
   // state (worker thread のみ touch)
   std::string current_map_name_;
@@ -73,6 +84,9 @@ private:
   rclcpp::Client<ros_gz_interfaces::srv::SpawnEntity>::SharedPtr spawn_client_;
   rclcpp::Client<ros_gz_interfaces::srv::DeleteEntity>::SharedPtr delete_client_;
   rclcpp::Client<ros_gz_interfaces::srv::SetEntityPose>::SharedPtr set_pose_client_;
+
+  // /initialpose late publisher (#202、Classic 側 #200 と API 一貫)
+  rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr initialpose_pub_;
 
   // subscription
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr config_path_sub_;

--- a/mapoi_server/src/mapoi_gz_bridge.cpp
+++ b/mapoi_server/src/mapoi_gz_bridge.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <filesystem>
 #include <sstream>
+#include <thread>
 
 #include <yaml-cpp/yaml.h>
 #include <ros_gz_interfaces/msg/entity.hpp>
@@ -34,15 +35,30 @@
 using namespace std::chrono_literals;
 using std::placeholders::_1;
 
+namespace
+{
+// late /initialpose の publish 回数と間隔 (#202、Classic 側 #200 と同値)。AMCL は /initialpose 受信時に
+// particle を covariance ± で gaussian 再分布するため (covariance 0.25 → σ=0.5m)、1 回 publish 後の
+// 数 frame は particle が σ 範囲に散ったままで /amcl_pose が一時的にずれる。2 回 publish (間隔 500ms) で
+// 初回ぶれを上書きすると過渡 drift が消える。環境非依存 (AMCL covariance 仕様で決まる) のため constexpr 固定。
+// gz-sim では teleport が atomic なので Classic のような delay は不要 (即時 publish)。
+constexpr int kTeleportInitialposePublishCount = 2;
+constexpr int kTeleportInitialposePublishIntervalMs = 500;
+}  // namespace
+
 
 MapoiGzBridge::MapoiGzBridge()
 : Node("mapoi_gz_bridge")
 {
   this->declare_parameter<std::string>("robot_entity_name", "burger");
   this->declare_parameter<std::string>("init_world_name", "default");
+  // /initialpose late publish 用 topic (#202、Classic 側 #200 と API 一貫)。
+  // gz-sim では delay parameter は持たない (atomic teleport で laser scan race 無し)。
+  this->declare_parameter<std::string>("initial_pose_topic", "/initialpose");
 
   robot_name_ = this->get_parameter("robot_entity_name").as_string();
   init_world_name_ = this->get_parameter("init_world_name").as_string();
+  initial_pose_topic_ = this->get_parameter("initial_pose_topic").as_string();
 
   // gz-sim native service 名 (parameter_bridge で同名 ROS 2 service として bridge される想定)
   const std::string spawn_srv = "/world/" + init_world_name_ + "/create";
@@ -60,6 +76,11 @@ MapoiGzBridge::MapoiGzBridge()
     remove_srv, rclcpp::ServicesQoS(), cb_group_);
   set_pose_client_ = this->create_client<ros_gz_interfaces::srv::SetEntityPose>(
     set_pose_srv, rclcpp::ServicesQoS(), cb_group_);
+
+  // /initialpose late publisher (#202): teleport 後に AMCL を spawn pose で再 init する。
+  // QoS は mapoi_nav_server::nav2_initialpose_pub_ と同じ default (depth=1)。
+  initialpose_pub_ = this->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    initial_pose_topic_, 1);
 
   auto sub_opts = rclcpp::SubscriptionOptions();
   sub_opts.callback_group = cb_group_;
@@ -301,6 +322,11 @@ bool MapoiGzBridge::switch_world(
   if (info.has_initial_pose) {
     if (!teleport_robot(info.initial_x, info.initial_y, info.initial_yaw)) {
       all_ok = false;
+    } else {
+      // teleport 成功直後に /initialpose を late publish (#202、Classic 側 #200 と API 一貫)。
+      // gz-sim は atomic teleport なので delay 不要、即時 publish。AMCL covariance 拡散ぶれ抑制
+      // のため複数回 publish は Classic と同じ。
+      publish_initialpose_after_teleport(info.initial_x, info.initial_y, info.initial_yaw);
     }
   } else {
     RCLCPP_WARN(this->get_logger(),
@@ -406,6 +432,35 @@ bool MapoiGzBridge::teleport_robot(double x, double y, double yaw)
     "teleport_robot(%s, %.2f, %.2f, yaw=%.2f): success",
     robot_name_.c_str(), x, y, yaw);
   return true;
+}
+
+
+void MapoiGzBridge::publish_initialpose_after_teleport(double x, double y, double yaw)
+{
+  geometry_msgs::msg::PoseWithCovarianceStamped msg;
+  msg.header.frame_id = "map";
+  msg.pose.pose.position.x = x;
+  msg.pose.pose.position.y = y;
+  msg.pose.pose.position.z = 0.0;
+  msg.pose.pose.orientation.z = std::sin(yaw / 2.0);
+  msg.pose.pose.orientation.w = std::cos(yaw / 2.0);
+  // covariance は mapoi_nav_server::publish_initial_pose と同じ default。
+  // 0.25 (m^2, x/y) と ~0.069 (rad^2, yaw、約 ±15deg) は AMCL の典型値。
+  msg.pose.covariance[0] = 0.25;
+  msg.pose.covariance[7] = 0.25;
+  msg.pose.covariance[35] = 0.06853891945200942;
+
+  for (int i = 0; i < kTeleportInitialposePublishCount; ++i) {
+    msg.header.stamp = this->now();
+    initialpose_pub_->publish(msg);
+    RCLCPP_INFO(this->get_logger(),
+      "Published late /initialpose after teleport (%d/%d): (%.2f, %.2f, yaw=%.2f) on '%s'",
+      i + 1, kTeleportInitialposePublishCount, x, y, yaw, initial_pose_topic_.c_str());
+    if (i + 1 < kTeleportInitialposePublishCount) {
+      std::this_thread::sleep_for(
+        std::chrono::milliseconds(kTeleportInitialposePublishIntervalMs));
+    }
+  }
 }
 
 


### PR DESCRIPTION
## 概要

`mapoi_gz_bridge` (Jazzy/gz-sim) に teleport_robot 成功後の `/initialpose` late publish 機能を追加し、Classic 側 (`mapoi_gazebo_bridge` / PR #200) と API を一貫化する。

Close #202.

## 背景

PR #200 で Classic 側に late /initialpose を入れた経緯から、両 bridge の API が非対称になっていた:

| | Classic (`mapoi_gazebo_bridge`) | gz-sim (`mapoi_gz_bridge`) |
|---|---|---|
| late /initialpose | ✓ #200 で追加 | ✗ なし |
| 動機 | delete+spawn race + AMCL covariance 拡散ぶれ | (atomic teleport で race 無し → drift 観測されず) |

issue #202 のとおり、AMCL covariance 拡散ぶれ (σ=0.5m) は両 simulator 共通の AMCL 仕様で、operator が気づきにくいレベルでも publish 後 1 frame は particle が散る。preventive measure として gz_bridge にも同等の仕掛けを入れることで:

- 両 bridge の使用感 / parameter 構造を揃える
- 将来 gz-sim でも switch 直後の細かいぶれが顕在化したときに対処済の状態にする

## 採用案

`mapoi_gz_bridge.cpp` / `.hpp` に追加:

- `geometry_msgs/PoseWithCovarianceStamped` publisher (`/initialpose`)
- `teleport_robot` 成功後に `publish_initialpose_after_teleport(x, y, yaw)` を呼ぶ
- 500ms 間隔で 2 回 publish (covariance 0.25 拡散ぶれ抑制)
- covariance は `mapoi_nav_server::publish_initial_pose` と同じ default

### parameters

| parameter | default | 用途 |
|---|---|---|
| `initial_pose_topic` | `/initialpose` | publish 先 topic (Classic 側 #200 と同名) |

### 内部 constexpr (Classic と同値)

| 定数 | 値 |
|---|---|
| `kTeleportInitialposePublishCount` | 2 |
| `kTeleportInitialposePublishIntervalMs` | 500 |

### Classic との差分

Classic の `respawn_initialpose_delay_ms` parameter は **gz_bridge では追加しない**:
- gz-sim は `SetEntityPose` で atomic teleport、Classic のような delete+spawn race が無い
- teleport 直後の laser scan が新 map と整合済 → delay 不要 (即時 publish)

## スコープ / 影響範囲

- 変更: `mapoi_gz_bridge.cpp` / `.hpp` のみ
- `mapoi_gazebo_bridge` (Classic、#200 で対応済) は無触
- 新規依存パッケージなし (`geometry_msgs`, `<thread>` の include 追加のみ、いずれも既存 depend)

## Test plan

- [x] Docker (Jazzy + gz-sim) で colcon build 成功 (全 5 packages)
- [x] `turtlebot3_navigation.launch.yaml` headless 起動 + `turtlebot3_world` → `turtlebot3_dqn_stage1` operator map switch
- [x] bridge log で以下を確認:
  - `mapoi_gz_bridge initialized`
  - `teleport_robot(burger, 0.00, 0.00, yaw=0.00): success`
  - `Published late /initialpose after teleport (1/2): (0.00, 0.00, yaw=0.00) on '/initialpose'`
  - `Published late /initialpose after teleport (2/2): (0.00, 0.00, yaw=0.00) on '/initialpose'`
- [ ] 実機 + RViz での視覚的最終確認 (Docker headless 検証まで完了)