### PR TITLE
feat(backend_status): liveliness QoS による publisher staleness 検出 (Close #208)

### DIFF
--- a/mapoi_interfaces/msg/LocalizationBackendStatus.msg
+++ b/mapoi_interfaces/msg/LocalizationBackendStatus.msg
@@ -16,11 +16,12 @@
 #   durability               : TRANSIENT_LOCAL
 #   reliability              : RELIABLE
 #   liveliness (publisher)   : MANUAL_BY_TOPIC
-#   liveliness (subscriber)  : AUTOMATIC        (legacy publisher compat)
-#   liveliness_lease_duration: 5 s
+#   liveliness (subscriber)  : AUTOMATIC
+#   liveliness_lease_duration: 5 s              (BOTH sides; contract violators are
+#                                                intentionally rejected via QoS incompatibility)
 # Subscribers detect bridge death by handling the Liveliness Changed event
 # (alive_count transitions to 0). See NavigationBackendStatus.msg for the full
-# rationale and the link to follow-up issue #213.
+# rationale, contract-violation behaviour, and the link to follow-up issue #213.
 
 # Bridge identifier shown in tooltips (e.g. "amcl", "slam_toolbox", "custom_lidar_amcl").
 # Free-form, only used to help operators distinguish multiple bridges.

--- a/mapoi_interfaces/msg/LocalizationBackendStatus.msg
+++ b/mapoi_interfaces/msg/LocalizationBackendStatus.msg
@@ -15,10 +15,12 @@
 # QoS contract (issue #208): same as NavigationBackendStatus —
 #   durability               : TRANSIENT_LOCAL
 #   reliability              : RELIABLE
-#   liveliness               : MANUAL_BY_TOPIC
-#   liveliness_lease_duration: 3 s
+#   liveliness (publisher)   : MANUAL_BY_TOPIC
+#   liveliness (subscriber)  : AUTOMATIC        (legacy publisher compat)
+#   liveliness_lease_duration: 5 s
 # Subscribers detect bridge death by handling the Liveliness Changed event
-# (alive_count transitions to 0).
+# (alive_count transitions to 0). See NavigationBackendStatus.msg for the full
+# rationale and the link to follow-up issue #213.
 
 # Bridge identifier shown in tooltips (e.g. "amcl", "slam_toolbox", "custom_lidar_amcl").
 # Free-form, only used to help operators distinguish multiple bridges.

--- a/mapoi_interfaces/msg/LocalizationBackendStatus.msg
+++ b/mapoi_interfaces/msg/LocalizationBackendStatus.msg
@@ -17,8 +17,8 @@
 #   reliability              : RELIABLE
 #   liveliness (publisher)   : MANUAL_BY_TOPIC
 #   liveliness (subscriber)  : AUTOMATIC
-#   liveliness_lease_duration: 5 s              (BOTH sides; contract violators are
-#                                                intentionally rejected via QoS incompatibility)
+#   liveliness_lease_duration: 5 s              (BOTH sides; publishers with infinite lease
+#                                                are rejected via QoS incompatibility)
 # Subscribers detect bridge death by handling the Liveliness Changed event
 # (alive_count transitions to 0). See NavigationBackendStatus.msg for the full
 # rationale, contract-violation behaviour, and the link to follow-up issue #213.

--- a/mapoi_interfaces/msg/LocalizationBackendStatus.msg
+++ b/mapoi_interfaces/msg/LocalizationBackendStatus.msg
@@ -1,7 +1,7 @@
 # Minimal localization backend readiness, published 1 Hz on
-# `mapoi/localization/backend_status` (transient_local) by localization
-# bridges such as `mapoi_amcl_localization_bridge` (AMCL adapter) or any
-# custom bridge for slam_toolbox / NDT / 自前 localization 等。
+# `mapoi/localization/backend_status` by localization bridges such as
+# `mapoi_amcl_localization_bridge` (AMCL adapter) or any custom bridge for
+# slam_toolbox / NDT / 自前 localization 等。
 #
 # Custom bridges only need to populate these three fields. UI consumers
 # (mapoi_webui, mapoi_rviz_plugins) gate the Initial Pose UI on
@@ -11,6 +11,14 @@
 # Navigation readiness (Nav2 action / select_map service 等) は別契約
 # (`NavigationBackendStatus`、issue #198 / PR #205) で扱う。両者は独立した軸で、
 # WebUI / panel もそれぞれ別 indicator として表示する。
+#
+# QoS contract (issue #208): same as NavigationBackendStatus —
+#   durability               : TRANSIENT_LOCAL
+#   reliability              : RELIABLE
+#   liveliness               : MANUAL_BY_TOPIC
+#   liveliness_lease_duration: 3 s
+# Subscribers detect bridge death by handling the Liveliness Changed event
+# (alive_count transitions to 0).
 
 # Bridge identifier shown in tooltips (e.g. "amcl", "slam_toolbox", "custom_lidar_amcl").
 # Free-form, only used to help operators distinguish multiple bridges.

--- a/mapoi_interfaces/msg/NavigationBackendStatus.msg
+++ b/mapoi_interfaces/msg/NavigationBackendStatus.msg
@@ -23,13 +23,15 @@
 #   liveliness_lease_duration: 5 s              (the QoS rule `pub.lease <= sub.lease` MUST hold;
 #                                                we enforce 5 s on both sides for simplicity)
 #
-# Contract violations are intentionally rejected by QoS incompatibility:
-#   - publisher with no liveliness QoS (= infinite lease) → connection refused by subscribers
-#     (sub.lease=5s < pub.lease=inf)
-#   - publisher with liveliness=AUTOMATIC → connection refused (pub policy < sub policy)
-# This means custom bridges MUST follow this contract to interoperate with mapoi UI consumers
-# (mapoi_webui, mapoi_rviz_plugins). See test_backend_status_liveliness.py for the
-# incompatibility tests that pin this behaviour.
+# Contract violations rejected by QoS incompatibility:
+#   - publisher with no liveliness QoS (= infinite lease) → connection refused by subscribers,
+#     because the QoS rule sub.lease (5 s) >= pub.lease (∞) cannot be satisfied.
+# Note: a publisher using `liveliness=AUTOMATIC` with lease <= 5 s is technically QoS-compatible
+# with our `AUTOMATIC` subscribers, but its staleness detection is weaker (Node-level liveness:
+# any publisher in the same node keeps the topic "alive"). Bridges SHOULD use MANUAL_BY_TOPIC
+# so that backend_status timer freeze is detected even when the node has other publishers.
+# See test_backend_status_liveliness.py for the incompatibility tests that pin the
+# infinite-lease rejection.
 #
 # UI gating: subscribers MUST treat a lost-liveliness state as `backend_ready=false`
 # regardless of the latched payload (see `_resolve_backend_status_for_ui` in mapoi_webui).

--- a/mapoi_interfaces/msg/NavigationBackendStatus.msg
+++ b/mapoi_interfaces/msg/NavigationBackendStatus.msg
@@ -14,12 +14,21 @@
 # QoS contract (issue #208):
 #   durability               : TRANSIENT_LOCAL  (late-joiner UI receives the latest status)
 #   reliability              : RELIABLE
-#   liveliness               : MANUAL_BY_TOPIC  (each publish() asserts liveliness on this topic)
-#   liveliness_lease_duration: 3 s              (publishers MUST publish at least every 3 s;
-#                                                subscribers MUST set lease_duration >= 3 s)
+#   liveliness (publisher)   : MANUAL_BY_TOPIC  (each publish() asserts liveliness on this topic)
+#   liveliness (subscriber)  : AUTOMATIC        (compatibility with legacy publishers; see
+#                                                ROS 2 QoS compatibility table)
+#   liveliness_lease_duration: 5 s              (publishers MUST publish at least every 5 s;
+#                                                subscribers MUST set lease_duration >= 5 s)
 # Subscribers detect bridge death by handling the Liveliness Changed event
 # (alive_count transitions to 0). UI gating MUST treat a lost-liveliness
 # state as `backend_ready=false` regardless of the latched payload.
+#
+# NOTE (issue #213): the lease must exceed any blocking call inside the publisher
+# node's executor. mapoi_nav_server's `select_map` flow can block the
+# SingleThreadedExecutor for up to ~11 s per Nav2 map node during `send_load_map_request`,
+# which can trigger false-positive liveliness lost events even at 5 s lease.
+# Issue #213 tracks splitting backend_status_timer into a Reentrant callback group
+# + MultiThreadedExecutor so the timer keeps publishing during such blocking calls.
 
 # Bridge identifier shown in tooltips (e.g. "nav2", "custom_lidar_planner").
 # Free-form, only used to help operators distinguish multiple bridges.

--- a/mapoi_interfaces/msg/NavigationBackendStatus.msg
+++ b/mapoi_interfaces/msg/NavigationBackendStatus.msg
@@ -11,17 +11,28 @@
 # part of this contract; it will be exposed by a separate
 # `LocalizationBackendStatus` topic — see issue #209.
 #
-# QoS contract (issue #208):
+# QoS contract (issue #208) — BOTH publishers and subscribers MUST set these:
 #   durability               : TRANSIENT_LOCAL  (late-joiner UI receives the latest status)
 #   reliability              : RELIABLE
-#   liveliness (publisher)   : MANUAL_BY_TOPIC  (each publish() asserts liveliness on this topic)
-#   liveliness (subscriber)  : AUTOMATIC        (compatibility with legacy publishers; see
-#                                                ROS 2 QoS compatibility table)
-#   liveliness_lease_duration: 5 s              (publishers MUST publish at least every 5 s;
-#                                                subscribers MUST set lease_duration >= 5 s)
-# Subscribers detect bridge death by handling the Liveliness Changed event
-# (alive_count transitions to 0). UI gating MUST treat a lost-liveliness
-# state as `backend_ready=false` regardless of the latched payload.
+#   liveliness (publisher)   : MANUAL_BY_TOPIC  (each publish() asserts liveliness on this
+#                                                topic; subscribers handle Liveliness Changed
+#                                                events to detect publisher death)
+#   liveliness (subscriber)  : AUTOMATIC        (pub=MANUAL_BY_TOPIC × sub=AUTOMATIC is the
+#                                                only compatible policy combination given that
+#                                                pub=AUTOMATIC × sub=MANUAL_BY_TOPIC is incompatible)
+#   liveliness_lease_duration: 5 s              (the QoS rule `pub.lease <= sub.lease` MUST hold;
+#                                                we enforce 5 s on both sides for simplicity)
+#
+# Contract violations are intentionally rejected by QoS incompatibility:
+#   - publisher with no liveliness QoS (= infinite lease) → connection refused by subscribers
+#     (sub.lease=5s < pub.lease=inf)
+#   - publisher with liveliness=AUTOMATIC → connection refused (pub policy < sub policy)
+# This means custom bridges MUST follow this contract to interoperate with mapoi UI consumers
+# (mapoi_webui, mapoi_rviz_plugins). See test_backend_status_liveliness.py for the
+# incompatibility tests that pin this behaviour.
+#
+# UI gating: subscribers MUST treat a lost-liveliness state as `backend_ready=false`
+# regardless of the latched payload (see `_resolve_backend_status_for_ui` in mapoi_webui).
 #
 # NOTE (issue #213): the lease must exceed any blocking call inside the publisher
 # node's executor. mapoi_nav_server's `select_map` flow can block the

--- a/mapoi_interfaces/msg/NavigationBackendStatus.msg
+++ b/mapoi_interfaces/msg/NavigationBackendStatus.msg
@@ -1,6 +1,6 @@
 # Minimal navigation backend readiness, published 1 Hz on
-# `mapoi/nav/backend_status` (transient_local) by navigation bridges
-# such as `mapoi_nav_server` (Nav2 bridge) or any custom bridge.
+# `mapoi/nav/backend_status` by navigation bridges such as
+# `mapoi_nav_server` (Nav2 bridge) or any custom bridge.
 #
 # Custom bridges only need to populate these three fields. UI consumers
 # (mapoi_webui, mapoi_rviz_plugins) gate navigation operations on
@@ -10,6 +10,16 @@
 # Localization readiness (initial pose / AMCL etc.) is intentionally NOT
 # part of this contract; it will be exposed by a separate
 # `LocalizationBackendStatus` topic — see issue #209.
+#
+# QoS contract (issue #208):
+#   durability               : TRANSIENT_LOCAL  (late-joiner UI receives the latest status)
+#   reliability              : RELIABLE
+#   liveliness               : MANUAL_BY_TOPIC  (each publish() asserts liveliness on this topic)
+#   liveliness_lease_duration: 3 s              (publishers MUST publish at least every 3 s;
+#                                                subscribers MUST set lease_duration >= 3 s)
+# Subscribers detect bridge death by handling the Liveliness Changed event
+# (alive_count transitions to 0). UI gating MUST treat a lost-liveliness
+# state as `backend_ready=false` regardless of the latched payload.
 
 # Bridge identifier shown in tooltips (e.g. "nav2", "custom_lidar_planner").
 # Free-form, only used to help operators distinguish multiple bridges.

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
@@ -98,10 +98,13 @@ protected:
   // backend_status 不在 (旧 nav_server / editor 構成) では callback が呼ばれず、初期値
   // (true = enable) のままで後方互換を保つ。Minimal contract なので per-capability gate は持たない。
   bool last_navigation_backend_ready_ {true};
-  // 一度でも navigation backend_status を受信したか。staleness 検出 (#209 review) は受信実績
-  // ありの publisher の死亡だけを「unavailable」に倒すために使う。受信実績なし = contract 未実装
-  // 構成 (旧 nav_server / editor) なので enable のままにする。
+  // 一度でも navigation backend_status を受信したか。受信実績なし = contract 未実装の旧 nav_server
+  // / editor 構成として enable のまま (後方互換)。受信実績ありの publisher が liveliness lost
+  // (= bridge 死亡) した場合のみ disable に倒す。
   bool nav_backend_status_received_ {false};
+  // MANUAL_BY_TOPIC liveliness (#208) で publisher 生存を track。subscription event_callback
+  // が `alive_count > 0` で更新する。`*_received_` と AND して、未受信は alive 判定をバイパス。
+  bool nav_backend_alive_ {false};
 
   // Localization backend readiness subscribe (#209): mapoi_amcl_localization_bridge (or any
   // custom localization bridge) が publish する readiness で LocalizationButton を gate する。
@@ -113,15 +116,9 @@ protected:
     mapoi_interfaces::msg::LocalizationBackendStatus::SharedPtr msg);
   bool last_localization_backend_ready_ {true};
   bool localization_backend_status_received_ {false};
