### PR TITLE
lint: mapoi_interfaces docs/implementation 整合性チェック導入 (Close #216)

### DIFF
--- a/.github/workflows/consistency-check.yml
+++ b/.github/workflows/consistency-check.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Check sample mapoi_config.yaml consistency
         run: python3 scripts/check_sample_yaml_consistency.py
 
+      - name: Check mapoi_interfaces docs/implementation consistency
+        run: python3 scripts/check_docs_consistency.py
+
   webui_js_tests:
     runs-on: ubuntu-latest
     steps:

--- a/mapoi_interfaces/README.md
+++ b/mapoi_interfaces/README.md
@@ -91,6 +91,8 @@ publisher / subscriber 双方で以下を必ず指定:
 
 `reason` は operator UI に表示され bag や remote dashboard に記録され得るため、credentials / token / 絶対パス / 内部 hostname / IP / user identifier / stack trace 等の機微情報を含めないこと。capability 名と短い状態動詞 (例: `not ready: navigate_to_pose action`) に留める。
 
+> **CI lint の責務範囲** (`scripts/check_docs_consistency.py`、PR #217 / Close #216): static check は `publish_backend_status` 系関数中の **明示的な string literal** のみを走査する。パラメータ連結 (`reason = "ip=" + this->get_parameter(...).as_string()`) など動的に組み立てられる文字列、および raw string literal (`R"(...)"`) は責務外。lint 通過 ≠ 完全な redaction 保証。bridge 実装者は dynamic 部分にも本節の禁止事項を適用すること。
+
 ### LocalizationBackendStatus.msg
 
 Localization bridge (`mapoi_amcl_localization_bridge` / 自前 bridge) が 1 Hz で `mapoi/localization/backend_status` に publish する readiness メッセージ (#209)。UI 側は `backend_ready` を見て Initial Pose 操作を gate します。Navigation backend (上記 `NavigationBackendStatus`) とは独立した軸で、それぞれ別 indicator として扱います。

--- a/mapoi_interfaces/README.md
+++ b/mapoi_interfaces/README.md
@@ -40,6 +40,27 @@ POI tolerance.xy 半径への侵入・退出 / 停止 / 再開イベントを表
 | `poi` | `mapoi_interfaces/PointOfInterest` | 対象 POI の情報 |
 | `stamp` | `builtin_interfaces/Time` | イベント発生時刻 |
 
+### TagDefinition.msg
+
+POI 分類タグ (system tag / user tag) の単一定義を表すメッセージです。`GetTagDefinitions.srv` のレスポンス成分としても使えるよう PR #193 で導入されました。
+
+| フィールド | 型 | 説明 |
+| --- | --- | --- |
+| `name` | `string` | タグ名 (例: `goal`, `event`) |
+| `description` | `string` | タグ用途の human-readable 説明 |
+| `is_system` | `bool` | `true` = システムタグ、`false` = ユーザー定義タグ |
+
+### InitialPoseRequest.msg
+
+operator の map switch / reload に伴う「初期姿勢候補 POI」通知メッセージ (#149 round 8 で文字列ペアから型化)。`mapoi_nav_server` が Nav2 `LoadMap` 成功後に publish し、localization bridge 群が subscribe します。詳細・stale 排除戦略は `msg/InitialPoseRequest.msg` の冒頭コメント参照。
+
+| フィールド | 型 | 説明 |
+| --- | --- | --- |
+| `map_name` | `string` | 通知対象の map 名 (世代識別用、空文字は publisher 側で禁止) |
+| `poi_name` | `string` | 採用する POI 名 (空文字 = 「候補なし」、subscriber は無視) |
+
+QoS は `transient_local` (depth=1) で後起動 subscriber も latched 値を受信できます。
+
 ### NavigationBackendStatus.msg
 
 Navigation bridge (Nav2 bridge / 自前 bridge) が 1 Hz で `mapoi/nav/backend_status` に publish する readiness メッセージです。UI 側 (`mapoi_webui`, `mapoi_rviz_plugins`) は `backend_ready` を見て navigation 操作を gate します。
@@ -69,6 +90,18 @@ publisher / subscriber 双方で以下を必ず指定:
 具体例とフィールド populate 方針 (`reason` の慣習表記含む) は `msg/NavigationBackendStatus.msg` の冒頭コメントに記載。
 
 `reason` は operator UI に表示され bag や remote dashboard に記録され得るため、credentials / token / 絶対パス / 内部 hostname / IP / user identifier / stack trace 等の機微情報を含めないこと。capability 名と短い状態動詞 (例: `not ready: navigate_to_pose action`) に留める。
+
+### LocalizationBackendStatus.msg
+
+Localization bridge (`mapoi_amcl_localization_bridge` / 自前 bridge) が 1 Hz で `mapoi/localization/backend_status` に publish する readiness メッセージ (#209)。UI 側は `backend_ready` を見て Initial Pose 操作を gate します。Navigation backend (上記 `NavigationBackendStatus`) とは独立した軸で、それぞれ別 indicator として扱います。
+
+| フィールド | 型 | 説明 |
+| --- | --- | --- |
+| `backend_type` | `string` | bridge 識別子 (例: `amcl`, `slam_toolbox`, `custom_lidar_amcl`)。tooltip 表示用 |
+| `backend_ready` | `bool` | bridge が新しい initial pose を受け付け転送できる状態か |
+| `reason` | `string` | `backend_ready=false` 時の human-readable 理由 (任意、機微情報禁止 — `NavigationBackendStatus` の節と同方針) |
+
+QoS contract (TRANSIENT_LOCAL / RELIABLE / MANUAL_BY_TOPIC publisher / AUTOMATIC subscriber / 5s lease) は `NavigationBackendStatus` と同一です。詳細は `msg/LocalizationBackendStatus.msg` の冒頭コメント参照。
 
 ## サービス (srv)
 

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -62,9 +62,10 @@ BACKEND_STATUS_FUNCTIONS = (
 # 各 pattern は `(label, regex)` で、検出時は label を fail メッセージに出す。
 # false positive を避けるため、pattern は string literal 内のみに適用する
 # (関数本体の生 source ではなく、抽出した string literal token のみ走査)。
+_OCTET = r'(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)'
 FORBIDDEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
-    ('absolute path', re.compile(r'(?:^|[\s\'"`(])(/(?:home|etc|usr|var)/)')),
-    ('IP literal', re.compile(r'\b(?:\d{1,3}\.){3}\d{1,3}\b')),
+    ('absolute path', re.compile(r'(?:^|[\s\'"`(])(/(?:home|etc|usr|var|opt|root)/)')),
+    ('IP literal', re.compile(rf'\b{_OCTET}(?:\.{_OCTET}){{3}}\b')),
     ('credential keyword', re.compile(r'\b(?:password|secret|credential|api[_-]?key|token)\b', re.IGNORECASE)),
     ('internal hostname', re.compile(r'\b[a-z][a-z0-9-]*\.(?:local|lan|internal|corp)\b', re.IGNORECASE)),
 )
@@ -76,14 +77,29 @@ def parse_cmake_inventory() -> dict[str, list[str]]:
 
     返り値: ``{'msg': [...], 'srv': [...]}`` (basename のみ、拡張子なし)。
     """
-    text = INTERFACES_CMAKELISTS.read_text()
-    m = re.search(r'rosidl_generate_interfaces\s*\([^)]*?\)', text, re.DOTALL)
-    if not m:
+    text = INTERFACES_CMAKELISTS.read_text(errors='replace')
+    head = re.search(r'rosidl_generate_interfaces\s*\(', text)
+    if not head:
         raise SystemExit(
             f'ERROR: rosidl_generate_interfaces() block が見つかりません: '
             f'{INTERFACES_CMAKELISTS.relative_to(REPO_ROOT)}'
         )
-    block = m.group(0)
+    # `(` から対応する `)` まで括弧を数えて切り出す。`[^)]*?` の最短マッチでは
+    # nested 括弧があれば途中で閉じてしまうので、明示的にカウントする。
+    depth = 1
+    i = head.end()
+    while i < len(text) and depth > 0:
+        if text[i] == '(':
+            depth += 1
+        elif text[i] == ')':
+            depth -= 1
+        i += 1
+    if depth != 0:
+        raise SystemExit(
+            f'ERROR: rosidl_generate_interfaces() の対応 ) が見つかりません: '
+            f'{INTERFACES_CMAKELISTS.relative_to(REPO_ROOT)}'
+        )
+    block = text[head.start():i]
     inventory: dict[str, list[str]] = {'msg': [], 'srv': []}
     # "msg/Foo.msg" / "srv/Bar.srv" のみ抽出 (DEPENDENCIES 等は無視)。
     for kind, name in re.findall(r'"(msg|srv)/([A-Za-z0-9_]+)\.(?:msg|srv)"', block):
@@ -100,7 +116,7 @@ def check_readme_section_presence(inventory: dict[str, list[str]]) -> list[str]:
     if not INTERFACES_README.exists():
         return [f'{INTERFACES_README.relative_to(REPO_ROOT)} が存在しません']
 
-    readme_text = INTERFACES_README.read_text()
+    readme_text = INTERFACES_README.read_text(errors='replace')
     # `### Foo.msg` / `### Foo.srv` パターン
     found_sections: set[str] = set()
     for m in re.finditer(r'^###\s+([A-Za-z0-9_]+)\.(msg|srv)\s*$', readme_text, re.MULTILINE):
@@ -152,70 +168,179 @@ def collect_scan_targets() -> list[Path]:
 
 
 def check_cross_references(targets: list[Path]) -> list[str]:
-    """走査対象内の `mapoi_interfaces/(msg|srv)/X.(msg|srv)` 参照が実在するか確認する。"""
+    """走査対象内の `mapoi_interfaces/(msg|srv)/X.(msg|srv)` 参照が実在するか確認する。
+
+    `re.DOTALL` 相当のテキスト全体スキャンで、Markdown の折り返しや C++ の
+    複数行コメントで参照が分割表記されたケースにも追従する。
+    """
     issues: list[str] = []
     pattern = re.compile(r'mapoi_interfaces/(msg|srv)/([A-Za-z0-9_]+)\.(msg|srv)')
     for path in targets:
         text = path.read_text(errors='replace')
-        for lineno, line in enumerate(text.splitlines(), start=1):
-            for m in pattern.finditer(line):
-                kind, name, ext = m.group(1), m.group(2), m.group(3)
-                if kind != ext:
-                    issues.append(
-                        f'{path.relative_to(REPO_ROOT)}:{lineno}: '
-                        f'kind 不一致 ({kind}/{name}.{ext})'
-                    )
-                    continue
-                target = INTERFACES_PKG / kind / f'{name}.{ext}'
-                if not target.exists():
-                    issues.append(
-                        f'{path.relative_to(REPO_ROOT)}:{lineno}: '
-                        f'参照先不在 `{m.group(0)}` -> {target.relative_to(REPO_ROOT)}'
-                    )
+        for m in pattern.finditer(text):
+            kind, name, ext = m.group(1), m.group(2), m.group(3)
+            lineno = text.count('\n', 0, m.start()) + 1
+            if kind != ext:
+                issues.append(
+                    f'{path.relative_to(REPO_ROOT)}:{lineno}: '
+                    f'kind 不一致 ({kind}/{name}.{ext})'
+                )
+                continue
+            target = INTERFACES_PKG / kind / f'{name}.{ext}'
+            if not target.exists():
+                issues.append(
+                    f'{path.relative_to(REPO_ROOT)}:{lineno}: '
+                    f'参照先不在 `{m.group(0)}` -> {target.relative_to(REPO_ROOT)}'
+                )
     return issues
+
+
+def _strip_cpp_comments(text: str) -> str:
+    """C++ コメント (`// ...` / `/* ... */`) を空白に置換する。
+
+    string literal 内の `//` `/*` を誤って削らないよう、文字列状態を track する。
+    改行は保持する (行番号情報を残すため)。
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_string = False
+    in_char = False
+    in_line_comment = False
+    in_block_comment = False
+    escape = False
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ''
+        if in_line_comment:
+            if ch == '\n':
+                in_line_comment = False
+                out.append(ch)
+            else:
+                out.append(' ')
+            i += 1
+            continue
+        if in_block_comment:
+            if ch == '*' and nxt == '/':
+                in_block_comment = False
+                out.extend(['  '])
+                i += 2
+                continue
+            out.append('\n' if ch == '\n' else ' ')
+            i += 1
+            continue
+        if in_string:
+            if escape:
+                escape = False
+                out.append(ch)
+            elif ch == '\\':
+                escape = True
+                out.append(ch)
+            elif ch == '"':
+                in_string = False
+                out.append(ch)
+            else:
+                out.append(ch)
+            i += 1
+            continue
+        if in_char:
+            if escape:
+                escape = False
+                out.append(ch)
+            elif ch == '\\':
+                escape = True
+                out.append(ch)
+            elif ch == "'":
+                in_char = False
+                out.append(ch)
+            else:
+                out.append(ch)
+            i += 1
+            continue
+        if ch == '/' and nxt == '/':
+            in_line_comment = True
+            out.extend(['  '])
+            i += 2
+            continue
+        if ch == '/' and nxt == '*':
+            in_block_comment = True
+            out.extend(['  '])
+            i += 2
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "'":
+            in_char = True
+            out.append(ch)
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return ''.join(out)
 
 
 def extract_function_body(text: str, func_name: str) -> tuple[int, str] | None:
     """C++ ソースから ``func_name`` の関数本体を抽出する。
 
     ``Foo::func_name`` / ``ReturnType func_name`` のいずれの定義形式にも対応する
-    ため、関数名 + 開き ``{`` の組を起点に対応 brace を数える。
+    ため、関数名 + 引数 list を経た後、宣言終端 ``;`` か関数本体開始 ``{`` の
+    どちらが先に出現するかを判定する。``)`` と ``{`` の間に ``const`` /
+    ``noexcept`` / ``-> ReturnType`` / 属性 / 改行 / コメントが挟まる定義に追従する。
+
+    実装: ``)`` から先頭非空白を見て ``;`` なら宣言なのでスキップ、それ以外なら
+    次の ``{`` を関数本体開始として扱う (= modifier 群を読み飛ばす)。コメントは
+    ``_strip_cpp_comments`` で先に除去してあるので modifier の同定が単純化される。
 
     返り値: ``(行番号 (開始 brace), 本体文字列)`` または None。
     """
-    # 関数定義の「名前」部分を見つける (引数 list を経て `)` の後の `{` まで)。
-    # 簡易: `func_name\s*\(` を探し、対応する `)` を見つけ、その後の最初の `{` から
-    # 対応 brace まで抽出する。
-    for name_match in re.finditer(rf'\b{re.escape(func_name)}\s*\(', text):
+    cleaned = _strip_cpp_comments(text)
+    n = len(cleaned)
+    for name_match in re.finditer(rf'\b{re.escape(func_name)}\s*\(', cleaned):
         start_paren = name_match.end() - 1
         depth = 1
         i = start_paren + 1
-        while i < len(text) and depth > 0:
-            if text[i] == '(':
+        while i < n and depth > 0:
+            if cleaned[i] == '(':
                 depth += 1
-            elif text[i] == ')':
+            elif cleaned[i] == ')':
                 depth -= 1
             i += 1
         if depth != 0:
             continue
-        # i は `)` の次。次の `{` を探す。
-        # ただし宣言だけ (i.e. 後続が `;`) ならスキップ。
-        rest = text[i:].lstrip()
-        if not rest or rest[0] != '{':
-            continue
-        body_start = text.index('{', i)
-        depth = 1
-        j = body_start + 1
-        while j < len(text) and depth > 0:
-            if text[j] == '{':
-                depth += 1
-            elif text[j] == '}':
-                depth -= 1
+        # i は `)` の次。次に出現するのが `{` (= 関数定義) か `;` (= 宣言) かを
+        # ``const`` / ``noexcept`` / ``-> ReturnType`` / 属性等を読み飛ばしながら判定する。
+        body_start = -1
+        is_declaration = False
+        j = i
+        while j < n:
+            ch = cleaned[j]
+            if ch == '{':
+                body_start = j
+                break
+            if ch == ';':
+                is_declaration = True
+                break
             j += 1
+        if is_declaration or body_start < 0:
+            continue
+        depth = 1
+        k = body_start + 1
+        while k < n and depth > 0:
+            if cleaned[k] == '{':
+                depth += 1
+            elif cleaned[k] == '}':
+                depth -= 1
+            k += 1
         if depth != 0:
             continue
-        body_lineno = text.count('\n', 0, body_start) + 1
-        return (body_lineno, text[body_start + 1:j - 1])
+        body_lineno = cleaned.count('\n', 0, body_start) + 1
+        # 本体抽出は cleaned から切り出す (コメント除去済み = 後続の reason 抽出も
+        # コメント混入の影響を受けない)。行番号は元 text と cleaned で一致する
+        # (改行は保存しているため)。
+        return (body_lineno, cleaned[body_start + 1:k - 1])
     return None
 
 

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -64,7 +64,8 @@ BACKEND_STATUS_FUNCTIONS = (
 # (関数本体の生 source ではなく、抽出した string literal token のみ走査)。
 _OCTET = r'(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)'
 FORBIDDEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
-    ('absolute path', re.compile(r'(?:^|[\s\'"`(])(/(?:home|etc|usr|var|opt|root)/)')),
+    ('absolute path', re.compile(
+        r'(?:^|[\s\'"`(])(/(?:home|etc|usr|var|opt|root|tmp|srv|mnt|media)/)')),
     ('IP literal', re.compile(rf'\b{_OCTET}(?:\.{_OCTET}){{3}}\b')),
     ('credential keyword', re.compile(r'\b(?:password|secret|credential|api[_-]?key|token)\b', re.IGNORECASE)),
     ('internal hostname', re.compile(r'\b[a-z][a-z0-9-]*\.(?:local|lan|internal|corp)\b', re.IGNORECASE)),
@@ -100,9 +101,12 @@ def parse_cmake_inventory() -> dict[str, list[str]]:
             f'{INTERFACES_CMAKELISTS.relative_to(REPO_ROOT)}'
         )
     block = text[head.start():i]
+    # CMake のコメント (`#` 行末まで) を除去。コメントアウトされた `# "msg/Old.msg"`
+    # を inventory に拾い、偽の README 節欠落を出すのを防ぐ。
+    block_no_comments = re.sub(r'#[^\n]*', '', block)
     inventory: dict[str, list[str]] = {'msg': [], 'srv': []}
     # "msg/Foo.msg" / "srv/Bar.srv" のみ抽出 (DEPENDENCIES 等は無視)。
-    for kind, name in re.findall(r'"(msg|srv)/([A-Za-z0-9_]+)\.(?:msg|srv)"', block):
+    for kind, name in re.findall(r'"(msg|srv)/([A-Za-z0-9_]+)\.(?:msg|srv)"', block_no_comments):
         inventory[kind].append(name)
     return inventory
 
@@ -396,25 +400,25 @@ def check_reason_redaction(targets: list[Path]) -> list[str]:
     を抽出し、FORBIDDEN_PATTERNS のいずれかにマッチしたら fail。
 
     関数 overload / 多重定義は全件走査する。raw string literal (`R"(...)"` /
-    `R"delim(...)delim"`) を含む関数は現実装の simple scanner で誤抽出するため、
-    検出時はその関数本体を skip し、代わりに警告として issue を返す
-    (誤抽出より「lint が効いていないことを露わにする」方が安全側)。
+    `R"delim(...)delim"`) を含むファイルは ``_strip_cpp_comments`` /
+    ``extract_function_bodies`` の brace counting が破綻しうるため、ファイル
+    全体を skip して警告 issue を出す (= 誤抽出して「lint OK」を出すより、
+    lint が効いていない事実を露わにする方が安全側)。
     """
     issues: list[str] = []
     cpp_targets = [p for p in targets if p.suffix in ('.cpp', '.hpp')]
     raw_string_pattern = re.compile(r'\bR"[^(]*\(')
     for path in cpp_targets:
         text = path.read_text(errors='replace')
+        if raw_string_pattern.search(text):
+            issues.append(
+                f'{path.relative_to(REPO_ROOT)}: ファイルに raw string literal '
+                f'(`R"(...)"`) を検出 — redaction lint は raw string 非対応のため '
+                f'scope 外。通常の `"..."` literal で書き直すか、follow-up issue 化を検討'
+            )
+            continue
         for func_name in BACKEND_STATUS_FUNCTIONS:
             for body_lineno, body in extract_function_bodies(text, func_name):
-                if raw_string_pattern.search(body):
-                    issues.append(
-                        f'{path.relative_to(REPO_ROOT)}:{body_lineno}: '
-                        f'`{func_name}` body に raw string literal を検出 — '
-                        f'redaction lint は raw string 非対応のため scope 外。'
-                        f'通常の `"..."` literal で書き直すか、follow-up issue 化を検討'
-                    )
-                    continue
                 literals = extract_reason_string_literals(body)
                 for lineno_in_body, literal in literals:
                     abs_lineno = body_lineno + lineno_in_body - 1

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""mapoi_interfaces の docs ↔ implementation 整合性 lint (#216)。
+
+PR #215 (Close #207) で `mapoi_interfaces/msg/NavigationBackendStatus.msg` /
+`mapoi_interfaces/README.md` / `mapoi_server/src/mapoi_nav_server.cpp` の 3
+ファイル間に pointer ベースの cross-reference を貼った (custom bridge 向け
+`backend_ready` 算出ガイダンス + `reason` 機微情報 redaction 指針)。一次情報を
+msg コメントに集約して README / cpp は msg を pointer する設計だが、片方だけ
+更新されると pointer が orphan 化し、custom bridge 実装者を誤誘導する。
+
+CI で本 script を回し、以下を検知する:
+
+1. README 節 presence: `mapoi_interfaces/CMakeLists.txt` の
+   `rosidl_generate_interfaces(...)` に列挙された `.msg` / `.srv` 全件について、
+   `mapoi_interfaces/README.md` に `### {Name}.{ext}` 節があるか。逆向きの orphan
+   節 (README にあるが CMakeLists にない) も検出する。
+
+2. Cross-reference 存在検証: 走査対象内の
+   `mapoi_interfaces/(msg|srv)/X.(msg|srv)` 参照について、相手ファイルが実在するか
+   確認する。
+
+3. `reason` 文字列の機微情報 redaction static check: C++ ソース中の
+   `publish_backend_status` 系関数本体から `reason = "..."` / `reason += "..."`
+   の文字列リテラル成分のみ抽出し、絶対パス / IP リテラル / 機密語 / hostname
+   らしき literal を含まないか確認する (パラメータ連結 `+ this->get_parameter(...)`
+   等の dynamic 部分は対象外)。
+
+設計方針:
+
+- (1)(2) は CMakeLists の inventory ベースで自動展開され、新 msg / srv 追加時の
+  README 節欠落も検知される。LocalizationBackendStatus (#209) など contract msg
+  の追加にも追従する。
+- (3) は `BACKEND_STATUS_FUNCTIONS` で対象関数名を持ち、bridge 追加時にここを
+  更新するだけで済む。
+
+使い方::
+    python3 scripts/check_docs_consistency.py
+
+Exit codes:
+- 0: OK
+- 1: 整合性違反を検出
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INTERFACES_PKG = REPO_ROOT / 'mapoi_interfaces'
+INTERFACES_README = INTERFACES_PKG / 'README.md'
+INTERFACES_CMAKELISTS = INTERFACES_PKG / 'CMakeLists.txt'
+
+# `reason` redaction static check の対象関数 (#216 (3))。
+# bridge 増加時はここに追加する。関数名のみで file path 非依存にすることで、
+# 関数を別 file に移しても follow できる。
+BACKEND_STATUS_FUNCTIONS = (
+    'publish_backend_status',
+)
+
+# `reason` 文字列リテラルに含まれてはいけない pattern。
+# 各 pattern は `(label, regex)` で、検出時は label を fail メッセージに出す。
+# false positive を避けるため、pattern は string literal 内のみに適用する
+# (関数本体の生 source ではなく、抽出した string literal token のみ走査)。
+FORBIDDEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ('absolute path', re.compile(r'(?:^|[\s\'"`(])(/(?:home|etc|usr|var)/)')),
+    ('IP literal', re.compile(r'\b(?:\d{1,3}\.){3}\d{1,3}\b')),
+    ('credential keyword', re.compile(r'\b(?:password|secret|credential|api[_-]?key|token)\b', re.IGNORECASE)),
+    ('internal hostname', re.compile(r'\b[a-z][a-z0-9-]*\.(?:local|lan|internal|corp)\b', re.IGNORECASE)),
+)
+
+
+def parse_cmake_inventory() -> dict[str, list[str]]:
+    """`mapoi_interfaces/CMakeLists.txt` の `rosidl_generate_interfaces(...)` から
+    msg / srv の inventory を抽出する。
+
+    返り値: ``{'msg': [...], 'srv': [...]}`` (basename のみ、拡張子なし)。
+    """
+    text = INTERFACES_CMAKELISTS.read_text()
+    m = re.search(r'rosidl_generate_interfaces\s*\([^)]*?\)', text, re.DOTALL)
+    if not m:
+        raise SystemExit(
+            f'ERROR: rosidl_generate_interfaces() block が見つかりません: '
+            f'{INTERFACES_CMAKELISTS.relative_to(REPO_ROOT)}'
+        )
+    block = m.group(0)
+    inventory: dict[str, list[str]] = {'msg': [], 'srv': []}
+    # "msg/Foo.msg" / "srv/Bar.srv" のみ抽出 (DEPENDENCIES 等は無視)。
+    for kind, name in re.findall(r'"(msg|srv)/([A-Za-z0-9_]+)\.(?:msg|srv)"', block):
+        inventory[kind].append(name)
+    return inventory
+
+
+def check_readme_section_presence(inventory: dict[str, list[str]]) -> list[str]:
+    """README に各 msg/srv の `### {Name}.{ext}` 節があるか確認する。
+
+    逆向き orphan (README にあるが CMakeLists にない) も検出する。
+    """
+    issues: list[str] = []
+    if not INTERFACES_README.exists():
+        return [f'{INTERFACES_README.relative_to(REPO_ROOT)} が存在しません']
+
+    readme_text = INTERFACES_README.read_text()
+    # `### Foo.msg` / `### Foo.srv` パターン
+    found_sections: set[str] = set()
+    for m in re.finditer(r'^###\s+([A-Za-z0-9_]+)\.(msg|srv)\s*$', readme_text, re.MULTILINE):
+        found_sections.add(f'{m.group(1)}.{m.group(2)}')
+
+    expected: set[str] = set()
+    for kind, names in inventory.items():
+        for n in names:
+            expected.add(f'{n}.{kind}')
+
+    missing = expected - found_sections
+    orphan = found_sections - expected
+
+    for name in sorted(missing):
+        issues.append(
+            f'README 節欠落: `### {name}` が '
+            f'{INTERFACES_README.relative_to(REPO_ROOT)} にない '
+            f'(CMakeLists には登録済み)'
+        )
+    for name in sorted(orphan):
+        issues.append(
+            f'README orphan 節: `### {name}` が '
+            f'{INTERFACES_README.relative_to(REPO_ROOT)} にあるが '
+            f'CMakeLists.txt に対応 .msg/.srv が無い'
+        )
+    return issues
+
+
+def collect_scan_targets() -> list[Path]:
+    """cross-reference 検証で走査するファイル一覧を返す。
+
+    対象: mapoi_interfaces 配下の `.msg` / `.srv` / README、および BACKEND_STATUS_FUNCTIONS
+    のいずれかを含む `.cpp` / `.hpp`。
+    """
+    targets: list[Path] = []
+    targets.append(INTERFACES_README)
+    targets.extend(sorted((INTERFACES_PKG / 'msg').glob('*.msg')))
+    targets.extend(sorted((INTERFACES_PKG / 'srv').glob('*.srv')))
+    for ext in ('cpp', 'hpp'):
+        for p in REPO_ROOT.rglob(f'*.{ext}'):
+            # build / install / log 配下は除外
+            rel = p.relative_to(REPO_ROOT).parts
+            if rel and rel[0] in ('build', 'install', 'log', '.git'):
+                continue
+            text = p.read_text(errors='replace')
+            if any(fn in text for fn in BACKEND_STATUS_FUNCTIONS):
+                targets.append(p)
+    return targets
+
+
+def check_cross_references(targets: list[Path]) -> list[str]:
+    """走査対象内の `mapoi_interfaces/(msg|srv)/X.(msg|srv)` 参照が実在するか確認する。"""
+    issues: list[str] = []
+    pattern = re.compile(r'mapoi_interfaces/(msg|srv)/([A-Za-z0-9_]+)\.(msg|srv)')
+    for path in targets:
+        text = path.read_text(errors='replace')
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for m in pattern.finditer(line):
+                kind, name, ext = m.group(1), m.group(2), m.group(3)
+                if kind != ext:
+                    issues.append(
+                        f'{path.relative_to(REPO_ROOT)}:{lineno}: '
+                        f'kind 不一致 ({kind}/{name}.{ext})'
+                    )
+                    continue
+                target = INTERFACES_PKG / kind / f'{name}.{ext}'
+                if not target.exists():
+                    issues.append(
+                        f'{path.relative_to(REPO_ROOT)}:{lineno}: '
+                        f'参照先不在 `{m.group(0)}` -> {target.relative_to(REPO_ROOT)}'
+                    )
+    return issues
+
+
+def extract_function_body(text: str, func_name: str) -> tuple[int, str] | None:
+    """C++ ソースから ``func_name`` の関数本体を抽出する。
+
+    ``Foo::func_name`` / ``ReturnType func_name`` のいずれの定義形式にも対応する
+    ため、関数名 + 開き ``{`` の組を起点に対応 brace を数える。
+
+    返り値: ``(行番号 (開始 brace), 本体文字列)`` または None。
+    """
+    # 関数定義の「名前」部分を見つける (引数 list を経て `)` の後の `{` まで)。
+    # 簡易: `func_name\s*\(` を探し、対応する `)` を見つけ、その後の最初の `{` から
+    # 対応 brace まで抽出する。
+    for name_match in re.finditer(rf'\b{re.escape(func_name)}\s*\(', text):
+        start_paren = name_match.end() - 1
+        depth = 1
+        i = start_paren + 1
+        while i < len(text) and depth > 0:
+            if text[i] == '(':
+                depth += 1
+            elif text[i] == ')':
+                depth -= 1
+            i += 1
+        if depth != 0:
+            continue
+        # i は `)` の次。次の `{` を探す。
+        # ただし宣言だけ (i.e. 後続が `;`) ならスキップ。
+        rest = text[i:].lstrip()
+        if not rest or rest[0] != '{':
+            continue
+        body_start = text.index('{', i)
+        depth = 1
+        j = body_start + 1
+        while j < len(text) and depth > 0:
+            if text[j] == '{':
+                depth += 1
+            elif text[j] == '}':
+                depth -= 1
+            j += 1
+        if depth != 0:
+            continue
+        body_lineno = text.count('\n', 0, body_start) + 1
+        return (body_lineno, text[body_start + 1:j - 1])
+    return None
+
+
+def extract_reason_string_literals(body: str) -> list[tuple[int, str]]:
+    """関数本体から ``reason = "..."`` / ``reason += "..."`` / ``reason +=`` 連鎖の
+    string literal 成分を抽出する。
+
+    パラメータ連結 (``+ this->get_parameter(...).as_string()``) の動的部分は
+    対象外で、明示的な文字列リテラルのみを返す。
+    """
+    literals: list[tuple[int, str]] = []
+    # `(.+?\.)?reason\s*(=|\+=)` で始まる statement を捕まえ、その statement 全体
+    # (次の `;` まで) を取得して string literal を切り出す。
+    for stmt_match in re.finditer(r'(?:(?:[A-Za-z_][A-Za-z0-9_]*\.)?reason)\s*(?:=|\+=)', body):
+        start = stmt_match.start()
+        # statement 終端 (`;`) を探す。string literal 内の `;` を避けるため簡易 scanner。
+        i = stmt_match.end()
+        in_string = False
+        escape = False
+        end = -1
+        while i < len(body):
+            ch = body[i]
+            if in_string:
+                if escape:
+                    escape = False
+                elif ch == '\\':
+                    escape = True
+                elif ch == '"':
+                    in_string = False
+            else:
+                if ch == '"':
+                    in_string = True
+                elif ch == ';':
+                    end = i
+                    break
+            i += 1
+        if end < 0:
+            continue
+        statement = body[start:end]
+        # statement 内の `"..."` literal を抽出 (escape 対応)。
+        for s_match in re.finditer(r'"((?:[^"\\]|\\.)*)"', statement):
+            lineno_in_body = body.count('\n', 0, start + s_match.start()) + 1
+            literals.append((lineno_in_body, s_match.group(1)))
+    return literals
+
+
+def check_reason_redaction(targets: list[Path]) -> list[str]:
+    """C++ ソースの BACKEND_STATUS_FUNCTIONS 関数本体から `reason` 文字列リテラル
+    を抽出し、FORBIDDEN_PATTERNS のいずれかにマッチしたら fail。"""
+    issues: list[str] = []
+    cpp_targets = [p for p in targets if p.suffix in ('.cpp', '.hpp')]
+    for path in cpp_targets:
+        text = path.read_text(errors='replace')
+        for func_name in BACKEND_STATUS_FUNCTIONS:
+            extracted = extract_function_body(text, func_name)
+            if extracted is None:
+                continue
+            body_lineno, body = extracted
+            literals = extract_reason_string_literals(body)
+            for lineno_in_body, literal in literals:
+                abs_lineno = body_lineno + lineno_in_body - 1
+                for label, pattern in FORBIDDEN_PATTERNS:
+                    m = pattern.search(literal)
+                    if m:
+                        issues.append(
+                            f'{path.relative_to(REPO_ROOT)}:{abs_lineno}: '
+                            f'`{func_name}` の reason に {label} 検出 '
+                            f'(matched: {m.group(0)!r}, literal: {literal!r})'
+                        )
+    return issues
+
+
+def main() -> int:
+    if not INTERFACES_PKG.is_dir():
+        print(f'ERROR: {INTERFACES_PKG} が存在しません', file=sys.stderr)
+        return 1
+
+    inventory = parse_cmake_inventory()
+    targets = collect_scan_targets()
+
+    all_issues: list[tuple[str, list[str]]] = [
+        ('README section presence', check_readme_section_presence(inventory)),
+        ('cross-reference integrity', check_cross_references(targets)),
+        ('reason redaction (sensitive info)', check_reason_redaction(targets)),
+    ]
+
+    failed = False
+    for label, issues in all_issues:
+        if issues:
+            failed = True
+            print(f'[FAIL] {label}', file=sys.stderr)
+            for i in issues:
+                print(f'  - {i}', file=sys.stderr)
+        else:
+            print(f'[OK]   {label}')
+
+    if failed:
+        return 1
+
+    msg_count = len(inventory['msg'])
+    srv_count = len(inventory['srv'])
+    cpp_count = sum(1 for p in targets if p.suffix in ('.cpp', '.hpp'))
+    print(
+        f'OK: mapoi_interfaces docs/implementation 整合性 OK '
+        f'(msg={msg_count}, srv={srv_count}, scanned cpp={cpp_count})'
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -282,20 +282,22 @@ def _strip_cpp_comments(text: str) -> str:
     return ''.join(out)
 
 
-def extract_function_body(text: str, func_name: str) -> tuple[int, str] | None:
-    """C++ ソースから ``func_name`` の関数本体を抽出する。
+def extract_function_bodies(text: str, func_name: str) -> list[tuple[int, str]]:
+    """C++ ソースから ``func_name`` の **全ての** 関数本体を抽出する。
 
-    ``Foo::func_name`` / ``ReturnType func_name`` のいずれの定義形式にも対応する
-    ため、関数名 + 引数 list を経た後、宣言終端 ``;`` か関数本体開始 ``{`` の
-    どちらが先に出現するかを判定する。``)`` と ``{`` の間に ``const`` /
-    ``noexcept`` / ``-> ReturnType`` / 属性 / 改行 / コメントが挟まる定義に追従する。
+    overload や同 file 内の多重定義に追従するため list を返す。``Foo::func_name`` /
+    ``ReturnType func_name`` のいずれの定義形式にも対応するため、関数名 +
+    引数 list を経た後、宣言終端 ``;`` か関数本体開始 ``{`` のどちらが先に出現
+    するかを判定する。``)`` と ``{`` の間に ``const`` / ``noexcept`` /
+    ``-> ReturnType`` / 属性 / 改行 / コメントが挟まる定義に追従する。
 
     実装: ``)`` から先頭非空白を見て ``;`` なら宣言なのでスキップ、それ以外なら
     次の ``{`` を関数本体開始として扱う (= modifier 群を読み飛ばす)。コメントは
     ``_strip_cpp_comments`` で先に除去してあるので modifier の同定が単純化される。
 
-    返り値: ``(行番号 (開始 brace), 本体文字列)`` または None。
+    返り値: 各定義について ``(行番号 (開始 brace), 本体文字列)`` の list。
     """
+    bodies: list[tuple[int, str]] = []
     cleaned = _strip_cpp_comments(text)
     n = len(cleaned)
     for name_match in re.finditer(rf'\b{re.escape(func_name)}\s*\(', cleaned):
@@ -310,8 +312,6 @@ def extract_function_body(text: str, func_name: str) -> tuple[int, str] | None:
             i += 1
         if depth != 0:
             continue
-        # i は `)` の次。次に出現するのが `{` (= 関数定義) か `;` (= 宣言) かを
-        # ``const`` / ``noexcept`` / ``-> ReturnType`` / 属性等を読み飛ばしながら判定する。
         body_start = -1
         is_declaration = False
         j = i
@@ -337,11 +337,8 @@ def extract_function_body(text: str, func_name: str) -> tuple[int, str] | None:
         if depth != 0:
             continue
         body_lineno = cleaned.count('\n', 0, body_start) + 1
-        # 本体抽出は cleaned から切り出す (コメント除去済み = 後続の reason 抽出も
-        # コメント混入の影響を受けない)。行番号は元 text と cleaned で一致する
-        # (改行は保存しているため)。
-        return (body_lineno, cleaned[body_start + 1:k - 1])
-    return None
+        bodies.append((body_lineno, cleaned[body_start + 1:k - 1]))
+    return bodies
 
 
 def extract_reason_string_literals(body: str) -> list[tuple[int, str]]:
@@ -350,11 +347,18 @@ def extract_reason_string_literals(body: str) -> list[tuple[int, str]]:
 
     パラメータ連結 (``+ this->get_parameter(...).as_string()``) の動的部分は
     対象外で、明示的な文字列リテラルのみを返す。
+
+    左辺は ``reason`` という識別子そのもの (word boundary 厳守、`my_reason` 等の
+    類似識別子に巻き込まれない)、または ``foo.reason`` / ``ptr->reason`` /
+    ``a.b.c.reason`` のような member 連鎖を許容する。pointer dereference (`->`)
+    を見落とすと redaction (security) が抜け落ちるため明示対応する。
     """
     literals: list[tuple[int, str]] = []
-    # `(.+?\.)?reason\s*(=|\+=)` で始まる statement を捕まえ、その statement 全体
-    # (次の `;` まで) を取得して string literal を切り出す。
-    for stmt_match in re.finditer(r'(?:(?:[A-Za-z_][A-Za-z0-9_]*\.)?reason)\s*(?:=|\+=)', body):
+    # `(?:[A-Za-z_][A-Za-z0-9_]*(?:\.|->))*reason\b\s*(=|+=)` で始まる statement を
+    # 捕まえ、その statement 全体 (次の `;` まで) を取得して string literal を
+    # 切り出す。
+    for stmt_match in re.finditer(
+        r'\b(?:[A-Za-z_][A-Za-z0-9_]*(?:\.|->))*reason\b\s*(?:=|\+=)', body):
         start = stmt_match.start()
         # statement 終端 (`;`) を探す。string literal 内の `;` を避けるため簡易 scanner。
         i = stmt_match.end()
@@ -389,27 +393,39 @@ def extract_reason_string_literals(body: str) -> list[tuple[int, str]]:
 
 def check_reason_redaction(targets: list[Path]) -> list[str]:
     """C++ ソースの BACKEND_STATUS_FUNCTIONS 関数本体から `reason` 文字列リテラル
-    を抽出し、FORBIDDEN_PATTERNS のいずれかにマッチしたら fail。"""
+    を抽出し、FORBIDDEN_PATTERNS のいずれかにマッチしたら fail。
+
+    関数 overload / 多重定義は全件走査する。raw string literal (`R"(...)"` /
+    `R"delim(...)delim"`) を含む関数は現実装の simple scanner で誤抽出するため、
+    検出時はその関数本体を skip し、代わりに警告として issue を返す
+    (誤抽出より「lint が効いていないことを露わにする」方が安全側)。
+    """
     issues: list[str] = []
     cpp_targets = [p for p in targets if p.suffix in ('.cpp', '.hpp')]
+    raw_string_pattern = re.compile(r'\bR"[^(]*\(')
     for path in cpp_targets:
         text = path.read_text(errors='replace')
         for func_name in BACKEND_STATUS_FUNCTIONS:
-            extracted = extract_function_body(text, func_name)
-            if extracted is None:
-                continue
-            body_lineno, body = extracted
-            literals = extract_reason_string_literals(body)
-            for lineno_in_body, literal in literals:
-                abs_lineno = body_lineno + lineno_in_body - 1
-                for label, pattern in FORBIDDEN_PATTERNS:
-                    m = pattern.search(literal)
-                    if m:
-                        issues.append(
-                            f'{path.relative_to(REPO_ROOT)}:{abs_lineno}: '
-                            f'`{func_name}` の reason に {label} 検出 '
-                            f'(matched: {m.group(0)!r}, literal: {literal!r})'
-                        )
+            for body_lineno, body in extract_function_bodies(text, func_name):
+                if raw_string_pattern.search(body):
+                    issues.append(
+                        f'{path.relative_to(REPO_ROOT)}:{body_lineno}: '
+                        f'`{func_name}` body に raw string literal を検出 — '
+                        f'redaction lint は raw string 非対応のため scope 外。'
+                        f'通常の `"..."` literal で書き直すか、follow-up issue 化を検討'
+                    )
+                    continue
+                literals = extract_reason_string_literals(body)
+                for lineno_in_body, literal in literals:
+                    abs_lineno = body_lineno + lineno_in_body - 1
+                    for label, pattern in FORBIDDEN_PATTERNS:
+                        m = pattern.search(literal)
+                        if m:
+                            issues.append(
+                                f'{path.relative_to(REPO_ROOT)}:{abs_lineno}: '
+                                f'`{func_name}` の reason に {label} 検出 '
+                                f'(matched: {m.group(0)!r}, literal: {literal!r})'
+                            )
     return issues
 
 


### PR DESCRIPTION
## Summary

- `scripts/check_docs_consistency.py` を追加。CI (\`.github/workflows/consistency-check.yml\` 既存 \`robot_radius_drift\` job) に step として組み込み、PR #215 で導入した「msg コメント (一次情報) / README / cpp の pointer 関係」が片側更新で orphan 化することを 3 chunk で検知する。
- 副次効果: 稼働した瞬間に既存の README drift を 3 件検知 → 同 PR で解消 (\`TagDefinition\` / \`InitialPoseRequest\` / \`LocalizationBackendStatus\` の節を追加)。lint の即時 PoC 効果あり。

## Background

Close #216。PR #215 (Close #207) で 3 ファイル間に pointer ベースの cross-reference を貼った経緯から、cursor review (round 1 low #1 / round 2 low #1) と codex sanity の双方が「lint 自動検知が望ましい」と同意。priority: low。

## Checks 内訳

| # | 名前 | 内容 |
|---|---|---|
| 1 | README section presence | \`mapoi_interfaces/CMakeLists.txt\` の \`rosidl_generate_interfaces(...)\` に列挙された全 .msg / .srv について、\`mapoi_interfaces/README.md\` に \`### {Name}.{ext}\` 節があるか。逆向きの orphan 節も検出 |
| 2 | Cross-reference integrity | \`.msg\` / \`.srv\` / \`mapoi_interfaces/README.md\` / \`publish_backend_status\` を含む \`.cpp\` 内の \`mapoi_interfaces/(msg\|srv)/X.(msg\|srv)\` pointer の参照先実在検証 |
| 3 | reason redaction | C++ ソース中の \`publish_backend_status\` 系関数本体から \`reason = "..."\` / \`reason += "..."\` の文字列リテラル成分を抽出し、絶対パス (\`/home/\` \`/etc/\` \`/usr/\` \`/var/\`) / IP リテラル / 機密語 (password / secret / credential / api_key / token) / hostname-looking literal を含まないか |

## 設計方針

- (1)(2) は CMakeLists の inventory ベースで自動展開され、新 msg / srv 追加時の README 節欠落も検知される。
- (3) は \`BACKEND_STATUS_FUNCTIONS\` const list で対象関数を持つ。bridge 増加時はここに追加するだけ。
- パラメータ連結 (\`+ this->get_parameter(...).as_string()\`) の動的部分は対象外。明示的な文字列リテラルのみを走査するため false positive を抑制。

## 副次効果: 既存 drift 3 件を解消

lint が稼働した瞬間に以下 3 件の README 節欠落を検知 → 同 PR 内で解消した:

- \`### TagDefinition.msg\` (PR #193 で msg 追加時に README 更新漏れ)
- \`### InitialPoseRequest.msg\` (#149 round 8 で文字列ペアから型化した際に README 更新漏れ)
- \`### LocalizationBackendStatus.msg\` (PR #210 / Close #209 で msg 追加時に README 更新漏れ)

## Local 確認

- 本番実行: 全 3 check \`[OK]\` (\`msg=7, srv=6, scanned cpp=4\`)
- Smoke test (一時 inject): 4 種の forbidden pattern (絶対パス / IP / credential / hostname) 全て検出、不在 msg pointer 検出、既存実コードの reason 文字列で false positive なし

## 対象外

- \`.msg\` / \`.srv\` / \`CMakeLists.txt\` 等の interface 本体は変更なし (ABI 不変)。
- runtime check (publish 時の reason 文字列を実機で監視) は scope 外。static check のみ。
- \`scripts/check_docs_consistency.py\` は ROS runtime に依存しない pure Python なので, colcon build / humble・jazzy distro テストには影響しない (precedent: \`check_robot_radius_drift.py\` と同じ standalone CI 運用)。

## Test plan

- [x] \`python3 scripts/check_docs_consistency.py\` がローカルで pass する
- [x] inject smoke test で各 check が違反を検出する
- [x] inject smoke test で false positive がないことを確認
- [ ] CI \`Consistency Check / robot_radius_drift\` job が PR で pass する

🤖 Generated with [Claude Code](https://claude.com/claude-code)