### PR TITLE
docs: custom bridge 向け backend_ready 算出指針追加 (Close #207)

### DIFF
--- a/mapoi_interfaces/README.md
+++ b/mapoi_interfaces/README.md
@@ -48,7 +48,7 @@ Navigation bridge (Nav2 bridge / 自前 bridge) が 1 Hz で `mapoi/nav/backend_
 | --- | --- | --- |
 | `backend_type` | `string` | bridge 識別子 (例: `nav2`, `custom_lidar_planner`)。tooltip 表示用 |
 | `backend_ready` | `bool` | bridge が navigation コマンドを受け付け実行できる状態か |
-| `reason` | `string` | `backend_ready=false` 時の human-readable 理由 (任意) |
+| `reason` | `string` | `backend_ready=false` 時の human-readable 理由 (任意、機微情報は含めない — 下記参照) |
 
 #### QoS contract (issue #208)
 
@@ -67,6 +67,8 @@ publisher / subscriber 双方で以下を必ず指定:
 `backend_ready` の算出は bridge ごとに「実際に expose する capability の AND」とすること。`mapoi_nav_server` (Nav2 bridge) の `goal_ready && route_ready && switch_map_ready` は **3 capability 全部を expose する bridge にのみ正しい**。片機能 bridge (例: NavigateToPose のみ) でこれを真似ると、expose していない capability が常に false → `backend_ready` も常に false → UI が常に "Navigation unavailable" になる。
 
 具体例とフィールド populate 方針 (`reason` の慣習表記含む) は `msg/NavigationBackendStatus.msg` の冒頭コメントに記載。
+
+`reason` は operator UI に表示され bag や remote dashboard に記録され得るため、credentials / token / 絶対パス / 内部 hostname / IP / user identifier / stack trace 等の機微情報を含めないこと。capability 名と短い状態動詞 (例: `not ready: navigate_to_pose action`) に留める。
 
 ## サービス (srv)
 

--- a/mapoi_interfaces/README.md
+++ b/mapoi_interfaces/README.md
@@ -40,6 +40,34 @@ POI tolerance.xy 半径への侵入・退出 / 停止 / 再開イベントを表
 | `poi` | `mapoi_interfaces/PointOfInterest` | 対象 POI の情報 |
 | `stamp` | `builtin_interfaces/Time` | イベント発生時刻 |
 
+### NavigationBackendStatus.msg
+
+Navigation bridge (Nav2 bridge / 自前 bridge) が 1 Hz で `mapoi/nav/backend_status` に publish する readiness メッセージです。UI 側 (`mapoi_webui`, `mapoi_rviz_plugins`) は `backend_ready` を見て navigation 操作を gate します。
+
+| フィールド | 型 | 説明 |
+| --- | --- | --- |
+| `backend_type` | `string` | bridge 識別子 (例: `nav2`, `custom_lidar_planner`)。tooltip 表示用 |
+| `backend_ready` | `bool` | bridge が navigation コマンドを受け付け実行できる状態か |
+| `reason` | `string` | `backend_ready=false` 時の human-readable 理由 (任意) |
+
+#### QoS contract (issue #208)
+
+publisher / subscriber 双方で以下を必ず指定:
+
+- `durability`: `TRANSIENT_LOCAL` (late-joiner UI が最新 status を受信できる)
+- `reliability`: `RELIABLE`
+- `liveliness` (publisher): `MANUAL_BY_TOPIC` (publish() ごとに liveliness assert)
+- `liveliness` (subscriber): `AUTOMATIC` (pub `MANUAL_BY_TOPIC` × sub `AUTOMATIC` のみ互換)
+- `liveliness_lease_duration`: 5 s (両側、`pub.lease <= sub.lease` を満たす)
+
+詳細・違反パターンは `msg/NavigationBackendStatus.msg` の冒頭コメント参照。
+
+#### Custom bridge 実装者向けガイダンス (issue #207)
+
+`backend_ready` の算出は bridge ごとに「実際に expose する capability の AND」とすること。`mapoi_nav_server` (Nav2 bridge) の `goal_ready && route_ready && switch_map_ready` は **3 capability 全部を expose する bridge にのみ正しい**。片機能 bridge (例: NavigateToPose のみ) でこれを真似ると、expose していない capability が常に false → `backend_ready` も常に false → UI が常に "Navigation unavailable" になる。
+
+具体例とフィールド populate 方針 (`reason` の慣習表記含む) は `msg/NavigationBackendStatus.msg` の冒頭コメントに記載。
+
 ## サービス (srv)
 
 ### SelectMap.srv

--- a/mapoi_interfaces/msg/NavigationBackendStatus.msg
+++ b/mapoi_interfaces/msg/NavigationBackendStatus.msg
@@ -7,6 +7,22 @@
 # `backend_ready` alone. Per-capability detail belongs to `reason` or to
 # bridge-specific topics, not this message.
 #
+# How to populate `backend_ready` (custom bridge implementers — issue #207):
+#   AND only the capabilities your bridge actually exposes. Do NOT copy
+#   `mapoi_nav_server`'s `goal_ready && route_ready && switch_map_ready`
+#   verbatim — that AND is correct only for a bridge that exposes all three
+#   (NavigateToPose + FollowWaypoints + map switch). For a single-capability
+#   bridge, ANDing in capabilities you don't expose pins `backend_ready` to
+#   `false` forever and the UI permanently shows "Navigation unavailable".
+#   Examples:
+#     - Goal-only bridge:  backend_ready = goal_ready
+#     - Route-only bridge: backend_ready = route_ready
+#     - Goal + map switch: backend_ready = goal_ready && switch_map_ready
+#   Convention for `reason` (recommended for operator UX consistency):
+#   when `backend_ready` is false, list missing capabilities joined by ", "
+#   prefixed with "not ready: " (see mapoi_nav_server::publish_backend_status
+#   for the canonical format).
+#
 # Localization readiness (initial pose / AMCL etc.) is intentionally NOT
 # part of this contract; it will be exposed by a separate
 # `LocalizationBackendStatus` topic — see issue #209.

--- a/mapoi_interfaces/msg/NavigationBackendStatus.msg
+++ b/mapoi_interfaces/msg/NavigationBackendStatus.msg
@@ -22,6 +22,11 @@
 #   when `backend_ready` is false, list missing capabilities joined by ", "
 #   prefixed with "not ready: " (see mapoi_nav_server::publish_backend_status
 #   for the canonical format).
+#   Privacy: `reason` is surfaced in the operator UI and may be logged by
+#   bag recorders or remote dashboards. Bridges MUST NOT include sensitive
+#   runtime info — credentials/tokens, absolute filesystem paths, internal
+#   hostnames/IPs, user identifiers, or stack traces. Stick to capability
+#   names and short status verbs (e.g. "not ready: navigate_to_pose action").
 #
 # Localization readiness (initial pose / AMCL etc.) is intentionally NOT
 # part of this contract; it will be exposed by a separate

--- a/mapoi_server/src/mapoi_nav_server.cpp
+++ b/mapoi_server/src/mapoi_nav_server.cpp
@@ -728,6 +728,10 @@ void MapoiNavServer::publish_backend_status()
   // backend_ready の AND に `select_map` service を含めるのは README contract が「map switch
   // を含む」と書いていることと整合させるため (#205 round 3 review high)。bridge 単独起動で
   // mapoi_server が居ない構成では `backend_ready=false` になるが、これは妥当な挙動。
+  // この AND は Nav2 bridge が `goal` / `route` / `switch_map` の 3 capability 全部を expose
+  // する前提に閉じた算出 (#207)。custom bridge は自前で expose する capability だけを AND
+  // すること (例: goal-only bridge なら `backend_ready = goal_ready`)。詳細は
+  // `mapoi_interfaces/msg/NavigationBackendStatus.msg` 冒頭コメント参照。
   const bool goal_ready =
     nav_to_pose_client_ && nav_to_pose_client_->action_server_is_ready();
   const bool route_ready =


### PR DESCRIPTION
## 背景

`NavigationBackendStatus` の `backend_ready` を bridge ごとに正しく算出してもらうためのドキュメント整備。PR #205 round 2 medium で cursor が指摘した「片機能 bridge で `backend_ready` が常に false 化する architectural 課題」を、msg 仕様変更ではなく **custom bridge 実装者向けの documentation 拡充** で解消する。

issue #207 で 3 案 (A: docs only / B: `required_capabilities` param / C: msg に `available_capabilities` 追加) を比較し、PR #212 で確立した「minimal 3 フィールド contract」精神に最も合致する **案 A** を採用。実装側に複雑度を持ち込まず、後から B/C への upgrade pass は残せる。

## 変更内容

| ファイル | 変更 |
|---|---|
| `mapoi_interfaces/msg/NavigationBackendStatus.msg` | 冒頭コメントに「How to populate `backend_ready` (custom bridge implementers)」section を追加。Nav2 bridge の AND ロジックを単純コピーすると片機能 bridge で `backend_ready` が永続 false になる落とし穴を明示し、goal-only / route-only / goal + map switch の populate 例を提示。`reason` の "not ready: ..., ..." 慣習表記も documentation。 |
| `mapoi_interfaces/README.md` | `NavigationBackendStatus.msg` 節を新設 (これまで msg 一覧から抜けていた)。3 フィールドの説明 table / QoS contract pointer / custom bridge ガイダンスを記載。 |
| `mapoi_server/src/mapoi_nav_server.cpp` | `publish_backend_status()` の comment に「この AND は Nav2 bridge が `goal` / `route` / `switch_map` の 3 capability 全部を expose する前提」と msg コメントへの pointer を追記。 |

**実コード / msg interface 定義は不変** (コメントと README のみ +48 行)。

## 案 A を選んだ根拠

1. PR #212 / #213 / #205 で確立した「minimal 3 フィールド contract」精神に合致 — 「3 フィールド populate するだけで統合可能」を docs で具体化するのが筋
2. mapoi に Nav2 bridge 1 つしかなく、Nav2 を片機能化する具体需要が現状無い (片機能 bridge は将来 user が自前 bridge を書く時の話)
3. 後から B/C への upgrade pass を阻害しない (msg 不変、param 追加余地あり)

## テスト

- 実コード変更なしのため build 影響なし
- msg interface 定義不変のため downstream 再生成不要

## 関連

- Close #207
- Addresses #205 round 2 medium (cursor review follow-up)
- 関連: #198 (元 issue) / #208 (QoS contract) / #212 (liveliness QoS PR) / #213 (callback group split) / #214 (#213 の PR)