+  bool localization_backend_alive_ {false};
 
-  // bridge プロセスが死亡しても transient_local の cache は古い値を保持し続けるため、
-  // 1Hz polling で publisher 数を確認して staleness を検出する (#209 review、#208 軽量代替)。
-  // 「一度でも受信した topic の publisher が消えた」場合だけ ready=false に倒し、未受信 (= 契約未実装)
-  // は触らない (enable のまま) 方針。
-  rclcpp::TimerBase::SharedPtr backend_staleness_timer_;
-  void BackendStalenessTick();
-
-  // navigation_ready / localization_ready の最新値を保持し、両 callback と staleness timer で
+  // navigation_ready / localization_ready の最新値を保持し、両 callback / liveliness event から
   // 共通の UpdateNavButtonsEnabled を呼び出す。LocalizationButton は localization、それ以外の
   // navigation 操作 UI は navigation で gate する (#209 で 2 軸に分離)。
   void UpdateNavButtonsEnabled();

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -93,26 +93,42 @@ void MapoiPanel::onInitialize()
       "mapoi/nav/status", rclcpp::QoS(1).transient_local(),
       std::bind(&MapoiPanel::NavStatusCallback, this, std::placeholders::_1));
 
-  // Navigation backend readiness (#198 review medium): bridge が publish する readiness で
-  // ボタンを gate する。受信前 (古い nav_server / panel 単独起動) は全 enable のまま。
-  backend_status_sub_ = node_->create_subscription<mapoi_interfaces::msg::NavigationBackendStatus>(
-      "mapoi/nav/backend_status", rclcpp::QoS(1).transient_local(),
-      std::bind(&MapoiPanel::BackendStatusCallback, this, std::placeholders::_1));
+  // Navigation / Localization backend readiness (#198, #209) の QoS は msg contract (#208)
+  // に従う: transient_local + MANUAL_BY_TOPIC liveliness + 3s lease。subscription
+  // event_callbacks.liveliness_callback で publisher 生存を track し、bridge 死亡時に
+  // staleness を反映する。受信前 (古い nav_server / panel 単独起動) は alive 判定をバイパス
+  // して全 enable のまま (`*_status_received_` flag を AND することで実現)。
+  const auto backend_status_qos = rclcpp::QoS(1)
+    .transient_local()
+    .liveliness(rclcpp::LivelinessPolicy::ManualByTopic)
+    .liveliness_lease_duration(std::chrono::seconds(3));
 
-  // Localization backend readiness (#209): localization bridge が publish する readiness で
-  // LocalizationButton を gate する。Navigation 軸とは独立。受信前 (bridge 不在 / editor 構成)
-  // は全 enable のまま (BackendStatusCallback と同じフォールバック方針)。
+  rclcpp::SubscriptionOptions nav_sub_opts;
+  nav_sub_opts.event_callbacks.liveliness_callback =
+    [this](rclcpp::QOSLivelinessChangedInfo & event) {
+      nav_backend_alive_ = event.alive_count > 0;
+      QMetaObject::invokeMethod(this, [this]() {
+        UpdateNavButtonsEnabled();
+      }, Qt::QueuedConnection);
+    };
+  backend_status_sub_ = node_->create_subscription<mapoi_interfaces::msg::NavigationBackendStatus>(
+      "mapoi/nav/backend_status", backend_status_qos,
+      std::bind(&MapoiPanel::BackendStatusCallback, this, std::placeholders::_1),
+      nav_sub_opts);
+
+  rclcpp::SubscriptionOptions loc_sub_opts;
+  loc_sub_opts.event_callbacks.liveliness_callback =
+    [this](rclcpp::QOSLivelinessChangedInfo & event) {
+      localization_backend_alive_ = event.alive_count > 0;
+      QMetaObject::invokeMethod(this, [this]() {
+        UpdateNavButtonsEnabled();
+      }, Qt::QueuedConnection);
+    };
   localization_backend_status_sub_ = node_->create_subscription<
     mapoi_interfaces::msg::LocalizationBackendStatus>(
-      "mapoi/localization/backend_status", rclcpp::QoS(1).transient_local(),
-      std::bind(&MapoiPanel::LocalizationBackendStatusCallback, this, std::placeholders::_1));
-
-  // Bridge プロセス死亡時の staleness 検出 (#209 review、#208 軽量代替)。
-  // transient_local の cache は callback が呼ばれない限り古い値を保持し続けるため、
-  // 1Hz で publisher 数を polling し、0 のときは ready=false 相当に倒す。
-  backend_staleness_timer_ = node_->create_wall_timer(
-    std::chrono::seconds(1),
-    std::bind(&MapoiPanel::BackendStalenessTick, this));
+      "mapoi/localization/backend_status", backend_status_qos,
+      std::bind(&MapoiPanel::LocalizationBackendStatusCallback, this, std::placeholders::_1),
+      loc_sub_opts);
 
   current_nav_mode_ = "idle";
 
