### PR TITLE
docs(server): CLI 起動例 + maps_path/map_name 取り違え注意を追加 (Close #172)

### DIFF
--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -33,6 +33,9 @@ ros2 launch mapoi_server mapoi_bringup.launch.yaml \
   map_name:=turtlebot3_world
 
 # ソースツリーから直接 (ros2_ws 内で source 後)
+# 注: 本 repo を `<ws>/src/mapoi/` 配下に展開している前提 (`git clone .../mapoi.git`)。
+# パッケージを `<ws>/src/mapoi_turtlebot3_example/` のようにフラット展開している場合は
+# パスを調整するか、上の `pkg prefix --share` 形式を使う方が確実。
 ros2 launch mapoi_server mapoi_bringup.launch.yaml \
   maps_path:=$(pwd)/src/mapoi/mapoi_turtlebot3_example/maps \
   map_name:=turtlebot3_dqn_stage1
@@ -46,11 +49,11 @@ ros2 launch mapoi_server mapoi_bringup.launch.yaml \
 |---|---|---|
 | `maps_path` | **地図群を束ねる親ディレクトリ** (各地図は配下のサブディレクトリ) | `/path/to/maps` |
 | `map_name` | `maps_path` 直下の地図サブディレクトリ名 | `turtlebot3_world` |
-| `config_file` | 地図サブディレクトリ内の設定ファイル名 (基本デフォルトのまま) | `mapoi_config.yaml` |
+| `config_file` | 地図サブディレクトリ内の設定ファイル名 (default: `mapoi_config.yaml`) | `mapoi_config.yaml` |
 
 実際にロードされるパスは `{maps_path}/{map_name}/{config_file}` で、上記例なら `/path/to/maps/turtlebot3_world/mapoi_config.yaml` となります。
 
-`maps_path` と `map_name` はどちらも `mapoi_bringup.launch.yaml` の **必須 launch arg** で、未指定なら `ros2 launch` 自体が `Required launch argument '<name>' was not provided` で fail します (node 起動前)。
+`maps_path` / `map_name` 必須 (上節参照) の検証は **2 段階**: `map_name` 自体未指定なら `ros2 launch` が `Required launch argument 'map_name' was not provided` で fail (node 起動前 / launch system 側)、`maps_path` がディレクトリでない等のセマンティクス違反は `mapoi_server` ノード起動時に `RCLCPP_FATAL` で fail します。
 
 **❌ よくある間違い**: `maps_path` に **config.yaml ファイルパスを直接指定** してしまう:
 

--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -22,6 +22,50 @@ mapoi のメインパッケージです。
 
 `maps_path` と `map_name` は **必須** です。`maps_path` 未指定 / 存在しないパス / ディレクトリでない場合は `RCLCPP_FATAL` ログ + 終了コード 1 で起動失敗します (#163)。`mapoi_turtlebot3_example` の sample を流用するなら `$(find-pkg-share mapoi_turtlebot3_example)/maps` を指定してください。
 
+### CLI から直接起動する例
+
+include せず `ros2 launch` を直接叩く場合の最小例:
+
+```bash
+# mapoi_turtlebot3_example の sample maps を流用 (apt / 配布 install 後にも動く)
+ros2 launch mapoi_server mapoi_bringup.launch.yaml \
+  maps_path:=$(ros2 pkg prefix --share mapoi_turtlebot3_example)/maps \
+  map_name:=turtlebot3_world
+
+# ソースツリーから直接 (ros2_ws 内で source 後)
+ros2 launch mapoi_server mapoi_bringup.launch.yaml \
+  maps_path:=$(pwd)/src/mapoi/mapoi_turtlebot3_example/maps \
+  map_name:=turtlebot3_dqn_stage1
+```
+
+#### 引数の取り違え注意
+
+各 launch arg のセマンティクスは以下のとおり (`{maps_path}/{map_name}/{config_file}` でアクセスする 3 レベルの分割):
+
+| arg | 渡すもの | 例 |
+|---|---|---|
+| `maps_path` | **地図群を束ねる親ディレクトリ** (各地図は配下のサブディレクトリ) | `/path/to/maps` |
+| `map_name` | `maps_path` 直下の地図サブディレクトリ名 | `turtlebot3_world` |
+| `config_file` | 地図サブディレクトリ内の設定ファイル名 (基本デフォルトのまま) | `mapoi_config.yaml` |
+
+実際にロードされるパスは `{maps_path}/{map_name}/{config_file}` で、上記例なら `/path/to/maps/turtlebot3_world/mapoi_config.yaml` となります。
+
+`maps_path` と `map_name` はどちらも `mapoi_bringup.launch.yaml` の **必須 launch arg** で、未指定なら `ros2 launch` 自体が `Required launch argument '<name>' was not provided` で fail します (node 起動前)。
+
+**❌ よくある間違い**: `maps_path` に **config.yaml ファイルパスを直接指定** してしまう:
+
+```bash
+# WRONG: maps_path はファイルではなくディレクトリ
+ros2 launch mapoi_server mapoi_bringup.launch.yaml \
+  maps_path:=./maps/turtlebot3_dqn_stage1/mapoi_config.yaml \
+  map_name:=turtlebot3_dqn_stage1
+# → 起動時に node が以下で FATAL:
+#    [FATAL] maps_path '...mapoi_config.yaml' does not exist or is not a directory.
+#            正しい maps ディレクトリ path を指定してください
+```
+
+`maps_path` は **地図群を束ねる親ディレクトリ** で、特定の地図ディレクトリやファイルではありません。ディレクトリ構成は本 README 末尾の「ディレクトリ構成」節を参照してください。
+
 `simulator` arg はシミュレータ連動 bridge の起動を制御します:
 - `gazebo` (Gazebo Classic / Humble): `mapoi_gazebo_bridge` を起動。operator map switch 時に Gazebo 内の `world_model` entity を入れ替え + ロボットを delete + spawn で **POI list 先頭** の座標に再生成 (#144 で旧 `initial_pose` system tag を廃止し、yaml 順序で表現する semantics に変更)
 - `gz` (gz-sim / Jazzy): `mapoi_gz_bridge` + `parameter_bridge` (`ros_gz_bridge`) を起動。operator map switch 時に gz-sim 内の `world_model` entity を入れ替え + ロボットを `SetEntityPose` で **POI list 先頭** の座標に teleport (gz-sim では Classic と異なり set_pose service が使えるため delete + spawn は不要)

--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -59,12 +59,15 @@ ros2 launch mapoi_server mapoi_bringup.launch.yaml \
 ros2 launch mapoi_server mapoi_bringup.launch.yaml \
   maps_path:=./maps/turtlebot3_dqn_stage1/mapoi_config.yaml \
   map_name:=turtlebot3_dqn_stage1
-# → 起動時に node が以下で FATAL:
-#    [FATAL] maps_path '...mapoi_config.yaml' does not exist or is not a directory.
-#            正しい maps ディレクトリ path を指定してください
 ```
 
-`maps_path` は **地図群を束ねる親ディレクトリ** で、特定の地図ディレクトリやファイルではありません。ディレクトリ構成は本 README 末尾の「ディレクトリ構成」節を参照してください。
+→ 起動時に `mapoi_server` ノードが以下を 1 行で出力して FATAL 終了します (`mapoi_server.cpp` 内の `RCLCPP_FATAL` ログ全文):
+
+```
+[FATAL] maps_path '...mapoi_config.yaml' does not exist or is not a directory. 正しい maps ディレクトリ path を指定してください (例: $(find-pkg-share mapoi_turtlebot3_example)/maps)。
+```
+
+`maps_path` は **地図群を束ねる親ディレクトリ** で、特定の地図ディレクトリやファイルではありません。ディレクトリ構成は本 README 末尾の [ディレクトリ構成](#ディレクトリ構成) 節を参照してください。
 
 `simulator` arg はシミュレータ連動 bridge の起動を制御します:
 - `gazebo` (Gazebo Classic / Humble): `mapoi_gazebo_bridge` を起動。operator map switch 時に Gazebo 内の `world_model` entity を入れ替え + ロボットを delete + spawn で **POI list 先頭** の座標に再生成 (#144 で旧 `initial_pose` system tag を廃止し、yaml 順序で表現する semantics に変更)


### PR DESCRIPTION
## Summary

- \`mapoi_server/README.md\` の自分のロボットへの組み込み方節に「CLI から直接起動する例」サブ節を追加。
- 引数 semantics 表 + ❌ よくある間違い (config.yaml ファイル path を maps_path に渡す誤用) を追記。
- docs only (+44 行)、ABI 不変。lint 3 件 OK。

## Background

Close #172。PR #170 (#163 段階 1+2) の動作確認で、\`maps_path\` に **config.yaml ファイルパス** を直接指定して起動失敗するケースが発生 (issue 本文の事例)。原因は \`mapoi_server/README.md\` に launch include 例 (YAML) はあるが CLI 直接起動例がないため、引数の semantics (= maps directory vs config file) を誤解しやすい。

## 仕様確認 (本 PR で参照した実装の根拠)

| 仕様 | 実装根拠 |
|---|---|
| \`maps_path\` REQUIRED (no default) | \`mapoi_server.cpp:23-29\`: empty なら \`RCLCPP_FATAL\` + \`throw\` |
| \`maps_path\` がディレクトリでない | \`mapoi_server.cpp:43-50\`: \`is_directory()\` false で \`"does not exist or is not a directory"\` FATAL |
| \`map_name\` launch arg REQUIRED | \`mapoi_bringup.launch.yaml:26-28\`: default なし、未指定時 \`ros2 launch\` 自体が fail |
| \`config_file\` default | launch arg + node 共に \`mapoi_config.yaml\` |
| 実際のロードパス | \`mapoi_server.cpp:180\`: \`{maps_path}/{map_name}/{config_file}\` |

## 追加内容

1. **CLI 起動例**: pkg prefix 経由 (\`$(ros2 pkg prefix --share mapoi_turtlebot3_example)/maps\`) + ソースツリー経由 (\`$(pwd)/src/mapoi/...\`) の 2 パターン
2. **引数 semantics 表**: \`maps_path\` (親 dir) / \`map_name\` (sub dir) / \`config_file\` (file) の 3 レベル
3. **launch arg 必須性の明記**: 未指定時の \`ros2 launch\` 側エラー文言を引用
4. **❌ よくある間違い**: \`maps_path\` に config.yaml を渡した場合の **実 FATAL 出力例**

## ルート README との整合確認

ルート \`README.md\` line 352-386 は別軸の「個別 node 配置」パターン (\`mapoi_server\` / \`mapoi_nav2_bridge\` / \`mapoi_amcl_localization_bridge\` / \`mapoi_rviz2_publisher\` を 1 個ずつ \`<node>\` で配置) で、変数名 (\`maps_path\` / \`map_name\` / \`config_file\`) と semantics は本変更と整合済 (drift なし)。bringup include vs 個別配置の推奨パターン乖離は本 PR scope 外。

## Test plan

- [x] \`python3 scripts/check_docs_consistency.py\` OK
- [x] \`python3 scripts/check_robot_radius_drift.py\` OK
- [x] \`python3 scripts/check_sample_yaml_consistency.py\` OK
- [ ] CI green (Consistency Check)

## 影響

- docs only、コード変更なし、ABI / runtime 挙動 不変
- humble / jazzy 両 distro で colcon build 影響なし (Docker 検証スキップ可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)