### PR TITLE
feat(events): PoiEvent を VISITED/PAUSED_AT/EXIT の 3 種別へ簡素化 (Close #220)

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -88,11 +88,11 @@ poi:
 
 ## 4. POI 半径イベントの利用（オプション）
 
-ユーザータグを持つ POI の半径内にロボットが入ると `mapoi/events` トピックにイベントが配信されます。
+route 走行中に route 登録 POI に入ると `mapoi/events` トピックに `EVENT_VISITED` / `EVENT_PAUSED_AT` (pause タグのみ) / `EVENT_EXIT` の 3 種別 event が配信されます。route 走行外 (IDLE / GOAL mode、`NavigateToPose` 単発 goal や手動操縦) では発火しません。
 
 ```sh
 # イベントの確認
 ros2 topic echo /mapoi/events
 ```
 
-詳細は [`mapoi_server` の README](../mapoi_server/README.md) を参照してください。
+詳細仕様は [`mapoi_server` の README](../mapoi_server/README.md) の「POI 半径イベント検知」節を参照してください。

--- a/mapoi_interfaces/README.md
+++ b/mapoi_interfaces/README.md
@@ -28,17 +28,25 @@ POI（Point of Interest）を表すメッセージです。
 
 ### PoiEvent.msg
 
-POI tolerance.xy 半径への侵入・退出 / 停止 / 再開イベントを表すメッセージです。
+route 走行中に route 登録 POI への侵入 / 退出、および `pause` タグ付き POI で navigation 停止が発生した時に publish されるイベントメッセージです (#220 で 4 種別 → 3 種別に簡素化)。
 
 | フィールド | 型 | 説明 |
 | --- | --- | --- |
-| `EVENT_ENTER` | `uint8` (定数=1) | 侵入イベント |
-| `EVENT_EXIT` | `uint8` (定数=2) | 退出イベント |
-| `EVENT_STOPPED` | `uint8` (定数=3) | tolerance.xy 半径内で停止 (publish 判定 logic は別 issue) |
-| `EVENT_RESUMED` | `uint8` (定数=4) | 停止後に動き出した (publish 判定 logic は別 issue) |
-| `event_type` | `uint8` | イベント種別 |
+| `EVENT_VISITED` | `uint8` (定数=1) | route 走行中に route 登録 POI の `tolerance.xy` 半径へ侵入 (`nav_mode == ROUTE` かつ `current_route_poi_names_` 該当 POI のみ、route 走行外 (IDLE / GOAL mode) では publish しない) |
+| `EVENT_PAUSED_AT` | `uint8` (定数=2) | `pause` タグ付き POI の `tolerance.xy` 内で navigation 停止 (cmd_vel dwell で検知)。pause 自動 trigger 後に Nav2 が停止状態に入った瞬間 |
+| `EVENT_EXIT` | `uint8` (定数=3) | route 登録 POI から `tolerance.xy * hysteresis_exit_multiplier` を超えて退出 |
+| `event_type` | `uint8` | イベント種別 (上記 3 種のいずれか) |
 | `poi` | `mapoi_interfaces/PointOfInterest` | 対象 POI の情報 |
 | `stamp` | `builtin_interfaces/Time` | イベント発生時刻 |
+
+ライフサイクル:
+```
+EVENT_VISITED -> [EVENT_PAUSED_AT (only if pause-tagged + nav stops)] -> EVENT_EXIT
+```
+
+`EVENT_PAUSED_AT` の前提:
+- 採用 controller が **navigation 停止中も cmd_vel = 0 を継続 publish する** こと (Nav2 default の挙動)。controller が静止時に cmd_vel publish を止める実装の場合、`EVENT_PAUSED_AT` は発火しません。
+- pause 自動 trigger は `mapoi_server` 側で実施し、resume は client 側 `mapoi/nav/resume` request で発動するため、`RESUMED` 相当の event は本仕様に含めません (resume は status topic で観測可能)。
 
 ### TagDefinition.msg
 

--- a/mapoi_interfaces/msg/PoiEvent.msg
+++ b/mapoi_interfaces/msg/PoiEvent.msg
@@ -1,9 +1,26 @@
-# Published when the robot enters / exits / stops at / resumes from a POI's tolerance.xy radius
-uint8 EVENT_ENTER=1     # Robot entered the POI tolerance.xy radius
-uint8 EVENT_EXIT=2      # Robot exited the POI tolerance.xy radius
-uint8 EVENT_STOPPED=3   # Robot stopped while inside the POI radius (Nav2 succeeded or sustained zero velocity)
-uint8 EVENT_RESUMED=4   # Robot resumed motion after STOPPED inside the POI radius
+# Published when the robot enters/exits a route POI tolerance.xy radius, or
+# when navigation pauses inside a `pause`-tagged POI. The event set is scoped
+# to **route navigation** (FollowWaypoints, nav_mode == ROUTE) and
+# **route-registered POIs** only; nothing is published outside route execution
+# (IDLE or GOAL modes). `pause`-tagged POIs additionally generate
+# `EVENT_PAUSED_AT` once nav has stopped (cmd_vel dwell).
+#
+# `EVENT_PAUSED_AT` requires the active controller to keep publishing zero
+# cmd_vel during nav pause/stop (default Nav2 behavior). Controllers that
+# silently stop publishing cmd_vel will not trigger `EVENT_PAUSED_AT`.
+#
+# Lifecycle:
+#   EVENT_VISITED -> [EVENT_PAUSED_AT (only if pause-tagged + nav stops)] -> EVENT_EXIT
+#
+# Note: `EVENT_RESUMED` is NOT a separate event in this contract. nav pause
+# is initiated by `mapoi_server` (auto-trigger on pause-tagged POI) and
+# resumed by client request via `mapoi/nav/resume`; client / status topic
+# already observes the resume timing without a dedicated PoiEvent.
 
-uint8 event_type                    # EVENT_ENTER / EVENT_EXIT / EVENT_STOPPED / EVENT_RESUMED
+uint8 EVENT_VISITED=1     # route 走行中に route 登録 POI の tolerance.xy 半径へ侵入
+uint8 EVENT_PAUSED_AT=2   # pause タグ付き POI の tolerance.xy 内で navigation 停止 (cmd_vel dwell)
+uint8 EVENT_EXIT=3        # route 登録 POI から tolerance.xy * hysteresis を超えて退出
+
+uint8 event_type                      # EVENT_VISITED / EVENT_PAUSED_AT / EVENT_EXIT
 mapoi_interfaces/PointOfInterest poi  # The POI that triggered the event
-builtin_interfaces/Time stamp       # Timestamp when the event occurred
+builtin_interfaces/Time stamp         # Timestamp when the event occurred

--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -156,7 +156,7 @@ POI 名を指定した自律走行と、POI 半径イベント検知を行うノ
 | `goal_pose` | `geometry_msgs/PoseStamped` | ゴール位置の配信 |
 | `mapoi/nav/status` | `std_msgs/String` | ナビゲーション状態を `"status"` または `"status:target"` 形式で配信（例: `"navigating:kitchen"`、`"succeeded:patrol_route"`、`"paused:patrol_route"`、`"map_switching:turtlebot3_world"`）。`status` は `navigating` / `succeeded` / `aborted` / `canceled` / `paused` / `map_switching` / `map_switch_succeeded` / `map_switch_failed` / `backend_unavailable`。`backend_unavailable` は Nav2 action / service 不在で goal / route / resume を実行できなかった場合（#198）。`target` は POI 名（goal mode）、route 名（route mode）、または map 名で、subscriber 側は最初の `:` で split して復元する（target 内に `:` が含まれても残り全体を target として扱える）。`transient_local` QoS の **現在状態 snapshot**（depth=1）で、後起動 subscriber が最後の状態を受信できるが状態遷移履歴は復元できない。現在走行中かは `navigating` / `paused` / `map_switching` で判定し、終端状態（`succeeded` / `aborted` / `canceled` / `map_switch_succeeded` / `map_switch_failed` / `backend_unavailable`）は直近結果として扱う |
 | `mapoi/nav/backend_status` | `mapoi_interfaces/NavigationBackendStatus` | navigation bridge の readiness summary を 1Hz で配信（#198）。`transient_local` QoS。Minimal 3 フィールド（`backend_type` / `backend_ready` / `reason`）。WebUI / panel は `backend_ready` で navigation 操作 UI を一括 gate する。詳細は ルート README "Navigation backend 仕様" 節を参照 |
-| `mapoi/events` | `mapoi_interfaces/PoiEvent` | POI 侵入・退出イベント |
+| `mapoi/events` | `mapoi_interfaces/PoiEvent` | route 走行中の POI 侵入 (`EVENT_VISITED`) / pause POI で navigation 停止 (`EVENT_PAUSED_AT`) / 退出 (`EVENT_EXIT`) イベント (#220) |
 
 #### アクションクライアント
 
@@ -165,15 +165,23 @@ POI 名を指定した自律走行と、POI 半径イベント検知を行うノ
 | `follow_waypoints` | `nav2_msgs/FollowWaypoints` | ウェイポイント追従 |
 | `navigate_to_pose` | `nav2_msgs/NavigateToPose` | 単一ゴールナビゲーション |
 
-#### POI 半径イベント検知
+#### POI 半径イベント検知 (`PoiEvent`)
 
-POI の半径内にロボットが侵入/退出した際に `mapoi/events` トピックにイベントを発行します。全 POI がタグに関わらず検知対象です。
+`mapoi/events` topic で 3 種別の event を publish します (#220 で 4 種別 → 3 種別に簡素化)。検知対象は **route 走行中 (`nav_mode == ROUTE`、`FollowWaypoints` 駆動)** + **route 登録 POI** のみで、route 走行外 (`IDLE` / `GOAL` mode) では event は発火しません。
+
+| event_type | 発火条件 |
+| --- | --- |
+| `EVENT_VISITED` | route POI の `tolerance.xy` 半径内へ侵入 |
+| `EVENT_PAUSED_AT` | `pause` タグ付き POI の `tolerance.xy` 内で **navigation 停止** (cmd_vel dwell で検知)、1 visit につき 1 回のみ |
+| `EVENT_EXIT` | route POI から `tolerance.xy * hysteresis_exit_multiplier` を超えて退出 |
+
+検知の前提:
 
 - TF lookup (`map` -> `base_link`) でロボット位置を取得（デフォルト 5Hz）
-- **侵入判定**: 距離 <= `tolerance.xy`
-- **退出判定**: 距離 > `tolerance.xy * hysteresis_exit_multiplier`（デフォルト 1.15）
-- `pause` タグ付き POI では侵入時に走行を自動一時停止（併せてイベントも発行）
+- `pause` タグ付き POI では侵入時に走行を自動一時停止 (併せて `EVENT_PAUSED_AT` を nav 停止後に publish)
+- `EVENT_PAUSED_AT` は採用 controller が **navigation 停止中も cmd_vel = 0 を継続 publish** する前提 (Nav2 default の挙動)。controller が静止時に cmd_vel publish を止める実装の場合、`EVENT_PAUSED_AT` は発火しません
 - マップ切替時は内部状態をリセットし、新しい POI リストで監視を再開
+- `RESUMED` 相当の event はありません (resume は client 側 request + `mapoi/nav/status` で観測可能)
 
 ### mapoi_amcl_localization_bridge
 

--- a/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
@@ -194,12 +194,12 @@ private:
   std::unordered_set<std::string> system_tags_;
   bool system_tags_loaded_ = false;
   std::unordered_map<std::string, bool> poi_inside_state_;  // key: poi.name
-  // STOPPED/RESUMED 判定用の per-POI 状態 (#140)。
-  //   was_stopped == true: 既に EVENT_STOPPED 発火済 (RESUMED まで持続)。
-  //   was_stopped == false: 未停止 / OUTSIDE / RESUMED 後。
-  // ENTER/EXIT 判定 (poi_inside_state_) と独立して持つ: STOPPED は inside 内での
-  // sub-state なので、EXIT 時は inside_state→false と同時に stopped_state→false に reset する。
-  std::unordered_map<std::string, bool> poi_stopped_state_;  // key: poi.name
+  // EVENT_PAUSED_AT 発火済 per-POI 状態 (#220)。
+  //   true: 既に EVENT_PAUSED_AT publish 済 (再 publish しない、EXIT で reset)
+  //   false: 未発火 / VISITED 後 / EXIT 後
+  // VISITED/EXIT 判定 (poi_inside_state_) と独立して持つ: PAUSED_AT は inside 内での
+  // sub-state なので、EXIT 時は inside_state→false と同時に paused_state→false に reset する。
+  std::unordered_map<std::string, bool> poi_paused_at_published_;  // key: poi.name
   std::vector<mapoi_interfaces::msg::PointOfInterest> event_pois_;
 
   // initial pose POI 名の publisher (Nav2 LoadMap 完了後 trigger 用、#209)。
@@ -208,39 +208,24 @@ private:
   // bridge が担当する (#209 で mapoi_nav2_bridge から分離)。
   rclcpp::Publisher<mapoi_interfaces::msg::InitialPoseRequest>::SharedPtr mapoi_initialpose_poi_pub_;
 
-  // --- STOPPED/RESUMED 判定 (#140) ---
-  // cmd_vel subscriber: 速度判定の source の一つ。Nav2 action SUCCEEDED もう一つの source は
-  // result_callback / ntp_result_callback で hook する (両方 OR で STOPPED 判定)。
+  // --- EVENT_PAUSED_AT trigger 用 cmd_vel dwell 検知 (#220) ---
+  // cmd_vel subscriber: pause タグ POI 内で navigation 停止を検知する source。
   // dwell 判定は robot 全体で 1 つ (POI ごとには持たない)。線速ノルムと角速度絶対値の両方が
   // 同じ閾値 ``stopped_speed_threshold`` 未満のとき停止扱い。線速 (m/s) と角速 (rad/s) に
   // 単位の異なる同一閾値を使う割り切りは、撮影シナリオで「その場旋回も停止扱いしたくない」
-  // 用途と整合する (param 説明 / CHANGELOG にも明記)。
+  // 用途と整合する (param 説明 / docs にも明記)。
+  // 前提: 採用 controller が navigation 停止中も cmd_vel = 0 を継続 publish すること
+  // (Nav2 default の挙動)。controller が静止時に cmd_vel publish を止める実装の場合、
+  // EVENT_PAUSED_AT は発火しない。
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
   void cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
   // 速度が閾値以下になり始めた時刻 (steady_clock)。閾値超えに戻ったら reset。
   std::chrono::steady_clock::time_point last_zero_velocity_start_ {};
   bool zero_velocity_active_ {false};
-  // STOPPED 判定 param のキャッシュ (cmd_vel callback で毎 tick 取得すると lock コストが高いため
+  // PAUSED_AT 判定 param のキャッシュ (cmd_vel callback で毎 tick 取得すると lock コストが高いため
   // constructor で読み込んで保持。ROS 動的 reconfigure で変更したい場合は再起動が必要)。
   double stopped_speed_threshold_ {0.01};
   double stopped_dwell_time_sec_ {1.0};
-
-  // 状態遷移判定の純関数 (unit test 用、#140)。inputs から transition を返すだけで副作用なし。
-  enum class StoppedTransition { NONE, TO_STOPPED, TO_RESUMED };
-  struct StoppedDetectionInputs {
-    bool inside;                 // robot が POI の tolerance.xy 内に居るか
-    bool was_stopped;            // 前 tick での poi_stopped_state_
-    bool zero_velocity_dwelled;  // 速度が閾値以下で dwell_time 以上経過
-  };
-  static StoppedTransition compute_stopped_transition(const StoppedDetectionInputs & in);
-
-  // STOPPED publish (Nav2 SUCCEEDED 受信時)。``target_poi_name`` が指定された場合、その POI は
-  // inside check を skip して強制的に STOPPED publish する (SUCCEEDED と tolerance_check tick の
-  // 非同期で「まだ inside と判定されていない」瞬間に SUCCEEDED が来ても取りこぼさない)。それ以外
-  // の inside POI は通常通り poi_inside_state_ を見て publish。``reason`` は log 用。
-  void stop_all_inside_pois(const std::string & reason, const std::string & target_poi_name = "");
-  // 全 stopped POI に対して RESUMED publish (新規 goal 受信時)。
-  void resume_all_stopped_pois();
 
   void fetch_system_tags();
   void on_system_tags_received(rclcpp::Client<mapoi_interfaces::srv::GetTagDefinitions>::SharedFuture future);
@@ -290,11 +275,6 @@ private:
   FRIEND_TEST(Nav2BridgeTestFixture, IsPauseEligibleGoalMode);
   FRIEND_TEST(Nav2BridgeTestFixture, IsPauseEligibleIdleMode);
   FRIEND_TEST(Nav2BridgeTestFixture, ResetNavStateClearsRouteContext);
-  FRIEND_TEST(Nav2BridgeTestFixture, ComputeStoppedTransitionNoOutside);
-  FRIEND_TEST(Nav2BridgeTestFixture, ComputeStoppedTransitionEnterStopped);
-  FRIEND_TEST(Nav2BridgeTestFixture, ComputeStoppedTransitionEnterMoving);
-  FRIEND_TEST(Nav2BridgeTestFixture, ComputeStoppedTransitionResumeOnVelocity);
-  FRIEND_TEST(Nav2BridgeTestFixture, ComputeStoppedTransitionStaysStopped);
 #endif
 };
 

--- a/mapoi_server/src/mapoi_nav2_bridge.cpp
+++ b/mapoi_server/src/mapoi_nav2_bridge.cpp
@@ -89,9 +89,10 @@ MapoiNav2Bridge::MapoiNav2Bridge(const rclcpp::NodeOptions & options)
   this->declare_parameter<double>("hysteresis_exit_multiplier", 1.15);
   this->declare_parameter<std::string>("map_frame", "map");
   this->declare_parameter<std::string>("base_frame", "base_link");
-  // STOPPED/RESUMED 判定 (#140): 線速ノルムと角速度絶対値の両方が ``stopped_speed_threshold``
-  // 未満の状態が ``stopped_dwell_time_sec`` 続いたら EVENT_STOPPED publish。線速 (m/s) と角速
-  // (rad/s) に同一閾値を使う割り切りで「その場旋回も停止扱いしない」用途を表現する。
+  // EVENT_PAUSED_AT 判定 (#220 で旧 STOPPED/RESUMED から spec 変更): 線速ノルムと角速度絶対値
+  // の両方が ``stopped_speed_threshold`` 未満の状態が ``stopped_dwell_time_sec`` 続いたら、
+  // pause タグ付き route POI 内に居る場合のみ EVENT_PAUSED_AT publish。線速 (m/s) と角速 (rad/s)
+  // に同一閾値を使う割り切りで「その場旋回も停止扱いしない」用途を表現する。
   this->declare_parameter<double>("stopped_speed_threshold", 0.01);
   this->declare_parameter<double>("stopped_dwell_time_sec", 1.0);
   this->declare_parameter<std::string>("cmd_vel_topic", "cmd_vel");
@@ -145,10 +146,8 @@ void MapoiNav2Bridge::mapoi_goal_pose_poi_cb(const std_msgs::msg::String::Shared
 {
   std::string poi_name = msg->data;
   RCLCPP_INFO(this->get_logger(), "Received POI name for goal pose: %s", poi_name.c_str());
-  // 新規 goal 受信時に現在 STOPPED 状態の POI を全て RESUMED publish する (#140)。
-  // 以降 Nav2 への goal 送信で robot が動き始めるため、STOPPED 中の subscriber が
-  // 「停止解除」を即時に検知できる (cmd_vel callback で観測する前に publish)。
-  resume_all_stopped_pois();
+  // #220 で RESUMED event は撤去 (resume は client request + status topic で観測可能)。
+  // poi_paused_at_published_ flag は VISITED → EXIT の lifecycle で reset される (EXIT 時 clear)。
   // target は send_goal_options に lambda capture で bind し、callback 側で
   // goal 固有の target を使って publish_nav_status する (#104 race fix)。
   // current_target_name_ は acceptance 時 (goal_response_callback) に更新され、
@@ -250,9 +249,7 @@ void MapoiNav2Bridge::mapoi_goal_pose_poi_cb(const std_msgs::msg::String::Shared
 void MapoiNav2Bridge::mapoi_route_cb(const std_msgs::msg::String::SharedPtr msg)
 {
   RCLCPP_INFO(this->get_logger(), "Received route name: %s", msg->data.c_str());
-  // 新規 route 受信時に現在 STOPPED 状態の POI を全て RESUMED publish (#140)。
-  // 以降の send_goal で robot が動き始めるため、即時に「停止解除」通知する。
-  resume_all_stopped_pois();
+  // #220 で RESUMED event は撤去 (resume は client request + status topic で観測可能)。
   // target は on_route_received → send_goal_options に lambda capture で bind し、
   // callback 側で goal 固有の target を使って publish_nav_status する (#104 race fix)。
   // current_target_name_ は acceptance 時 (goal_response_callback) に更新される。
@@ -617,10 +614,8 @@ void MapoiNav2Bridge::result_callback(std::string target, size_t nav_generation,
       reset_nav_state();
       publish_nav_status("succeeded", target);
       RCLCPP_INFO(this->get_logger(), "Navigation SUCCEEDED!");
-      // Nav2 SUCCEEDED 時点で robot は goal で停止している。target POI に対して強制 publish
-      // (inside check skip で取りこぼし防止) + 他の inside POI にも STOPPED publish (#140)。
-      // cmd_vel ベースの dwell 待ちを経由せず即時発火。
-      stop_all_inside_pois("Nav2 FollowWaypoints succeeded", target);
+      // #220 で Nav2 SUCCEEDED hook 経由の event publish は撤去
+      // (PAUSED_AT は cmd_vel dwell only で trigger、STOPPED event 自体撤去)。
       break;
     case rclcpp_action::ResultCode::ABORTED:
       reset_nav_state();
@@ -682,7 +677,7 @@ void MapoiNav2Bridge::ntp_result_callback(std::string target, size_t nav_generat
       reset_nav_state();
       publish_nav_status("succeeded", target);
       RCLCPP_INFO(this->get_logger(), "NavigateToPose SUCCEEDED!");
-      stop_all_inside_pois("Nav2 NavigateToPose succeeded", target);
+      // #220 で Nav2 SUCCEEDED hook 経由の event publish は撤去。
       break;
     case rclcpp_action::ResultCode::ABORTED:
       reset_nav_state();
@@ -1017,7 +1012,7 @@ void MapoiNav2Bridge::tolerance_check_callback()
   double rx = transform.transform.translation.x;
   double ry = transform.transform.translation.y;
   double hysteresis = this->get_parameter("hysteresis_exit_multiplier").as_double();
-  // STOPPED 判定: zero_velocity が dwell threshold 以上続いたら停止扱い (#140)。
+  // PAUSED_AT 判定 (#220): zero_velocity が dwell threshold 以上続いたら停止扱い。
   // 全 POI 共通の判定なので timer tick 内で 1 回計算して使い回す。
   bool zero_velocity_dwelled = false;
   if (zero_velocity_active_) {
@@ -1026,7 +1021,7 @@ void MapoiNav2Bridge::tolerance_check_callback()
     zero_velocity_dwelled = (dwell >= stopped_dwell_time_sec_);
   }
 
-  // pause タグ POI の ENTER を収集（mutex 外で処理するため）
+  // pause タグ POI の VISITED を収集（mutex 外で auto-pause trigger するため）
   std::string pause_triggered_poi;
 
   {
@@ -1035,71 +1030,71 @@ void MapoiNav2Bridge::tolerance_check_callback()
       return;
     }
 
+    // EVENT_VISITED は route 走行中 + route 登録 POI のみが publish 対象 (#220)。
+    // route 走行外 (IDLE / GOAL mode) や non-route POI への侵入は通知しない。
+    const bool route_active = (nav_mode_ == NavMode::ROUTE);
+
     for (const auto & poi : event_pois_) {
       double dist = distance_2d(poi.pose, rx, ry);
       bool was_inside = poi_inside_state_[poi.name];
 
+      // route 登録 POI かつ ROUTE mode 走行中なら event 発火対象 (#220)。
+      const bool is_route_poi = route_active &&
+        current_route_poi_names_.find(poi.name) != current_route_poi_names_.end();
+
       // pause 自動発火は ROUTE 走行中 + active route POI + "pause" タグの 3 条件 (#143)。
-      // 判定 logic は is_pause_eligible に切り出して unit test (#148)。
+      // (is_route_poi と前提が一致するため、is_pause_eligible で同じ check を行う。)
       const bool is_pause_poi = is_pause_eligible(poi, nav_mode_, current_route_poi_names_);
 
       if (!was_inside && dist <= poi.tolerance.xy) {
-        // ENTER event: 全POIでPoiEvent発行
+        // VISITED event: route POI のみ publish
         poi_inside_state_[poi.name] = true;
-        mapoi_interfaces::msg::PoiEvent event;
-        event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_ENTER;
-        event.poi = poi;
-        event.stamp = this->now();
-        poi_event_pub_->publish(event);
-        RCLCPP_INFO(this->get_logger(), "POI ENTER: %s (dist=%.2f, tolerance.xy=%.2f)",
-                    poi.name.c_str(), dist, poi.tolerance.xy);
+        if (is_route_poi) {
+          mapoi_interfaces::msg::PoiEvent event;
+          event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_VISITED;
+          event.poi = poi;
+          event.stamp = this->now();
+          poi_event_pub_->publish(event);
+          RCLCPP_INFO(this->get_logger(), "POI VISITED: %s (dist=%.2f, tolerance.xy=%.2f)",
+                      poi.name.c_str(), dist, poi.tolerance.xy);
+        }
         // pauseタグがあれば自動pause対象 (active route POI かつ ROUTE 走行中のみ)
         if (is_pause_poi) {
           pause_triggered_poi = poi.name;
         }
       } else if (was_inside && dist > poi.tolerance.xy * hysteresis) {
-        // EXIT event: 全POIでPoiEvent発行
+        // EXIT event: route POI のみ publish
         poi_inside_state_[poi.name] = false;
-        // STOPPED state も EXIT で clear (#140)。RESUMED publish は EXIT で兼ねる扱いとする
-        // (ライフサイクル: ENTER → STOPPED → (RESUMED |) EXIT。EXIT 時に明示 RESUMED を出すと
-        // 同 tick で 2 イベントが連続発火して subscriber 側の handler 設計が複雑化するため見送り)。
-        poi_stopped_state_[poi.name] = false;
-        mapoi_interfaces::msg::PoiEvent event;
-        event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_EXIT;
-        event.poi = poi;
-        event.stamp = this->now();
-        poi_event_pub_->publish(event);
-        RCLCPP_INFO(this->get_logger(), "POI EXIT: %s (dist=%.2f, tolerance.xy=%.2f)",
-                    poi.name.c_str(), dist, poi.tolerance.xy);
-        continue;  // STOPPED/RESUMED 判定不要 (今 tick で OUTSIDE 化)
+        // PAUSED_AT 発火済 flag も EXIT で reset (#220 lifecycle: VISITED → [PAUSED_AT] → EXIT)
+        poi_paused_at_published_[poi.name] = false;
+        if (is_route_poi) {
+          mapoi_interfaces::msg::PoiEvent event;
+          event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_EXIT;
+          event.poi = poi;
+          event.stamp = this->now();
+          poi_event_pub_->publish(event);
+          RCLCPP_INFO(this->get_logger(), "POI EXIT: %s (dist=%.2f, tolerance.xy=%.2f)",
+                      poi.name.c_str(), dist, poi.tolerance.xy);
+        }
+        continue;  // PAUSED_AT 判定不要 (今 tick で OUTSIDE 化)
       }
 
-      // STOPPED / RESUMED 判定 (#140): inside (新規 ENTER 含む) かつ velocity / RESUMED 条件。
+      // PAUSED_AT 判定 (#220): inside かつ pause タグ持ち かつ cmd_vel dwell かつ未発火
       if (!poi_inside_state_[poi.name]) continue;
-      const bool was_stopped = poi_stopped_state_[poi.name];
-      const StoppedDetectionInputs in{true, was_stopped, zero_velocity_dwelled};
-      const auto trans = compute_stopped_transition(in);
-      if (trans == StoppedTransition::TO_STOPPED) {
-        poi_stopped_state_[poi.name] = true;
-        mapoi_interfaces::msg::PoiEvent event;
-        event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_STOPPED;
-        event.poi = poi;
-        event.stamp = this->now();
-        poi_event_pub_->publish(event);
-        RCLCPP_INFO(this->get_logger(), "POI STOPPED: %s", poi.name.c_str());
-      } else if (trans == StoppedTransition::TO_RESUMED) {
-        poi_stopped_state_[poi.name] = false;
-        mapoi_interfaces::msg::PoiEvent event;
-        event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_RESUMED;
-        event.poi = poi;
-        event.stamp = this->now();
-        poi_event_pub_->publish(event);
-        RCLCPP_INFO(this->get_logger(), "POI RESUMED: %s", poi.name.c_str());
-      }
+      if (!is_pause_poi) continue;
+      if (!zero_velocity_dwelled) continue;
+      if (poi_paused_at_published_[poi.name]) continue;
+      poi_paused_at_published_[poi.name] = true;
+      mapoi_interfaces::msg::PoiEvent event;
+      event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED_AT;
+      event.poi = poi;
+      event.stamp = this->now();
+      poi_event_pub_->publish(event);
+      RCLCPP_INFO(this->get_logger(), "POI PAUSED_AT: %s", poi.name.c_str());
     }
   }  // data_mutex_ をここで解放
 
-  // pause タグ POI の ENTER → 自動 pause (is_pause_poi 判定で route + ROUTE mode を確認済)
+  // pause タグ POI の VISITED → 自動 pause (is_pause_poi 判定で route + ROUTE mode を確認済)
   if (!pause_triggered_poi.empty() && !is_paused_) {
     RCLCPP_INFO(this->get_logger(),
       "Auto-pausing route navigation: entered pause POI '%s'", pause_triggered_poi.c_str());
@@ -1143,101 +1138,6 @@ void MapoiNav2Bridge::cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPt
     }
   } else {
     zero_velocity_active_ = false;
-  }
-}
-
-// 純関数 (副作用なし、unit test 用)。inside / was_stopped / zero_velocity / zero_velocity_dwelled
-// の組み合わせから次の遷移を返す。
-//
-// 仕様:
-//   - !inside: NONE (EXIT 側で stopped state は別途 reset する)
-//   - !was_stopped + zero_velocity_dwelled (停止が dwell_time 続いた): TO_STOPPED
-//   - was_stopped + !zero_velocity (動き始めた): TO_RESUMED (dwell 不要、即時)
-//   - それ以外: NONE
-MapoiNav2Bridge::StoppedTransition MapoiNav2Bridge::compute_stopped_transition(
-  const StoppedDetectionInputs & in)
-{
-  if (!in.inside) return StoppedTransition::NONE;
-  if (!in.was_stopped) {
-    return in.zero_velocity_dwelled ? StoppedTransition::TO_STOPPED : StoppedTransition::NONE;
-  }
-  // was_stopped == true
-  return in.zero_velocity_dwelled ? StoppedTransition::NONE : StoppedTransition::TO_RESUMED;
-}
-
-void MapoiNav2Bridge::stop_all_inside_pois(
-  const std::string & reason, const std::string & target_poi_name)
-{
-  // Nav2 SUCCEEDED 受信時に呼ぶ: 現在 inside の全 POI に対して STOPPED publish
-  // (既に STOPPED state の POI は idempotent に skip)。
-  // ``target_poi_name`` が指定された場合は、その POI は inside check を skip して
-  // 強制的に STOPPED publish する (SUCCEEDED と tolerance_check tick の非同期による
-  // 取りこぼし防止、#176 review medium #1)。
-  // target POI でまだ ENTER 未発火の場合、lifecycle invariant ``ENTER → STOPPED → EXIT`` を
-  // 守るため ENTER を先に publish してから STOPPED を発火する (#176 review r2 high #1)。
-  // event_pois_ / poi_inside_state_ / poi_stopped_state_ を lock で守って snapshot を
-  // 取り、publish は lock 外で実行 (既存 tolerance_check の pattern と整合)。
-  std::vector<mapoi_interfaces::msg::PointOfInterest> to_enter;
-  std::vector<mapoi_interfaces::msg::PointOfInterest> to_stop;
-  {
-    std::lock_guard<std::mutex> lock(data_mutex_);
-    for (const auto & poi : event_pois_) {
-      const bool is_target = !target_poi_name.empty() && poi.name == target_poi_name;
-      const bool was_inside = poi_inside_state_[poi.name];
-      const bool eligible = is_target || was_inside;
-      if (!eligible) continue;
-      // target POI で inside_state がまだ false なら ENTER 先行 publish (lifecycle 整合)。
-      if (is_target && !was_inside) {
-        poi_inside_state_[poi.name] = true;
-        to_enter.push_back(poi);
-      }
-      if (!poi_stopped_state_[poi.name]) {
-        poi_stopped_state_[poi.name] = true;
-        to_stop.push_back(poi);
-      }
-    }
-  }
-  // ENTER → STOPPED の順で publish (subscriber 側の handler 設計が ENTER を前提にできる)。
-  for (const auto & poi : to_enter) {
-    mapoi_interfaces::msg::PoiEvent event;
-    event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_ENTER;
-    event.poi = poi;
-    event.stamp = this->now();
-    poi_event_pub_->publish(event);
-    RCLCPP_INFO(this->get_logger(),
-      "POI ENTER (forced by %s): %s", reason.c_str(), poi.name.c_str());
-  }
-  for (const auto & poi : to_stop) {
-    mapoi_interfaces::msg::PoiEvent event;
-    event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_STOPPED;
-    event.poi = poi;
-    event.stamp = this->now();
-    poi_event_pub_->publish(event);
-    RCLCPP_INFO(this->get_logger(), "POI STOPPED (%s): %s", reason.c_str(), poi.name.c_str());
-  }
-}
-
-void MapoiNav2Bridge::resume_all_stopped_pois()
-{
-  // 新規 goal 受信時に呼ぶ: 現在 STOPPED 状態の全 POI に RESUMED publish。
-  // event_pois_ と poi_stopped_state_ を lock で守って snapshot を取り、publish は lock 外。
-  std::vector<mapoi_interfaces::msg::PointOfInterest> to_resume;
-  {
-    std::lock_guard<std::mutex> lock(data_mutex_);
-    for (const auto & poi : event_pois_) {
-      if (poi_stopped_state_[poi.name]) {
-        poi_stopped_state_[poi.name] = false;
-        to_resume.push_back(poi);
-      }
-    }
-  }
-  for (const auto & poi : to_resume) {
-    mapoi_interfaces::msg::PoiEvent event;
-    event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_RESUMED;
-    event.poi = poi;
-    event.stamp = this->now();
-    poi_event_pub_->publish(event);
-    RCLCPP_INFO(this->get_logger(), "POI RESUMED (new goal): %s", poi.name.c_str());
   }
 }
 

--- a/mapoi_server/src/mapoi_nav2_bridge.cpp
+++ b/mapoi_server/src/mapoi_nav2_bridge.cpp
@@ -788,11 +788,15 @@ void MapoiNav2Bridge::reset_nav_state()
   current_route_waypoints_.clear();
   paused_waypoints_.clear();
   current_waypoint_index_ = 0;
-  // active route POI set もここで clear (#143)。route 終端 / cancel / failure 等で route が
-  // 終わったあとに pause 発火条件が誤って残らないようにする。
+  // active route POI set / per-POI 状態をここで clear (#143 / #220)。
+  // route 終端 / cancel / failure 等で route が終わったあと、次回 route mode 開始時に
+  // 「既に inside / paused 状態」のまま開始されて VISITED / PAUSED_AT が発火しない、
+  // または lifecycle 順序が崩れる、を防ぐ。
   {
     std::lock_guard<std::mutex> lock(data_mutex_);
     current_route_poi_names_.clear();
+    poi_inside_state_.clear();
+    poi_paused_at_published_.clear();
   }
 }
 
@@ -1030,52 +1034,58 @@ void MapoiNav2Bridge::tolerance_check_callback()
       return;
     }
 
-    // EVENT_VISITED は route 走行中 + route 登録 POI のみが publish 対象 (#220)。
-    // route 走行外 (IDLE / GOAL mode) や non-route POI への侵入は通知しない。
-    const bool route_active = (nav_mode_ == NavMode::ROUTE);
+    // EVENT_VISITED / EVENT_PAUSED_AT / EVENT_EXIT は route 走行中 + route 登録 POI のみが
+    // publish 対象 (#220)。route 走行外 (IDLE / GOAL mode) や non-route POI への侵入は通知
+    // しない。lifecycle invariant: VISITED → [PAUSED_AT] → EXIT を守るため、is_route_poi で
+    // ない POI の inside/paused state は **書き換えない** (旧 build / route 外で勝手に内部
+    // 状態が進むと、ROUTE 開始時に既に inside=true で VISITED が出ない / PAUSED_AT が
+    // VISITED を経ずに出る等の lifecycle 違反になる)。
 
     for (const auto & poi : event_pois_) {
       double dist = distance_2d(poi.pose, rx, ry);
-      bool was_inside = poi_inside_state_[poi.name];
 
       // route 登録 POI かつ ROUTE mode 走行中なら event 発火対象 (#220)。
-      const bool is_route_poi = route_active &&
+      // is_pause_eligible は同じ前提 (ROUTE mode + active route POI) + pause タグの
+      // 3 条件、is_route_poi はそこから tag check を除いた superset。
+      // invariant: !is_route_poi → !is_pause_poi (is_pause_poi は is_route_poi の subset)。
+      const bool is_pause_poi = is_pause_eligible(poi, nav_mode_, current_route_poi_names_);
+      const bool is_route_poi = (nav_mode_ == NavMode::ROUTE) &&
         current_route_poi_names_.find(poi.name) != current_route_poi_names_.end();
 
-      // pause 自動発火は ROUTE 走行中 + active route POI + "pause" タグの 3 条件 (#143)。
-      // (is_route_poi と前提が一致するため、is_pause_eligible で同じ check を行う。)
-      const bool is_pause_poi = is_pause_eligible(poi, nav_mode_, current_route_poi_names_);
+      if (!is_route_poi) {
+        // route 外 POI / route 走行外 mode では state を書き換えない (lifecycle 保護)。
+        // pause 自動 trigger も is_pause_eligible で false なので発火しない。
+        continue;
+      }
+
+      bool was_inside = poi_inside_state_[poi.name];
 
       if (!was_inside && dist <= poi.tolerance.xy) {
-        // VISITED event: route POI のみ publish
+        // VISITED event
         poi_inside_state_[poi.name] = true;
-        if (is_route_poi) {
-          mapoi_interfaces::msg::PoiEvent event;
-          event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_VISITED;
-          event.poi = poi;
-          event.stamp = this->now();
-          poi_event_pub_->publish(event);
-          RCLCPP_INFO(this->get_logger(), "POI VISITED: %s (dist=%.2f, tolerance.xy=%.2f)",
-                      poi.name.c_str(), dist, poi.tolerance.xy);
-        }
-        // pauseタグがあれば自動pause対象 (active route POI かつ ROUTE 走行中のみ)
+        mapoi_interfaces::msg::PoiEvent event;
+        event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_VISITED;
+        event.poi = poi;
+        event.stamp = this->now();
+        poi_event_pub_->publish(event);
+        RCLCPP_INFO(this->get_logger(), "POI VISITED: %s (dist=%.2f, tolerance.xy=%.2f)",
+                    poi.name.c_str(), dist, poi.tolerance.xy);
+        // pauseタグがあれば自動pause対象
         if (is_pause_poi) {
           pause_triggered_poi = poi.name;
         }
       } else if (was_inside && dist > poi.tolerance.xy * hysteresis) {
-        // EXIT event: route POI のみ publish
+        // EXIT event
         poi_inside_state_[poi.name] = false;
         // PAUSED_AT 発火済 flag も EXIT で reset (#220 lifecycle: VISITED → [PAUSED_AT] → EXIT)
         poi_paused_at_published_[poi.name] = false;
-        if (is_route_poi) {
-          mapoi_interfaces::msg::PoiEvent event;
-          event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_EXIT;
-          event.poi = poi;
-          event.stamp = this->now();
-          poi_event_pub_->publish(event);
-          RCLCPP_INFO(this->get_logger(), "POI EXIT: %s (dist=%.2f, tolerance.xy=%.2f)",
-                      poi.name.c_str(), dist, poi.tolerance.xy);
-        }
+        mapoi_interfaces::msg::PoiEvent event;
+        event.event_type = mapoi_interfaces::msg::PoiEvent::EVENT_EXIT;
+        event.poi = poi;
+        event.stamp = this->now();
+        poi_event_pub_->publish(event);
+        RCLCPP_INFO(this->get_logger(), "POI EXIT: %s (dist=%.2f, tolerance.xy=%.2f)",
+                    poi.name.c_str(), dist, poi.tolerance.xy);
         continue;  // PAUSED_AT 判定不要 (今 tick で OUTSIDE 化)
       }
 

--- a/mapoi_server/test/test_mapoi_config.yaml
+++ b/mapoi_server/test/test_mapoi_config.yaml
@@ -22,3 +22,7 @@ poi:
 
 custom_tags:
   - {name: audio_info, description: "Audio guide trigger"}
+
+route:
+  - name: route_a
+    waypoints: [poi_goal_only, poi_with_pause, poi_with_custom, poi_pause_and_custom]

--- a/mapoi_server/test/test_mapoi_config.yaml
+++ b/mapoi_server/test/test_mapoi_config.yaml
@@ -23,6 +23,7 @@ poi:
 custom_tags:
   - {name: audio_info, description: "Audio guide trigger"}
 
+# route_a: ROUTE-mode integration test 用 (#220 follow-up で活用予定、現 PR では未使用)
 route:
   - name: route_a
     waypoints: [poi_goal_only, poi_with_pause, poi_with_custom, poi_pause_and_custom]

--- a/mapoi_server/test/test_nav2_bridge_unit.cpp
+++ b/mapoi_server/test/test_nav2_bridge_unit.cpp
@@ -237,52 +237,9 @@ TEST_F(Nav2BridgeTestFixture, ResetNavStateClearsRouteContext)
   EXPECT_DOUBLE_EQ(node_->paused_goal_pose_.pose.position.x, 0.0);
 }
 
-// --- compute_stopped_transition (#140) ---
-// STOPPED/RESUMED 判定の純関数 state machine の test。副作用なしで inside / was_stopped /
-// zero_velocity_dwelled の組み合わせから次の遷移を返すだけなので Node 不要 (TEST で十分)。
-
-TEST_F(Nav2BridgeTestFixture, ComputeStoppedTransitionNoOutside)
-{
-  using S = MapoiNav2Bridge::StoppedDetectionInputs;
-  using T = MapoiNav2Bridge::StoppedTransition;
-  // !inside の場合は state に関わらず NONE (EXIT で別途 stopped state を reset する規約)。
-  EXPECT_EQ(MapoiNav2Bridge::compute_stopped_transition(S{false, false, false}), T::NONE);
-  EXPECT_EQ(MapoiNav2Bridge::compute_stopped_transition(S{false, false, true}),  T::NONE);
-  EXPECT_EQ(MapoiNav2Bridge::compute_stopped_transition(S{false, true, false}),  T::NONE);
-  EXPECT_EQ(MapoiNav2Bridge::compute_stopped_transition(S{false, true, true}),   T::NONE);
-}
-
-TEST_F(Nav2BridgeTestFixture, ComputeStoppedTransitionEnterStopped)
-{
-  using S = MapoiNav2Bridge::StoppedDetectionInputs;
-  using T = MapoiNav2Bridge::StoppedTransition;
-  // inside + !was_stopped + dwelled → TO_STOPPED
-  EXPECT_EQ(MapoiNav2Bridge::compute_stopped_transition(S{true, false, true}), T::TO_STOPPED);
-}
-
-TEST_F(Nav2BridgeTestFixture, ComputeStoppedTransitionEnterMoving)
-{
-  using S = MapoiNav2Bridge::StoppedDetectionInputs;
-  using T = MapoiNav2Bridge::StoppedTransition;
-  // inside + !was_stopped + !dwelled → NONE (停止が dwell 経過するまで何もしない)
-  EXPECT_EQ(MapoiNav2Bridge::compute_stopped_transition(S{true, false, false}), T::NONE);
-}
-
-TEST_F(Nav2BridgeTestFixture, ComputeStoppedTransitionResumeOnVelocity)
-{
-  using S = MapoiNav2Bridge::StoppedDetectionInputs;
-  using T = MapoiNav2Bridge::StoppedTransition;
-  // inside + was_stopped + !dwelled (動き始めた) → TO_RESUMED (即時、dwell 不要)
-  EXPECT_EQ(MapoiNav2Bridge::compute_stopped_transition(S{true, true, false}), T::TO_RESUMED);
-}
-
-TEST_F(Nav2BridgeTestFixture, ComputeStoppedTransitionStaysStopped)
-{
-  using S = MapoiNav2Bridge::StoppedDetectionInputs;
-  using T = MapoiNav2Bridge::StoppedTransition;
-  // inside + was_stopped + dwelled (停止継続) → NONE (重複 STOPPED 発火しない)
-  EXPECT_EQ(MapoiNav2Bridge::compute_stopped_transition(S{true, true, true}), T::NONE);
-}
+// (#220 で compute_stopped_transition / StoppedDetectionInputs / StoppedTransition を撤去。
+//  EVENT_STOPPED / EVENT_RESUMED 自体が消え、PAUSED_AT は cmd_vel dwell ベースの単純判定で
+//  純関数 state machine 不要になったため、unit test 群も併せて削除した。)
 
 int main(int argc, char ** argv)
 {

--- a/mapoi_server/test/test_poi_event_integration.py
+++ b/mapoi_server/test/test_poi_event_integration.py
@@ -129,7 +129,7 @@ class TestPoiEventIntegration(unittest.TestCase):
     @classmethod
     def _event_callback(cls, msg):
         cls.received_events.append(msg)
-        if msg.event_type == PoiEvent.EVENT_ENTER:
+        if msg.event_type == PoiEvent.EVENT_VISITED:
             cls.inside_state[msg.poi.name] = True
         elif msg.event_type == PoiEvent.EVENT_EXIT:
             cls.inside_state[msg.poi.name] = False
@@ -235,159 +235,31 @@ class TestPoiEventIntegration(unittest.TestCase):
                 return True
         return False
 
-    def _enter_poi(self, poi_name, x, y):
-        self._set_cmd_vel(0.2, 0.0)
-        self._spin_for(0.2)
-        self._set_robot_pose(x, y)
-        found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_ENTER
-                       and e.poi.name == poi_name))
-        self.assertTrue(found, f"{poi_name} に ENTER できるべき")
+    # 旧 _enter_poi / _enter_and_stop_poi は #220 で撤去。新 spec では _activate_route
+    # 経由で ROUTE mode に入ってから VISITED を待つ流れに変更 (各 test 内で構築)。
 
-    def _enter_and_stop_poi(self, poi_name='poi_goal_only', x=1.0, y=0.0):
-        self._enter_poi(poi_name, x, y)
-        self.received_events.clear()
-        self._set_cmd_vel(0.0, 0.0)
-        found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_STOPPED
-                       and e.poi.name == poi_name),
-            timeout_sec=self.EVENT_WAIT_TIMEOUT)
-        self.assertTrue(found, f"{poi_name} の EVENT_STOPPED が発行されるべき")
+    # --- 新 PoiEvent 仕様 (#220) ---
+    # EVENT_VISITED / EVENT_PAUSED_AT / EVENT_EXIT の 3 種別 + route 走行中 + route 登録 POI のみ。
+    #
+    # NOTE: ROUTE-mode integration test (VISITED / PAUSED_AT / EXIT 発火確認) は本 PR では
+    # 含まない。bridge は `mapoi_route_cb` で Nav2 FollowWaypoints action server に
+    # 接続できないと `reset_nav_state()` で `nav_mode_` を IDLE に戻すため、ROUTE mode
+    # を維持して event 発火を観測するには Nav2 action server mock が必要。これは scope が
+    # 中規模 (mock setup + test infra) のため別 issue で扱う。本 PR では下の
+    # `test_no_event_in_non_route_mode` で「新 spec で route 走行外 (IDLE / GOAL mode) は
+    # event を発火しない」ことを negative evidence として確認する。
 
-    def test_enter_event_goal_only_poi(self):
-        """goalタグのみのPOI (1.0, 0.0) 付近 → ENTER イベント発行"""
-        self._set_robot_pose(1.0, 0.0)
-        found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_ENTER
-                       and e.poi.name == 'poi_goal_only'))
-        self.assertTrue(found,
-                        "goal-only POI の ENTER イベントが発行されるべき")
+    def test_no_event_in_non_route_mode(self):
+        """route 走行外 (IDLE / GOAL mode、ROUTE 未開始) では POI に侵入しても event 発火しない (#220)。
 
-    def test_isolation_re_enter_same_poi(self):
-        """isolation 検証 (#165): 同 POI に ENTER → reset → 再 ENTER できる
-        ことを 1 test 内で完結確認する。実行順や個別実行に依存しない。
-
-        reset helper で `poi_inside_state_` を false に戻していなければ
-        ENTER の再発火条件 (was_inside=false && dist <= radius) を満たせず
-        2 回目の `_wait_for_event` が timeout する。helper を tearDown とも
-        共有しているので、本 test が PASS する限り tearDown isolation も
-        実装上等価に検証できる。
+        旧 spec では IDLE / GOAL でも EVENT_ENTER が発火していたため、本 test は
+        新 spec への migration evidence として機能する (旧コードでは fail、新コードで pass)。
         """
+        # ROUTE mode に入っていない = nav_mode_ は IDLE のまま
         self._set_robot_pose(1.0, 0.0)
-        found1 = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_ENTER
-                       and e.poi.name == 'poi_goal_only'))
-        self.assertTrue(found1,
-                        "1 回目: poi_goal_only に ENTER できるべき")
-
-        self._reset_inside_state()
-
-        self._set_robot_pose(1.0, 0.0)
-        found2 = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_ENTER
-                       and e.poi.name == 'poi_goal_only'))
-        self.assertTrue(found2,
-                        "reset 後: 同 POI への再 ENTER が観測されるべき")
-
-    def test_enter_event_pause_poi(self):
-        """pauseタグ付きPOI (0.0, 2.0) 付近 → ENTER イベント発行"""
-        self._set_robot_pose(0.0, 2.0)
-        found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_ENTER
-                       and e.poi.name == 'poi_with_pause'))
-        self.assertTrue(found,
-                        "pause POI の ENTER イベントが発行されるべき")
-
-    def test_enter_event_custom_poi(self):
-        """custom_tag付きPOI (3.0, 0.0) 付近 → ENTER イベント発行"""
-        self._set_robot_pose(3.0, 0.0)
-        found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_ENTER
-                       and e.poi.name == 'poi_with_custom'))
-        self.assertTrue(found,
-                        "custom_tag POI の ENTER イベントが発行されるべき")
-
-    def test_exit_event(self):
-        """POI内 → radius外 に移動 → EXIT イベント発行"""
-        # 後段の EXIT 条件 (was_inside && dist > radius*hyst) は前段で ENTER して
-        # was_inside=true を成立させないと永遠に満たせない。前提を assert で固定する。
-        self._set_robot_pose(1.0, 0.0)
-        enter_found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_ENTER
-                       and e.poi.name == 'poi_goal_only'))
-        self.assertTrue(enter_found,
-                        "前提: poi_goal_only が ENTER 状態になっていること")
-        self.received_events.clear()
-        # radius=0.5, hysteresis=1.15 → 0.575m以上離れる
-        self._set_robot_pose(5.0, 5.0)
-        exit_found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_EXIT
-                       and e.poi.name == 'poi_goal_only'))
-        self.assertTrue(exit_found,
-                        "poi_goal_only の EXIT イベントが発行されるべき")
-
-    def test_stopped_event_from_cmd_vel_dwell_once(self):
-        """cmd_vel=0 の dwell 継続で STOPPED が 1 回だけ発火する (#177)。"""
-        self._enter_poi('poi_goal_only', 1.0, 0.0)
-        self.received_events.clear()
-
-        self._set_cmd_vel(0.0, 0.0)
-        stopped_found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_STOPPED
-                       and e.poi.name == 'poi_goal_only'))
-        self.assertTrue(stopped_found,
-                        "cmd_vel=0 dwell 後に EVENT_STOPPED が発行されるべき")
-        stopped_count = self._count_events(
-            lambda e: (e.event_type == PoiEvent.EVENT_STOPPED
-                       and e.poi.name == 'poi_goal_only'))
-
-        self._spin_for(STOPPED_DWELL_TIME_SEC + 0.5)
-        self.assertEqual(
-            self._count_events(
-                lambda e: (e.event_type == PoiEvent.EVENT_STOPPED
-                           and e.poi.name == 'poi_goal_only')),
-            stopped_count,
-            "停止継続中に EVENT_STOPPED が重複発行されるべきではない")
-
-    def test_resumed_event_when_cmd_vel_recovers(self):
-        """STOPPED 中に cmd_vel が復活すると dwell なしで RESUMED が発火する (#177)。"""
-        self._enter_and_stop_poi('poi_goal_only', 1.0, 0.0)
-        self.received_events.clear()
-
-        self._set_cmd_vel(0.2, 0.0)
-        resumed_found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_RESUMED
-                       and e.poi.name == 'poi_goal_only'))
-        self.assertTrue(resumed_found,
-                        "cmd_vel 復活後に EVENT_RESUMED が発行されるべき")
-
-    def test_new_goal_resumes_stopped_poi_and_allows_next_stop_flow(self):
-        """STOPPED 中の新規 goal 受信で RESUMED し、次 POI でも STOPPED できる (#177)。"""
-        self._enter_and_stop_poi('poi_goal_only', 1.0, 0.0)
-        self.received_events.clear()
-
-        self.assertTrue(
-            self._wait_for_subscriber('mapoi/nav/goal_pose_poi'),
-            "mapoi_nav2_bridge が mapoi/nav/goal_pose_poi を subscribe しているべき")
-        msg = String()
-        msg.data = 'poi_with_custom'
-        self.goal_pose_poi_pub.publish(msg)
-
-        resumed_found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_RESUMED
-                       and e.poi.name == 'poi_goal_only'))
-        self.assertTrue(resumed_found,
-                        "新規 goal 受信で stopped POI の EVENT_RESUMED が発行されるべき")
-
-        # 新規 goal に向かって動き始めた状況を cmd_vel/TF で模擬し、次の POI でも
-        # ENTER → STOPPED flow が成立することを固定する。
-        self._set_cmd_vel(0.2, 0.0)
-        self._set_robot_pose(100.0, 100.0)
-        exit_found = self._wait_for_event(
-            lambda e: (e.event_type == PoiEvent.EVENT_EXIT
-                       and e.poi.name == 'poi_goal_only'))
-        self.assertTrue(exit_found,
-                        "新規 goal 走行開始後に旧 POI から EXIT できるべき")
-
-        self.received_events.clear()
-        self._enter_and_stop_poi('poi_with_custom', 3.0, 0.0)
+        # 発火しないことを timeout で確認
+        not_found = self._wait_for_event(
+            lambda e: e.poi.name == 'poi_goal_only',
+            timeout_sec=2.0)
+        self.assertFalse(not_found,
+                         "route 走行外 (IDLE / GOAL mode) では route POI でも event 発火しないべき")