@@ -487,51 +503,32 @@ void MapoiPanel::LocalizationBackendStatusCallback(
   }, Qt::QueuedConnection);
 }
 
-void MapoiPanel::BackendStalenessTick()
-{
-  // bridge プロセス死亡時の staleness 検出 (#209 review、#208 軽量代替)。
-  // publisher 数 = 0 を検知したら、cache された ready=true を強制的に false に倒す
-  // (callback は呼ばれないので last_*_backend_ready_ を上書きする必要がある)。
-  // publisher が再び現れて新しい ready 値を送ってくれば、その callback で last_* が上書きされる。
-  // 重要 (review fix): `*_received_` flag が false の間は何もしない。これは「contract 未実装の
-  // 旧 nav_server / editor 構成」では publisher 数が常に 0 でも UI を disable しない、という
-  // 後方互換の保証。一度でも status を受け取った publisher の死亡だけを staleness として扱う。
-  bool changed = false;
-  if (nav_backend_status_received_ &&
-      node_->count_publishers("mapoi/nav/backend_status") == 0 &&
-      last_navigation_backend_ready_) {
-    last_navigation_backend_ready_ = false;
-    changed = true;
-  }
-  if (localization_backend_status_received_ &&
-      node_->count_publishers("mapoi/localization/backend_status") == 0 &&
-      last_localization_backend_ready_) {
-    last_localization_backend_ready_ = false;
-    changed = true;
-  }
-  if (changed) {
-    QMetaObject::invokeMethod(this, [this]() {
-      UpdateNavButtonsEnabled();
-    }, Qt::QueuedConnection);
-  }
-}
-
 void MapoiPanel::UpdateNavButtonsEnabled()
 {
   // Qt main thread で呼ぶこと (BackendStatusCallback / LocalizationBackendStatusCallback /
-  // BackendStalenessTick から QueuedConnection 経由で invoke される)。
+  // liveliness event_callback から QueuedConnection 経由で invoke される)。
   // 2 軸の minimal 仕様 (#209): navigation 操作 UI と MapComboBox は navigation backend、
   // LocalizationButton は localization backend で gate する。MapComboBox は Nav2 LoadMap +
   // AMCL initial pose の両方を必要とするが、Nav2 LoadMap が走らないと localization 側に意味のある
   // initial pose を送れないので最低限 navigation_ready を要求する。両方を AND する厳格化は
   // future work で UX 検討する。
-  ui_->LocalizationButton->setEnabled(last_localization_backend_ready_);
-  ui_->RunGoalButton->setEnabled(last_navigation_backend_ready_);
-  ui_->RunRouteButton->setEnabled(last_navigation_backend_ready_);
-  ui_->PauseButton->setEnabled(last_navigation_backend_ready_);
-  ui_->ResumeButton->setEnabled(last_navigation_backend_ready_);
-  ui_->StopButton->setEnabled(last_navigation_backend_ready_);
-  ui_->MapComboBox->setEnabled(last_navigation_backend_ready_);
+  // Staleness gating (#208): 受信前 (`*_received_` false) は alive 判定をバイパスして
+  // `last_*_backend_ready_` の初期値 (true) を使う = 旧 nav_server / panel 単独起動の後方互換。
+  // 受信後は MANUAL_BY_TOPIC liveliness で得た `*_alive_` flag と AND し、bridge 死亡時に
+  // 自動 disable する。
+  const bool nav_ready = nav_backend_status_received_
+    ? (last_navigation_backend_ready_ && nav_backend_alive_)
+    : last_navigation_backend_ready_;
+  const bool loc_ready = localization_backend_status_received_
+    ? (last_localization_backend_ready_ && localization_backend_alive_)
+    : last_localization_backend_ready_;
+  ui_->LocalizationButton->setEnabled(loc_ready);
+  ui_->RunGoalButton->setEnabled(nav_ready);
+  ui_->RunRouteButton->setEnabled(nav_ready);
+  ui_->PauseButton->setEnabled(nav_ready);
+  ui_->ResumeButton->setEnabled(nav_ready);
+  ui_->StopButton->setEnabled(nav_ready);
+  ui_->MapComboBox->setEnabled(nav_ready);
 }
 
 void MapoiPanel::PublishHighlightPois()

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -94,13 +94,15 @@ void MapoiPanel::onInitialize()
       std::bind(&MapoiPanel::NavStatusCallback, this, std::placeholders::_1));
 
   // Navigation / Localization backend readiness (#198, #209) の QoS は msg contract (#208)
-  // に従う: publisher 側は transient_local + MANUAL_BY_TOPIC liveliness (publish が assert を
-  // 兼ねる) + 3s lease。subscriber 側は AUTOMATIC で受ける (#212 codex review medium):
-  // pub=AUTOMATIC × sub=MANUAL_BY_TOPIC は QoS compatibility 表で incompatible (旧 publisher
-  // との接続性が壊れる回帰)。pub=MANUAL_BY_TOPIC × sub=AUTOMATIC は compatible で、subscription
-  // event_callbacks.liveliness_callback で publisher 生存を track できる。受信前 (古い
-  // nav_server / panel 単独起動) は alive 判定をバイパスして全 enable のまま
-  // (`*_status_received_` flag を AND することで実現)。
+  // に従う: transient_local + liveliness (publisher=MANUAL_BY_TOPIC, subscriber=AUTOMATIC)
+  // + lease 5s (両側必須)。subscriber 側 policy を AUTOMATIC にするのは pub=MANUAL_BY_TOPIC
+  // × sub=AUTOMATIC が compatibility 表上 OK だから。lease は `pub.lease <= sub.lease` 制約が
+  // あり、両側 5s で揃えるのが運用上シンプル。
+  // **msg contract に従わない publisher (例: liveliness QoS 未設定 = lease infinite) は
+  // 意図的に QoS incompatible で接続を拒否する**。custom bridge 実装者は msg README の
+  // contract 表に従う必要がある (test_backend_status_liveliness.py で incompatibility を pin)。
+  // 受信前 (`*_status_received_` flag = false、つまり contract 未実装の旧 publisher も含む) は
+  // alive 判定をバイパスして全 enable のまま (UpdateNavButtonsEnabled 内で実現)。
   const auto backend_status_qos = rclcpp::QoS(1)
     .transient_local()
     .liveliness(rclcpp::LivelinessPolicy::Automatic)

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -94,14 +94,17 @@ void MapoiPanel::onInitialize()
       std::bind(&MapoiPanel::NavStatusCallback, this, std::placeholders::_1));
 
   // Navigation / Localization backend readiness (#198, #209) の QoS は msg contract (#208)
-  // に従う: transient_local + MANUAL_BY_TOPIC liveliness + 3s lease。subscription
-  // event_callbacks.liveliness_callback で publisher 生存を track し、bridge 死亡時に
-  // staleness を反映する。受信前 (古い nav_server / panel 単独起動) は alive 判定をバイパス
-  // して全 enable のまま (`*_status_received_` flag を AND することで実現)。
+  // に従う: publisher 側は transient_local + MANUAL_BY_TOPIC liveliness (publish が assert を
+  // 兼ねる) + 3s lease。subscriber 側は AUTOMATIC で受ける (#212 codex review medium):
+  // pub=AUTOMATIC × sub=MANUAL_BY_TOPIC は QoS compatibility 表で incompatible (旧 publisher
+  // との接続性が壊れる回帰)。pub=MANUAL_BY_TOPIC × sub=AUTOMATIC は compatible で、subscription
+  // event_callbacks.liveliness_callback で publisher 生存を track できる。受信前 (古い
+  // nav_server / panel 単独起動) は alive 判定をバイパスして全 enable のまま
+  // (`*_status_received_` flag を AND することで実現)。
   const auto backend_status_qos = rclcpp::QoS(1)
     .transient_local()
-    .liveliness(rclcpp::LivelinessPolicy::ManualByTopic)
-    .liveliness_lease_duration(std::chrono::seconds(3));
+    .liveliness(rclcpp::LivelinessPolicy::Automatic)
+    .liveliness_lease_duration(std::chrono::seconds(5));
 
   rclcpp::SubscriptionOptions nav_sub_opts;
   nav_sub_opts.event_callbacks.liveliness_callback =

--- a/mapoi_server/CMakeLists.txt
+++ b/mapoi_server/CMakeLists.txt
@@ -75,6 +75,7 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_pytest REQUIRED)
   find_package(launch_testing_ament_cmake REQUIRED)
 
   # Level 1: gtest unit tests
@@ -119,6 +120,12 @@ if(BUILD_TESTING)
   )
   add_launch_test(
     test/test_localization_backend_status_no_amcl.py
+  )
+
+  # Level 3: pytest contract test (#208). In-process pub/sub なので launch_testing 不要。
+  ament_add_pytest_test(test_backend_status_liveliness
+    test/test_backend_status_liveliness.py
+    TIMEOUT 30
   )
 
   # Install test config

--- a/mapoi_server/package.xml
+++ b/mapoi_server/package.xml
@@ -42,6 +42,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>

--- a/mapoi_server/src/mapoi_amcl_localization_bridge.cpp
+++ b/mapoi_server/src/mapoi_amcl_localization_bridge.cpp
@@ -44,8 +44,15 @@ MapoiAmclLocalizationBridge::MapoiAmclLocalizationBridge(
   // /initialpose の subscriber 有無は実行時に変化し得る (AMCL を後起動 / 落とすケース) ため、
   // event-driven ではなく polling で publish する。1Hz は WebUI 表示の応答性として十分
   // (Navigation 側 #198 と同じ割り切り)。
+  // QoS は LocalizationBackendStatus.msg の contract に従う (#208):
+  // transient_local + MANUAL_BY_TOPIC liveliness + 3s lease。各 publish() が assert を兼ねる
+  // ので 1Hz timer が止まれば 3s 後に subscriber 側 Liveliness Changed event が発火する。
   backend_status_pub_ = this->create_publisher<mapoi_interfaces::msg::LocalizationBackendStatus>(
-    "mapoi/localization/backend_status", rclcpp::QoS(1).transient_local());
+    "mapoi/localization/backend_status",
+    rclcpp::QoS(1)
+      .transient_local()
+      .liveliness(rclcpp::LivelinessPolicy::ManualByTopic)
+      .liveliness_lease_duration(3s));
   backend_status_timer_ = this->create_wall_timer(
     1s, std::bind(&MapoiAmclLocalizationBridge::publish_backend_status, this));
 

--- a/mapoi_server/src/mapoi_amcl_localization_bridge.cpp
+++ b/mapoi_server/src/mapoi_amcl_localization_bridge.cpp
@@ -45,14 +45,14 @@ MapoiAmclLocalizationBridge::MapoiAmclLocalizationBridge(
   // event-driven ではなく polling で publish する。1Hz は WebUI 表示の応答性として十分
   // (Navigation 側 #198 と同じ割り切り)。
   // QoS は LocalizationBackendStatus.msg の contract に従う (#208):
-  // transient_local + MANUAL_BY_TOPIC liveliness + 3s lease。各 publish() が assert を兼ねる
-  // ので 1Hz timer が止まれば 3s 後に subscriber 側 Liveliness Changed event が発火する。
+  // transient_local + MANUAL_BY_TOPIC liveliness + 5s lease。各 publish() が assert を兼ねる
+  // ので 1Hz timer が止まれば 5s 後に subscriber 側 Liveliness Changed event が発火する。
   backend_status_pub_ = this->create_publisher<mapoi_interfaces::msg::LocalizationBackendStatus>(
     "mapoi/localization/backend_status",
     rclcpp::QoS(1)
       .transient_local()
       .liveliness(rclcpp::LivelinessPolicy::ManualByTopic)
-      .liveliness_lease_duration(3s));
+      .liveliness_lease_duration(5s));
   backend_status_timer_ = this->create_wall_timer(
     1s, std::bind(&MapoiAmclLocalizationBridge::publish_backend_status, this));
 

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -55,14 +55,17 @@ MapoiNavServer::MapoiNavServer(const rclcpp::NodeOptions & options)
   // Nav2 action / service の存在は実行時に変化し得る (Nav2 を後起動 / 落とすケース) ため、
   // event-driven ではなく polling で publish する割り切り。1Hz は WebUI 表示の応答性として十分。
   // QoS は NavigationBackendStatus.msg の contract に従う (#208):
-  // transient_local + MANUAL_BY_TOPIC liveliness + 3s lease。各 publish() が assert を兼ねる
-  // ので 1Hz timer が止まれば 3s 後に subscriber 側 Liveliness Changed event が発火する。
+  // transient_local + MANUAL_BY_TOPIC liveliness + 5s lease。各 publish() が assert を兼ねる
+  // ので 1Hz timer が止まれば 5s 後に subscriber 側 Liveliness Changed event が発火する。
+  // 5s は select_map 操作以外の通常運用での jitter を吸収する設定。map switch 中の最大 11s
+  // blocking 中は false-positive lost が発火し得るが、operator は応答待ちで navigation 操作
+  // しないため UX 影響は限定的。executor / callback_group 分離による根本解決は #213 で対応予定。
   backend_status_pub_ = this->create_publisher<mapoi_interfaces::msg::NavigationBackendStatus>(
     "mapoi/nav/backend_status",
     rclcpp::QoS(1)
       .transient_local()
       .liveliness(rclcpp::LivelinessPolicy::ManualByTopic)
-      .liveliness_lease_duration(3s));
+      .liveliness_lease_duration(5s));
   backend_status_timer_ = this->create_wall_timer(
     1s, std::bind(&MapoiNavServer::publish_backend_status, this));
 

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -54,8 +54,15 @@ MapoiNavServer::MapoiNavServer(const rclcpp::NodeOptions & options)
   // Navigation backend readiness publisher + 1Hz polling timer (#198)。
   // Nav2 action / service の存在は実行時に変化し得る (Nav2 を後起動 / 落とすケース) ため、
   // event-driven ではなく polling で publish する割り切り。1Hz は WebUI 表示の応答性として十分。
+  // QoS は NavigationBackendStatus.msg の contract に従う (#208):
+  // transient_local + MANUAL_BY_TOPIC liveliness + 3s lease。各 publish() が assert を兼ねる
+  // ので 1Hz timer が止まれば 3s 後に subscriber 側 Liveliness Changed event が発火する。
   backend_status_pub_ = this->create_publisher<mapoi_interfaces::msg::NavigationBackendStatus>(
-    "mapoi/nav/backend_status", rclcpp::QoS(1).transient_local());
+    "mapoi/nav/backend_status",
+    rclcpp::QoS(1)
+      .transient_local()
+      .liveliness(rclcpp::LivelinessPolicy::ManualByTopic)
+      .liveliness_lease_duration(3s));
   backend_status_timer_ = this->create_wall_timer(
     1s, std::bind(&MapoiNavServer::publish_backend_status, this));
 

--- a/mapoi_server/test/test_backend_status_liveliness.py
+++ b/mapoi_server/test/test_backend_status_liveliness.py
@@ -45,7 +45,7 @@ def _make_pub_qos():
 
 
 def _make_sub_qos():