### PR DESCRIPTION
## Summary

旧仕様 (4 種別: \`ENTER\` / \`EXIT\` / \`STOPPED\` / \`RESUMED\`、全 \`event_pois_\` で発火) を **3 種別** (\`VISITED\` / \`PAUSED_AT\` / \`EXIT\`、**route 走行中 + route 登録 POI のみ**) に簡素化する破壊的変更。subscriber 0 件 (本リポ内、grep 確認済) のため互換 alias なしで進める。Net diff: **-255 行 (-411 / +156)**。

## 仕様確定 (issue #220 本文の 3 論点)

| 論点 | 結論 |
|---|---|
| 「navigation が停止した」の定義 | **B. cmd_vel dwell only** (Nav2 SUCCEEDED は pause タグ POI が中間 waypoint で SUCCEEDED にならず不採用) |
| pause 自動 trigger との関係 | **OK**: ENTER pause POI → \`mapoi_pause_cb\` 内部呼び出し → Nav2 paused (cmd_vel 0) → cmd_vel dwell 検知 → \`EVENT_PAUSED_AT\` publish の流れで成立 |
| \`hysteresis_exit_multiplier\` | **存続** (EXIT 判定 logic 不変) |

## 新仕様

\`\`\`
PoiEvent.msg
  uint8 EVENT_VISITED=1     # route 走行中に route 登録 POI の tolerance.xy 半径へ侵入
  uint8 EVENT_PAUSED_AT=2   # pause タグ付き POI の tolerance.xy 内で navigation 停止 (cmd_vel dwell)
  uint8 EVENT_EXIT=3        # route 登録 POI から tolerance.xy * hysteresis を超えて退出
\`\`\`

ライフサイクル:
\`\`\`
EVENT_VISITED -> [EVENT_PAUSED_AT (only if pause-tagged + nav stops)] -> EVENT_EXIT
\`\`\`

route 走行外 (\`IDLE\` / \`GOAL\` mode、\`NavigateToPose\` 単発 goal や手動操縦) では event は発火しない。

## 撤去したもの

- \`EVENT_STOPPED\` / \`EVENT_RESUMED\` 定数 (RESUMED は client 側 resume request + \`mapoi/nav/status\` topic で観測可能)
- \`compute_stopped_transition\` 純関数 + \`StoppedDetectionInputs\` / \`StoppedTransition\` enum
- \`stop_all_inside_pois\` / \`resume_all_stopped_pois\` (Nav2 SUCCEEDED hook 経由 publish 撤去)
- 関連 unit test 5 件 + integration test 7 件

## ファイル変更

| ファイル | 変更 |
|---|---|
| \`mapoi_interfaces/msg/PoiEvent.msg\` | 3 種別 enum へ書き換え + controller cmd_vel publish 前提を冒頭注記 |
| \`mapoi_interfaces/README.md\` | PoiEvent 節を新 spec で書き直し (lifecycle 図 + 前提条件) |
| \`mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp\` | \`StoppedTransition\` / \`StoppedDetectionInputs\` 撤去、\`poi_stopped_state_\` → \`poi_paused_at_published_\` rename、FRIEND_TEST 5 件撤去 |
| \`mapoi_server/src/mapoi_nav2_bridge.cpp\` | \`tolerance_check_callback\` 簡素化 (route filter + 3 種別 publish)、\`stop_all_inside_pois\` / \`resume_all_stopped_pois\` / \`compute_stopped_transition\` 撤去 |
| \`mapoi_server/test/test_nav2_bridge_unit.cpp\` | \`compute_stopped_transition\` 5 件 unit test 撤去 |
| \`mapoi_server/test/test_poi_event_integration.py\` | 旧 ENTER/EXIT/STOPPED/RESUMED 系 7 件撤去、新 \`test_no_event_in_non_route_mode\` 追加 |
| \`mapoi_server/test/test_mapoi_config.yaml\` | \`route_a\` を追加 (将来の ROUTE-mode integration test 用) |
| \`mapoi_server/README.md\` | PoiEvent 節を新 spec で書き直し |
| \`docs/integration.md\` | event 説明を新 spec へ更新 |

## 動作確認

- \`env -u ROS_DISTRO docker compose run --rm dev colcon build && colcon test\` (jazzy default): **81 tests / 0 errors / 0 failures** (旧 93 → -12 撤去 / +1 追加)
- \`ROS_DISTRO=humble docker compose run --rm dev ...\`: 同様に **81 tests pass**
- \`scripts/check_docs_consistency.py\` / \`check_robot_radius_drift.py\` / \`check_sample_yaml_consistency.py\` 3 種全 OK

## Scope-out (follow-up issue 候補)

ROUTE-mode integration test (VISITED / PAUSED_AT / EXIT 発火確認) は本 PR では含めず。bridge は \`mapoi_route_cb\` で Nav2 FollowWaypoints action server に接続できないと \`reset_nav_state()\` で \`nav_mode_\` を IDLE に戻すため、ROUTE mode を維持して event 発火を観測するには **Nav2 action server mock が必要** (scope 中規模)。本 PR では \`test_no_event_in_non_route_mode\` で「新 spec で route 走行外は event を発火しない」 negative evidence を提供。

ROUTE-mode integration test は別 issue で:
- Nav2 FollowWaypoints fake action server を test launch_description に追加
- \`route_a\` route 経由で ROUTE mode 維持
- VISITED / PAUSED_AT / EXIT の 3 種別を網羅 test

## 影響範囲

- 破壊的変更だが本リポ内 subscriber 0 件、影響は外部 (inbox 設計フェーズの subscriber や issue #88 sample) で吸収
- 機能後退: route 走行外での POI 接近通知が消える (subscriber は \`mapoi/nav/status\` の \`succeeded:<poi_name>\` で代替検知可能)
- 機能取得: subscriber 側の handler 単純化、event 数が絞られて意図が明確に

## Migration

旧 spec subscriber が居る場合 (本リポ外):

| 旧 event | 新対応 |
|---|---|
| \`EVENT_ENTER\` (任意 mode) | \`EVENT_VISITED\` (route 走行中のみ) |
| \`EVENT_EXIT\` (任意 mode) | \`EVENT_EXIT\` (route 走行中のみ) |
| \`EVENT_STOPPED\` | \`EVENT_PAUSED_AT\` (pause タグ POI のみ)、または \`mapoi/nav/status\` の \`succeeded:<target>\` |
| \`EVENT_RESUMED\` | \`mapoi/nav/status\` の状態遷移 (\`paused\` → \`navigating\`) で代替検知 |

## Test plan

- [x] humble colcon build / test 81 件 pass
- [x] jazzy colcon build / test 81 件 pass
- [x] consistency-check 3 種
- [ ] CI green (Consistency Check + WebUI vitest)
- [ ] follow-up issue 起票: ROUTE-mode integration test with Nav2 mock

## Next

merge 後、follow-up issue (ROUTE-mode integration test with Nav2 mock) を起票して #88 sample subscriber 設計と並行で進める。

🤖 Generated with [Claude Code](https://claude.com/claude-code)