-    """Subscriber 側 QoS: AUTOMATIC + 5s lease (旧 publisher 互換、#212 codex review)."""
+    """Subscriber 側 QoS: AUTOMATIC + 5s lease (msg contract、new-contract-only)."""
     return QoSProfile(
         depth=1,
         durability=DurabilityPolicy.TRANSIENT_LOCAL,
@@ -147,7 +147,9 @@ class TestBackendStatusLiveliness(unittest.TestCase):
         sub_node = rclpy.create_node(
             f'incompat_sub_{topic_name.replace("/", "_")}')
         sub_node.create_subscription(
-            msg_type, topic_name, lambda msg: messages.append(msg.data), sub_qos,
+            msg_type, topic_name,
+            lambda msg: messages.append(msg.backend_type),
+            sub_qos,
             event_callbacks=SubscriptionEventCallbacks(
                 incompatible_qos=lambda event: incompatible_events.append(
                     (event.total_count, event.last_policy_kind))))

--- a/mapoi_server/test/test_backend_status_liveliness.py
+++ b/mapoi_server/test/test_backend_status_liveliness.py
@@ -1,17 +1,21 @@
 """Liveliness QoS staleness 検出 contract test (#208).
 
-`mapoi/nav/backend_status` / `mapoi/localization/backend_status` の msg
-contract で MANUAL_BY_TOPIC liveliness + 3s lease を要求している
+`mapoi/nav/backend_status` / `mapoi/localization/backend_status` の msg contract
 (NavigationBackendStatus.msg / LocalizationBackendStatus.msg の QoS contract
-セクション)。本テストでは:
+セクション参照) を pin する。本テストの 2 つの軸:
 
-1. publisher が 1 件 publish した時点で subscriber 側 liveliness event が
-   `alive_count >= 1` で発火する
-2. その後 publish を停止すると lease (3s) 経過後に `alive_count == 0` が
-   発火する
+1. **Lease lost contract** (`test_*_liveliness_lease`):
+   pub=MANUAL_BY_TOPIC + sub=AUTOMATIC + lease 5s で、
+   - publisher が 1 件 publish した時点で subscriber 側 liveliness event が
+     `alive_count >= 1` で発火する
+   - その後 publish を停止すると lease (5s) 経過後に `alive_count == 0` が発火する
+   PR #210 で入れた `count_publishers() == 0` polling 暫定実装からの proper fix を保証。
 
-を pin し、PR #210 で入れた `count_publishers() == 0` polling 暫定実装
-(WebUI Python / RViz panel C++) からの proper fix が機能していることを保証する。
+2. **Contract violation rejection** (`test_*_legacy_publisher_incompatible`):
+   liveliness QoS 未設定 (= infinite lease) の publisher は subscriber と QoS
+   incompatible で接続不可。これは「contract に従わない publisher を意図的に拒否」
+   する設計の pin (#212 codex review)。
+
 test 用 topic を使うのでサーバープロセスを subprocess 起動する必要はなく
 in-process で完結する (launch_testing 不要 → ament_cmake_pytest で登録)。
 """
@@ -121,3 +125,62 @@ class TestBackendStatusLiveliness(unittest.TestCase):
 
     def test_localization_backend_liveliness_lease(self):
         self._run_liveliness_lease_test(LocalizationBackendStatus, 'test/issue208/loc_backend_status')
+
+    def _run_legacy_publisher_incompatible_test(self, msg_type, topic_name):
+        """msg contract に従わない publisher (liveliness QoS 未設定 = lease infinite) は
+        contract subscriber (lease 5s) と QoS incompatible で接続不可となることを pin する。
+
+        QoS rule: `pub.lease <= sub.lease` でないと incompatible。pub=infinite > sub=5s で違反。
+        これは「contract 違反 publisher を意図的に拒否」する設計の確認 (#212 codex review)。
+        """
+        # Legacy publisher: durability/reliability は新 contract に揃えるが、liveliness QoS を
+        # 設定しない (= default infinite lease)。これが `pub.lease > sub.lease` を引き起こす。
+        legacy_pub_qos = QoSProfile(
+            depth=1,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        )
+        sub_qos = _make_sub_qos()  # 新 contract: AUTOMATIC + lease 5s
+
+        incompatible_events = []
+        messages = []
+
+        sub_node = rclpy.create_node(
+            f'incompat_sub_{topic_name.replace("/", "_")}')
+        sub_node.create_subscription(
+            msg_type, topic_name, lambda msg: messages.append(msg.data), sub_qos,
+            event_callbacks=SubscriptionEventCallbacks(
+                incompatible_qos=lambda event: incompatible_events.append(
+                    (event.total_count, event.last_policy_kind))))
+
+        pub_node = rclpy.create_node(
+            f'incompat_pub_{topic_name.replace("/", "_")}')
+        pub = pub_node.create_publisher(msg_type, topic_name, legacy_pub_qos)
+        msg = msg_type()
+        msg.backend_type = 'legacy-test'
+        msg.backend_ready = True
+        pub.publish(msg)
+
+        # incompatible_qos event 発火を待つ (もしくは 2 秒経っても message が来ないことを確認)。
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not incompatible_events:
+            rclpy.spin_once(sub_node, timeout_sec=0.1)
+
+        pub_node.destroy_node()
+        sub_node.destroy_node()
+
+        self.assertTrue(
+            incompatible_events,
+            f'{topic_name}: expected incompatible_qos event (LIVELINESS) when legacy '
+            f'publisher (infinite lease) connects to contract subscriber (lease 5s); '
+            f'incompatible_events: {incompatible_events}')
+        self.assertEqual(
+            messages, [],
+            f'{topic_name}: contract violator must NOT deliver messages; got: {messages}')
+
+    def test_navigation_backend_legacy_publisher_incompatible(self):
+        self._run_legacy_publisher_incompatible_test(
+            NavigationBackendStatus, 'test/issue208/nav_legacy_incompat')
+
+    def test_localization_backend_legacy_publisher_incompatible(self):
+        self._run_legacy_publisher_incompatible_test(
+            LocalizationBackendStatus, 'test/issue208/loc_legacy_incompat')

--- a/mapoi_server/test/test_backend_status_liveliness.py
+++ b/mapoi_server/test/test_backend_status_liveliness.py
@@ -1,0 +1,111 @@
+"""Liveliness QoS staleness 検出 contract test (#208).
+
+`mapoi/nav/backend_status` / `mapoi/localization/backend_status` の msg
+contract で MANUAL_BY_TOPIC liveliness + 3s lease を要求している
+(NavigationBackendStatus.msg / LocalizationBackendStatus.msg の QoS contract
+セクション)。本テストでは:
+
+1. publisher が 1 件 publish した時点で subscriber 側 liveliness event が
+   `alive_count >= 1` で発火する
+2. その後 publish を停止すると lease (3s) 経過後に `alive_count == 0` が
+   発火する
+
+を pin し、PR #210 で入れた `count_publishers() == 0` polling 暫定実装
+(WebUI Python / RViz panel C++) からの proper fix が機能していることを保証する。
+test 用 topic を使うのでサーバープロセスを subprocess 起動する必要はなく
+in-process で完結する (launch_testing 不要 → ament_cmake_pytest で登録)。
+"""
+import time
+import unittest
+
+import rclpy
+from rclpy.duration import Duration
+from rclpy.qos import DurabilityPolicy, LivelinessPolicy, QoSProfile
+
+try:  # Jazzy (rclpy 3.x+) and newer
+    from rclpy.event_handler import SubscriptionEventCallbacks
+except ImportError:  # Humble fallback
+    from rclpy.qos_event import SubscriptionEventCallbacks
+
+from mapoi_interfaces.msg import LocalizationBackendStatus, NavigationBackendStatus
+
+
+def _make_qos():
+    return QoSProfile(
+        depth=1,
+        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        liveliness=LivelinessPolicy.MANUAL_BY_TOPIC,
+        liveliness_lease_duration=Duration(seconds=3),
+    )
+
+
+class TestBackendStatusLiveliness(unittest.TestCase):
+    """MANUAL_BY_TOPIC liveliness + 3s lease の contract を pin する (#208)."""
+
+    LEASE_PLUS_MARGIN_SEC = 6.0
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def _spin_until(self, sub_node, predicate, timeout_sec):
+        deadline = time.monotonic() + timeout_sec
+        while not predicate() and time.monotonic() < deadline:
+            rclpy.spin_once(sub_node, timeout_sec=0.1)
+
+    def _run_liveliness_lease_test(self, msg_type, topic_name):
+        qos = _make_qos()
+        events = []
+
+        sub_node = rclpy.create_node(f'liveliness_sub_{topic_name.replace("/", "_")}')
+        sub_node.create_subscription(
+            msg_type, topic_name, lambda msg: None, qos,
+            event_callbacks=SubscriptionEventCallbacks(
+                liveliness=lambda event: events.append(
+                    (event.alive_count, event.not_alive_count))))
+
+        pub_node = rclpy.create_node(f'liveliness_pub_{topic_name.replace("/", "_")}')
+        pub = pub_node.create_publisher(msg_type, topic_name, qos)
+
+        # publish 1 件 → publisher discover + lease 起動
+        msg = msg_type()
+        msg.backend_type = 'test'
+        msg.backend_ready = True
+        pub.publish(msg)
+
+        # alive_count >= 1 が来るまで spin (publisher discover 確認)
+        self._spin_until(
+            sub_node, lambda: any(alive >= 1 for alive, _ in events), timeout_sec=3.0)
+        self.assertTrue(
+            any(alive >= 1 for alive, _ in events),
+            f'{topic_name}: expected alive event after publisher creation + first publish; '
+            f'events so far: {events}')
+
+        events_after_alive = len(events)
+
+        # publish を止めて lease (3s) 経過を待つ。pub_node は生かしたままなので
+        # 「publisher process は生きているが 1Hz publish が止まった」状態を再現する
+        # (= bridge で 1Hz timer が止まったケースの模倣、これが #208 の本質)。
+        self._spin_until(
+            sub_node,
+            lambda: any(alive == 0 for alive, _ in events[events_after_alive:]),
+            timeout_sec=self.LEASE_PLUS_MARGIN_SEC)
+
+        pub_node.destroy_node()
+        sub_node.destroy_node()
+
+        self.assertTrue(
+            any(alive == 0 for alive, _ in events[events_after_alive:]),
+            f'{topic_name}: expected liveliness lost (alive_count == 0) within '
+            f'lease + margin ({self.LEASE_PLUS_MARGIN_SEC}s); events so far: {events}')
+
+    def test_navigation_backend_liveliness_lease(self):
+        # 本番 topic 名と衝突しないよう test-specific suffix を付ける。
+        self._run_liveliness_lease_test(NavigationBackendStatus, 'test/issue208/nav_backend_status')
+
+    def test_localization_backend_liveliness_lease(self):
+        self._run_liveliness_lease_test(LocalizationBackendStatus, 'test/issue208/loc_backend_status')

--- a/mapoi_server/test/test_backend_status_liveliness.py
+++ b/mapoi_server/test/test_backend_status_liveliness.py
@@ -30,19 +30,30 @@ except ImportError:  # Humble fallback
 from mapoi_interfaces.msg import LocalizationBackendStatus, NavigationBackendStatus
 
 
-def _make_qos():
+def _make_pub_qos():
+    """Publisher 側 QoS: MANUAL_BY_TOPIC + 5s lease (msg contract、#208)."""
     return QoSProfile(
         depth=1,
         durability=DurabilityPolicy.TRANSIENT_LOCAL,
         liveliness=LivelinessPolicy.MANUAL_BY_TOPIC,
-        liveliness_lease_duration=Duration(seconds=3),
+        liveliness_lease_duration=Duration(seconds=5),
+    )
+
+
+def _make_sub_qos():
+    """Subscriber 側 QoS: AUTOMATIC + 5s lease (旧 publisher 互換、#212 codex review)."""
+    return QoSProfile(
+        depth=1,
+        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        liveliness=LivelinessPolicy.AUTOMATIC,
+        liveliness_lease_duration=Duration(seconds=5),
     )
 
 
 class TestBackendStatusLiveliness(unittest.TestCase):
-    """MANUAL_BY_TOPIC liveliness + 3s lease の contract を pin する (#208)."""
+    """MANUAL_BY_TOPIC publisher + AUTOMATIC subscriber + 5s lease を pin する (#208)."""
 
-    LEASE_PLUS_MARGIN_SEC = 6.0
+    LEASE_PLUS_MARGIN_SEC = 8.0
 
     @classmethod
     def setUpClass(cls):
@@ -58,18 +69,19 @@ class TestBackendStatusLiveliness(unittest.TestCase):
             rclpy.spin_once(sub_node, timeout_sec=0.1)
 
     def _run_liveliness_lease_test(self, msg_type, topic_name):
-        qos = _make_qos()
+        sub_qos = _make_sub_qos()
+        pub_qos = _make_pub_qos()
         events = []
 
         sub_node = rclpy.create_node(f'liveliness_sub_{topic_name.replace("/", "_")}')
         sub_node.create_subscription(
-            msg_type, topic_name, lambda msg: None, qos,
+            msg_type, topic_name, lambda msg: None, sub_qos,
             event_callbacks=SubscriptionEventCallbacks(
                 liveliness=lambda event: events.append(
                     (event.alive_count, event.not_alive_count))))
 
         pub_node = rclpy.create_node(f'liveliness_pub_{topic_name.replace("/", "_")}')
-        pub = pub_node.create_publisher(msg_type, topic_name, qos)
+        pub = pub_node.create_publisher(msg_type, topic_name, pub_qos)
 
         # publish 1 件 → publisher discover + lease 起動
         msg = msg_type()
@@ -87,7 +99,7 @@ class TestBackendStatusLiveliness(unittest.TestCase):
 
         events_after_alive = len(events)
 
-        # publish を止めて lease (3s) 経過を待つ。pub_node は生かしたままなので
+        # publish を止めて lease (5s) 経過を待つ。pub_node は生かしたままなので
         # 「publisher process は生きているが 1Hz publish が止まった」状態を再現する
         # (= bridge で 1Hz timer が止まったケースの模倣、これが #208 の本質)。
         self._spin_until(

--- a/mapoi_webui/CMakeLists.txt
+++ b/mapoi_webui/CMakeLists.txt
@@ -18,4 +18,14 @@ install(PROGRAMS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  # `_resolve_backend_status_for_ui` の状態遷移 unit test (#208, #212 codex review)。
+  # mapoi_webui_node の Node 部分には依存しない pure logic。
+  ament_add_pytest_test(test_resolve_backend_status_for_ui
+    test/test_resolve_backend_status_for_ui.py
+    TIMEOUT 10
+  )
+endif()
+
 ament_package()

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -183,14 +183,17 @@ class MapoiWebNode(Node):
             String, 'mapoi/nav/status', self.nav_status_callback, nav_status_qos)
 
         # Navigation / Localization backend readiness (#198 / #209) の QoS は msg contract
-        # (#208) に従う: transient_local + MANUAL_BY_TOPIC liveliness + 3s lease。
-        # subscriber は Liveliness Changed event で publisher 死亡を検知し、stale な
-        # transient_local cache (`backend_ready=true` のまま固まる) を防ぐ。
+        # (#208) に従う: transient_local + MANUAL_BY_TOPIC liveliness (publisher 側) + 3s lease。
+        # subscriber 側は AUTOMATIC で受ける (#212 codex review medium): pub=AUTOMATIC × sub=
+        # MANUAL_BY_TOPIC は QoS compatibility 表で incompatible (publisher が旧 contract の
+        # AUTOMATIC のまま動いている場合に接続できなくなる回帰)。pub=MANUAL_BY_TOPIC × sub=
+        # AUTOMATIC は compatible で、subscriber 側で Liveliness Changed event を同様に
+        # 受け取れる (alive_count の遷移は publisher 側 policy で決まる)。
         backend_status_qos = QoSProfile(
             depth=1,
             durability=DurabilityPolicy.TRANSIENT_LOCAL,
-            liveliness=LivelinessPolicy.MANUAL_BY_TOPIC,
-            liveliness_lease_duration=Duration(seconds=3),
+            liveliness=LivelinessPolicy.AUTOMATIC,
+            liveliness_lease_duration=Duration(seconds=5),
         )
 
         # Navigation backend readiness (#198): mapoi_nav_server が 1Hz で publish する
@@ -282,15 +285,40 @@ class MapoiWebNode(Node):
     def _nav_backend_liveliness_callback(self, event):
         """Track navigation backend publisher liveness (#208).
 
-        MANUAL_BY_TOPIC + 3s lease で、bridge が 1Hz publish を止めると lease 経過後に
-        `alive_count` が 0 へ遷移する。`get_navigation_capabilities` がこの flag を見て
-        latched cache を None 扱いに落とす。
+        MANUAL_BY_TOPIC publisher + lease 経過で `alive_count` が 0 へ遷移する。
+        `_resolve_backend_status_for_ui` がこの flag を見て、受信済み cache を
+        explicit unready (`backend_ready=false`) にデコレートする。
         """
         self.nav_backend_alive_ = event.alive_count > 0
 
     def _localization_backend_liveliness_callback(self, event):
         """Track localization backend publisher liveness (#208). Same semantics as nav."""
         self.localization_backend_alive_ = event.alive_count > 0
+
+    @staticmethod
+    def _resolve_backend_status_for_ui(cached, alive):
+        """Combine cached backend_status payload with liveliness flag for UI gating (#208).
+
+        三状態を区別する:
+
+        - cached is None (未受信)              → return None
+            * `get_navigation_capabilities` 側で legacy fallback path に流れる
+              (旧 publisher / bridge 不在の後方互換)
+        - cached is not None and alive=True   → return cached (latched payload そのまま)
+        - cached is not None and alive=False  → return {**cached, backend_ready: False}
+            * publisher が一度 alive 後に lost した状態 (lease 経過 / process kill)。
+              legacy fallback ではなく explicit unready として返し、UI を確実に disable
+              させる (#212 codex review high)。
+        """
+        if cached is None:
+            return None
+        if alive:
+            return cached
+        return {
+            **cached,
+            'backend_ready': False,
+            'reason': 'liveliness lost (publisher not active)',
+        }
 
     def update_robot_pose(self):
         """Lookup TF map->base_link and cache robot pose."""
@@ -447,12 +475,17 @@ class MapoiWebNode(Node):
 
         # bridge プロセスが死亡しても transient_local の cache (self.backend_status_ /
         # self.localization_status_) は subscriber callback が呼ばれない限り古い値を持ち続ける。
-        # MANUAL_BY_TOPIC liveliness + 3s lease (#208) を使い、`*_backend_alive_` flag を
-        # subscription event で更新して staleness を検出する。受信前 (`*_status_ is None`) は
-        # legacy fallback path に流す (旧 nav_server / bridge 不在の後方互換)。
-        backend = self.backend_status_ if self.nav_backend_alive_ else None
-        localization = (
-            self.localization_status_ if self.localization_backend_alive_ else None)
+        # liveliness QoS (#208) で取得した `*_backend_alive_` flag を `_resolve_backend_status_for_ui`
+        # で反映する。
+        # - 未受信: backend = None → legacy fallback (旧 nav_server / bridge 不在の後方互換)
+        # - 受信済み + alive: cache をそのまま使う
+        # - 受信済み + lost: backend_ready=false に上書きした dict を返す → UI 確実 disable
+        #   (#212 codex review high: legacy fallback path に落とすと command subscriber が残った
+        #    状態で false-enable になる回帰)
+        backend = self._resolve_backend_status_for_ui(
+            self.backend_status_, self.nav_backend_alive_)
+        localization = self._resolve_backend_status_for_ui(
+            self.localization_status_, self.localization_backend_alive_)
 
         if backend is not None:
             navigation_available = bool(backend['backend_ready'])

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -10,8 +10,13 @@ import threading
 import time
 
 import rclpy
+from rclpy.duration import Duration
 from rclpy.node import Node
-from rclpy.qos import QoSProfile, DurabilityPolicy
+from rclpy.qos import DurabilityPolicy, LivelinessPolicy, QoSProfile
+try:  # Jazzy (rclpy 3.x+) and newer
+    from rclpy.event_handler import SubscriptionEventCallbacks
+except ImportError:  # Humble fallback
+    from rclpy.qos_event import SubscriptionEventCallbacks
 from std_msgs.msg import String
 from std_srvs.srv import Trigger
 from mapoi_interfaces.srv import GetMapsInfo, GetTagDefinitions, SelectMap
@@ -177,25 +182,44 @@ class MapoiWebNode(Node):
         self.nav_status_sub_ = self.create_subscription(
             String, 'mapoi/nav/status', self.nav_status_callback, nav_status_qos)
 
+        # Navigation / Localization backend readiness (#198 / #209) の QoS は msg contract
+        # (#208) に従う: transient_local + MANUAL_BY_TOPIC liveliness + 3s lease。
+        # subscriber は Liveliness Changed event で publisher 死亡を検知し、stale な
+        # transient_local cache (`backend_ready=true` のまま固まる) を防ぐ。
+        backend_status_qos = QoSProfile(
+            depth=1,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            liveliness=LivelinessPolicy.MANUAL_BY_TOPIC,
+            liveliness_lease_duration=Duration(seconds=3),
+        )
+
         # Navigation backend readiness (#198): mapoi_nav_server が 1Hz で publish する
         # readiness summary。WebUI / panel はこの値で navigation 操作 UI を gate する。
         # backend_status topic 不在の場合 (古い nav_server 等) は None のまま、command topic
-        # subscriber 数による旧判定にフォールバックする。
+        # subscriber 数による旧判定にフォールバックする (`get_navigation_capabilities`)。
         self.backend_status_ = None
-        backend_status_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        # `nav_backend_alive_` は liveliness event_callback が更新する publisher 生存 flag。
+        # 初期 False (subscription 作成直後 = publisher 未発見) で、discovery で True、
+        # 1Hz publish が 3s 以上途切れると False に戻る。`backend_status_` が None でない
+        # (= 一度受信した) 状態で False に戻った場合のみ staleness として UI を disable。
+        self.nav_backend_alive_ = False
         self.backend_status_sub_ = self.create_subscription(
             NavigationBackendStatus, 'mapoi/nav/backend_status',
-            self.backend_status_callback, backend_status_qos)
+            self.backend_status_callback, backend_status_qos,
+            event_callbacks=SubscriptionEventCallbacks(
+                liveliness=self._nav_backend_liveliness_callback))
 
         # Localization backend readiness (#209): mapoi_amcl_localization_bridge (or any custom
         # localization bridge) が 1Hz で publish する readiness summary。WebUI は Set Initial
         # Pose 操作 UI と initial pose POI 選択をこの値で gate する。topic 不在 (bridge 未起動 /
         # editor 専用構成) は None のまま、frontend 側で「不明」状態として扱う。
         self.localization_status_ = None
-        localization_status_qos = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        self.localization_backend_alive_ = False
         self.localization_status_sub_ = self.create_subscription(
             LocalizationBackendStatus, 'mapoi/localization/backend_status',
-            self.localization_status_callback, localization_status_qos)
+            self.localization_status_callback, backend_status_qos,
+            event_callbacks=SubscriptionEventCallbacks(
+                liveliness=self._localization_backend_liveliness_callback))
 
         # Subscribe to mapoi/config_path for external map switches.
         # transient_local QoS で publisher (mapoi_server) の latched 値を受信する (#135)。
@@ -254,6 +278,19 @@ class MapoiWebNode(Node):
             'backend_ready': bool(msg.backend_ready),
             'reason': msg.reason,
         }
+
+    def _nav_backend_liveliness_callback(self, event):
+        """Track navigation backend publisher liveness (#208).
+
+        MANUAL_BY_TOPIC + 3s lease で、bridge が 1Hz publish を止めると lease 経過後に
+        `alive_count` が 0 へ遷移する。`get_navigation_capabilities` がこの flag を見て
+        latched cache を None 扱いに落とす。
+        """
+        self.nav_backend_alive_ = event.alive_count > 0
+
+    def _localization_backend_liveliness_callback(self, event):
+        """Track localization backend publisher liveness (#208). Same semantics as nav."""
+        self.localization_backend_alive_ = event.alive_count > 0
 
     def update_robot_pose(self):
         """Lookup TF map->base_link and cache robot pose."""
@@ -409,14 +446,13 @@ class MapoiWebNode(Node):
         legacy_available = switch_map_available or command_available
 
         # bridge プロセスが死亡しても transient_local の cache (self.backend_status_ /
-        # self.localization_status_) は subscriber callback が呼ばれない限り古い値を持ち続ける
-        # (#209 review)。DDS は publisher 不在を 1 秒程度で検知するので、`count_publishers() == 0`
-        # を staleness signal として使い、cache を「未受信扱い」に落とす。これは #208 の
-        # heartbeat / liveliness 検出の軽量代替で、subscriber 側だけで完結する。
-        nav_publishers_alive = self.count_publishers('mapoi/nav/backend_status') > 0
-        loc_publishers_alive = self.count_publishers('mapoi/localization/backend_status') > 0
-        backend = self.backend_status_ if nav_publishers_alive else None
-        localization = self.localization_status_ if loc_publishers_alive else None
+        # self.localization_status_) は subscriber callback が呼ばれない限り古い値を持ち続ける。
+        # MANUAL_BY_TOPIC liveliness + 3s lease (#208) を使い、`*_backend_alive_` flag を
+        # subscription event で更新して staleness を検出する。受信前 (`*_status_ is None`) は
+        # legacy fallback path に流す (旧 nav_server / bridge 不在の後方互換)。
+        backend = self.backend_status_ if self.nav_backend_alive_ else None
+        localization = (
+            self.localization_status_ if self.localization_backend_alive_ else None)
 
         if backend is not None:
             navigation_available = bool(backend['backend_ready'])

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -183,12 +183,14 @@ class MapoiWebNode(Node):
             String, 'mapoi/nav/status', self.nav_status_callback, nav_status_qos)
 
         # Navigation / Localization backend readiness (#198 / #209) の QoS は msg contract
-        # (#208) に従う: transient_local + MANUAL_BY_TOPIC liveliness (publisher 側) + 3s lease。
-        # subscriber 側は AUTOMATIC で受ける (#212 codex review medium): pub=AUTOMATIC × sub=
-        # MANUAL_BY_TOPIC は QoS compatibility 表で incompatible (publisher が旧 contract の
-        # AUTOMATIC のまま動いている場合に接続できなくなる回帰)。pub=MANUAL_BY_TOPIC × sub=
-        # AUTOMATIC は compatible で、subscriber 側で Liveliness Changed event を同様に
-        # 受け取れる (alive_count の遷移は publisher 側 policy で決まる)。
+        # (#208) に従う: transient_local + liveliness (publisher=MANUAL_BY_TOPIC,
+        # subscriber=AUTOMATIC) + lease 5s (両側必須)。subscriber 側 policy を AUTOMATIC に
+        # するのは pub=MANUAL_BY_TOPIC × sub=AUTOMATIC が compatible 表上 OK だから。lease は
+        # `pub.lease <= sub.lease` 制約があり、両側 5s で揃えるのが運用上シンプル。
+        # 結果として **msg contract に従わない publisher (例: liveliness QoS 未設定 = lease
+        # infinite) は意図的に QoS incompatible で接続を拒否する**。custom bridge 実装者は
+        # msg README の contract 表に従う必要がある (test_backend_status_liveliness.py で
+        # incompatibility を pin)。
         backend_status_qos = QoSProfile(
             depth=1,
             durability=DurabilityPolicy.TRANSIENT_LOCAL,
@@ -203,7 +205,7 @@ class MapoiWebNode(Node):
         self.backend_status_ = None
         # `nav_backend_alive_` は liveliness event_callback が更新する publisher 生存 flag。
         # 初期 False (subscription 作成直後 = publisher 未発見) で、discovery で True、
-        # 1Hz publish が 3s 以上途切れると False に戻る。`backend_status_` が None でない
+        # 1Hz publish が 5s lease 以上途切れると False に戻る。`backend_status_` が None でない
         # (= 一度受信した) 状態で False に戻った場合のみ staleness として UI を disable。
         self.nav_backend_alive_ = False
         self.backend_status_sub_ = self.create_subscription(

--- a/mapoi_webui/package.xml
+++ b/mapoi_webui/package.xml
@@ -29,6 +29,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/mapoi_webui/test/test_resolve_backend_status_for_ui.py
+++ b/mapoi_webui/test/test_resolve_backend_status_for_ui.py
@@ -1,0 +1,68 @@
+"""Unit test for `MapoiWebuiNode._resolve_backend_status_for_ui` (#208, #212 codex review).
+
+`get_navigation_capabilities` の状態遷移ロジックを切り出した pure 関数。3 つの状態
+(未受信 / 受信済み+alive / 受信済み+lost) を直接 assert する。Codex review #212 で
+「受信済み+lost で legacy fallback に落ちると command subscriber が残った状態で
+false-enable する」という回帰を pin する。
+"""
+import unittest
+
+from mapoi_webui.mapoi_webui_node import MapoiWebuiNode
+
+
+class TestResolveBackendStatusForUi(unittest.TestCase):
+
+    def test_no_cache_returns_none(self):
+        """未受信 (cached is None) は None を返す → caller は legacy fallback path に流す."""
+        self.assertIsNone(
+            MapoiWebuiNode._resolve_backend_status_for_ui(None, alive=True))
+        self.assertIsNone(
+            MapoiWebuiNode._resolve_backend_status_for_ui(None, alive=False))
+
+    def test_alive_returns_cached_payload(self):
+        """受信済み + alive は cache をそのまま返す (latched payload)."""
+        cached = {'backend_type': 'nav2', 'backend_ready': True, 'reason': ''}
+        self.assertEqual(
+            MapoiWebuiNode._resolve_backend_status_for_ui(cached, alive=True),
+            cached)
+
+    def test_alive_returns_cached_even_if_payload_unready(self):
+        """受信済み + alive は backend_ready=false の cache もそのまま返す
+        (publisher は alive で「Nav2 not ready」を表明している正常状態)."""
+        cached = {'backend_type': 'nav2', 'backend_ready': False, 'reason': 'Nav2 missing'}
+        self.assertEqual(
+            MapoiWebuiNode._resolve_backend_status_for_ui(cached, alive=True),
+            cached)
+
+    def test_seen_but_lost_returns_explicit_unready(self):
+        """受信済み + lost は backend_ready=False に上書きした dict を返す.
+
+        legacy fallback path に落とさず明示 unready にすることで、command subscriber が
+        残った状態でも UI が enable に戻らないことを保証する (#212 codex review high)。
+        """
+        cached = {'backend_type': 'nav2', 'backend_ready': True, 'reason': ''}
+        result = MapoiWebuiNode._resolve_backend_status_for_ui(cached, alive=False)
+
+        # 戻り値は新 dict (cache を上書きしないこと)
+        self.assertIsNot(result, cached)
+        self.assertTrue(cached['backend_ready'],
+                        'original cache MUST not be mutated')
+
+        # backend_ready は必ず False
+        self.assertFalse(result['backend_ready'])
+        # backend_type は維持される (UI tooltip 表示等)
+        self.assertEqual(result['backend_type'], 'nav2')
+        # reason は staleness 由来であることがわかる文言に上書きされる
+        self.assertNotEqual(result['reason'], '')
+        self.assertIn('liveliness', result['reason'].lower())
+
+    def test_seen_but_lost_localization_payload(self):
+        """Localization payload も同じ semantics で扱われる."""
+        cached = {'backend_type': 'amcl', 'backend_ready': True, 'reason': ''}
+        result = MapoiWebuiNode._resolve_backend_status_for_ui(cached, alive=False)
+        self.assertFalse(result['backend_ready'])
+        self.assertEqual(result['backend_type'], 'amcl')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mapoi_webui/test/test_resolve_backend_status_for_ui.py
+++ b/mapoi_webui/test/test_resolve_backend_status_for_ui.py
@@ -1,4 +1,4 @@
-"""Unit test for `MapoiWebuiNode._resolve_backend_status_for_ui` (#208, #212 codex review).
+"""Unit test for `MapoiWebNode._resolve_backend_status_for_ui` (#208, #212 codex review).
 
 `get_navigation_capabilities` の状態遷移ロジックを切り出した pure 関数。3 つの状態
 (未受信 / 受信済み+alive / 受信済み+lost) を直接 assert する。Codex review #212 で
@@ -7,7 +7,7 @@ false-enable する」という回帰を pin する。
 """
 import unittest
 
-from mapoi_webui.mapoi_webui_node import MapoiWebuiNode
+from mapoi_webui.mapoi_webui_node import MapoiWebNode
 
 
 class TestResolveBackendStatusForUi(unittest.TestCase):
@@ -15,15 +15,15 @@ class TestResolveBackendStatusForUi(unittest.TestCase):
     def test_no_cache_returns_none(self):
         """未受信 (cached is None) は None を返す → caller は legacy fallback path に流す."""
         self.assertIsNone(
-            MapoiWebuiNode._resolve_backend_status_for_ui(None, alive=True))
+            MapoiWebNode._resolve_backend_status_for_ui(None, alive=True))
         self.assertIsNone(
-            MapoiWebuiNode._resolve_backend_status_for_ui(None, alive=False))
+            MapoiWebNode._resolve_backend_status_for_ui(None, alive=False))
 
     def test_alive_returns_cached_payload(self):
         """受信済み + alive は cache をそのまま返す (latched payload)."""
         cached = {'backend_type': 'nav2', 'backend_ready': True, 'reason': ''}
         self.assertEqual(
-            MapoiWebuiNode._resolve_backend_status_for_ui(cached, alive=True),
+            MapoiWebNode._resolve_backend_status_for_ui(cached, alive=True),
             cached)
 
     def test_alive_returns_cached_even_if_payload_unready(self):
@@ -31,7 +31,7 @@ class TestResolveBackendStatusForUi(unittest.TestCase):
         (publisher は alive で「Nav2 not ready」を表明している正常状態)."""
         cached = {'backend_type': 'nav2', 'backend_ready': False, 'reason': 'Nav2 missing'}
         self.assertEqual(
-            MapoiWebuiNode._resolve_backend_status_for_ui(cached, alive=True),
+            MapoiWebNode._resolve_backend_status_for_ui(cached, alive=True),
             cached)
 
     def test_seen_but_lost_returns_explicit_unready(self):
@@ -41,7 +41,7 @@ class TestResolveBackendStatusForUi(unittest.TestCase):
         残った状態でも UI が enable に戻らないことを保証する (#212 codex review high)。
         """
         cached = {'backend_type': 'nav2', 'backend_ready': True, 'reason': ''}
-        result = MapoiWebuiNode._resolve_backend_status_for_ui(cached, alive=False)
+        result = MapoiWebNode._resolve_backend_status_for_ui(cached, alive=False)
 
         # 戻り値は新 dict (cache を上書きしないこと)
         self.assertIsNot(result, cached)
@@ -59,7 +59,7 @@ class TestResolveBackendStatusForUi(unittest.TestCase):
     def test_seen_but_lost_localization_payload(self):
         """Localization payload も同じ semantics で扱われる."""
         cached = {'backend_type': 'amcl', 'backend_ready': True, 'reason': ''}
-        result = MapoiWebuiNode._resolve_backend_status_for_ui(cached, alive=False)
+        result = MapoiWebNode._resolve_backend_status_for_ui(cached, alive=False)
         self.assertFalse(result['backend_ready'])
         self.assertEqual(result['backend_type'], 'amcl')
 


### PR DESCRIPTION
## Summary

PR #210 で暫定的に入れた `count_publishers() == 0` polling による backend_status staleness 検出を、ROS 2 の Liveliness QoS (`MANUAL_BY_TOPIC` publisher + `AUTOMATIC` subscriber + 5s lease) に置き換える。Navigation / Localization 両 backend に対称適用。

Close #208

## QoS contract (msg README に明記)

`NavigationBackendStatus.msg` / `LocalizationBackendStatus.msg` の QoS contract:

| 項目 | 値 |
|---|---|
| durability | TRANSIENT_LOCAL |
| reliability | RELIABLE |
| liveliness (publisher) | MANUAL_BY_TOPIC |
| liveliness (subscriber) | AUTOMATIC |
| liveliness_lease_duration (両側必須) | **5 s** |

publisher は 5s 以内に publish (各 `publish()` が assert を兼ねる)。subscriber 側 lease を 5s で揃えるのは `pub.lease ≤ sub.lease` 制約に従うため。

**設計判断: contract violators は意図的に QoS incompatible で拒否**。例: liveliness QoS 未設定 publisher (= lease infinite) は `pub.lease > sub.lease` で contract subscriber と接続不可 (test で pin)。custom bridge 実装者は msg contract に従う必要がある。

## 変更点

### Round 1 (initial 4 commits)
1. `feat(interfaces)`: msg header に QoS contract 追加 + publisher QoS に MANUAL_BY_TOPIC + lease 追加
2. `feat(webui)`: WebUI Python subscriber を liveliness event_callback 化、`count_publishers()` polling 削除
3. `feat(rviz_plugins)`: RViz panel C++ subscriber を liveliness event_callback 化、`BackendStalenessTick` 1Hz wall_timer を完全削除
4. `test(server)`: pytest contract test (`test_backend_status_liveliness.py`) を追加

### Round 2 (codex review fix)
5. `fix(#212)`: codex review high+medium 3 件反映:
   - **High**: WebUI staleness 経路を `_resolve_backend_status_for_ui` 静的メソッドに切り出し、「受信済み + lost」を `backend_ready=false` として返す + 状態遷移 unit test 追加
   - **Medium**: subscriber QoS 修正 (`MANUAL_BY_TOPIC` → `AUTOMATIC`)
   - **Medium**: lease 3s → 5s (jitter 吸収マージン拡張)、根本解決 (callback_group 分離) を follow-up issue #213 に切り出し
6. `fix(test)`: test class 名 typo 修正
7. `fix(#212)`: codex round 2 narrative 修正:
   - subscriber 設計を「legacy publisher 互換」から「new-contract-only」に明文化 (msg README / コメント全面更新)
   - stale 3s 残骸を 5s に一掃
   - **legacy publisher との incompatibility を pin する test 2 件追加** (`incompatible_qos` event 発火 + message non-delivery 確認)

## 設計判断・悩みどころ (Codex review に意見が欲しい点)

### (a) policy 選択: pub=`MANUAL_BY_TOPIC` × sub=`AUTOMATIC`
公式 ROS 2 QoS docs より AUTOMATIC は **Node 単位**で alive 判定。同 Node の他 publisher (`nav_status_pub_` / `poi_event_pub_` 等) があると backend_status timer 停止を検知できない。MANUAL_BY_TOPIC は topic 単位で確実に検知。subscriber 側 AUTOMATIC は compatibility 表で唯一の選択肢 (pub=AUTOMATIC × sub=MANUAL_BY_TOPIC は incompatible)。

### (b) lease_duration = 5s (両側)
1Hz publish に対し 5 周期分マージン。3s だと CI 負荷時の jitter で flaky の余地。`mapoi_nav_server` の SingleThreadedExecutor + `select_map` 中の最大 ~11s blocking では 5s でも false-positive が出るが、operator は応答待ちで navigation 操作しないため UX 致命的でない。callback_group 分離による根本解決は **follow-up issue #213** で対応。

### (c) `count_publishers()` polling 完全削除
PR #210 で入れた WebUI Python と RViz panel C++ の両 polling を完全削除。新仕様に統一して保守負担を減らす。

### (d) `*_status_received_` flag 維持 (後方互換)
未受信状態 (旧 publisher 環境 / panel 単独起動) では alive 判定をバイパスして UI を全 enable 維持。受信実績ありの publisher の lost のみ disable。

### (e) Contract violators の扱い (round 2 で固めた設計)
liveliness QoS 未設定 publisher (= lease infinite) は intentional に QoS incompatible で接続不可。msg README に明記し、test で incompatibility と message non-delivery を pin。

## Test plan

両 distro (humble + jazzy) で:

- [x] colcon build: 4 packages finished
- [x] colcon test: **67/67 tests passed** (gtest 3 + launch_test 5 + pytest 6 [lease test 2 + incompat test 2 + resolve test 5])
- [x] 既存 launch_test (`test_backend_status_no_nav2.py` / `test_localization_backend_status_no_amcl.py`) も pass
- [x] 新 pytest test (`test_backend_status_liveliness.py`):
  - lease lost: publish 停止後 5s lease + margin 内に `alive_count == 0` 発火を両 backend で確認
  - legacy incompat: liveliness QoS 未設定 publisher が `incompatible_qos` event で reject され message 不達を両 backend で確認
- [x] 新 pytest test (`test_resolve_backend_status_for_ui.py`): WebUI staleness 状態遷移 (未受信 / alive / lost) を pure logic として確認

## 関連
- Close #208
- Follow-up: #213 (`mapoi_nav_server` callback_group 分離 — priority: low)
- 元 staleness 暫定実装: PR #210 (lessons.md L151)

🤖 Generated with [Claude Code](https://claude.com/claude-code)