### PR TITLE
test(events): ROUTE-mode PoiEvent integration test を追加 (Close #226)

### DIFF
--- a/mapoi_server/CMakeLists.txt
+++ b/mapoi_server/CMakeLists.txt
@@ -109,6 +109,13 @@ if(BUILD_TESTING)
   add_launch_test(
     test/test_poi_event_integration.py
   )
+  # ROUTE-mode 経路は Nav2 follow_waypoints mock が前提なので別ファイルに分離 (#226)。
+  # mock の MultiThreadedExecutor 立ち上げ + 複数 test の cancel/cleanup 待ちで
+  # 5 test 合計 60s を超えやすいため、default 60s から 120s へ延長。
+  add_launch_test(
+    test/test_poi_event_route_integration.py
+    TIMEOUT 120
+  )
   add_launch_test(
     test/test_reload_clears_initialpose.py
   )

--- a/mapoi_server/test/test_poi_event_route_integration.py
+++ b/mapoi_server/test/test_poi_event_route_integration.py
@@ -1,0 +1,464 @@
+"""ROUTE-mode PoiEvent 発火 integration test (#226).
+
+`test_poi_event_integration.py` (negative evidence: route 走行外では発火しない) の
+positive 版。bridge が ROUTE mode に入ってから ENTER / PAUSED / EXIT が発火することを
+launch_testing で検証する。
+
+bridge は `mapoi_route_cb` で Nav2 ``follow_waypoints`` action server に接続できないと
+``reset_nav_state()`` で ``nav_mode_`` を IDLE に戻すため、ROUTE mode を維持して event
+発火を観測するには Nav2 mock が必須。本テストでは下記 ``FakeFollowWaypointsServer``
+が単一の goal を ACCEPTED → EXECUTING で保持し、cancel 要求が来たら CANCELED で
+finalize するだけの最小実装。tolerance event 判定は TF 由来なので Nav2 feedback の
+``current_waypoint`` 進行は不要 (mock は feedback も result 進行も流さない)。
+"""
+
+import os
+import threading
+import time
+import unittest
+
+import launch
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+
+import rclpy
+from rclpy.action import ActionServer, CancelResponse
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+from tf2_ros import TransformBroadcaster
+from geometry_msgs.msg import TransformStamped
+from geometry_msgs.msg import Twist
+from mapoi_interfaces.msg import PoiEvent
+from nav2_msgs.action import FollowWaypoints
+from ament_index_python.packages import get_package_share_directory
+from std_msgs.msg import String
+
+
+# pause 判定 dwell。tolerance_check_hz=10 (= 100ms) より十分長く取り、PAUSED まで
+# 到達するまでの待ち時間を test 全体で短く保つ。
+STOPPED_DWELL_TIME_SEC = 0.3
+
+
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    pkg_share = get_package_share_directory('mapoi_server')
+    test_config_dir = os.path.join(pkg_share, 'test')
+
+    mapoi_server_node = launch_ros.actions.Node(
+        package='mapoi_server',
+        executable='mapoi_server',
+        name='mapoi_server',
+        parameters=[{
+            'maps_path': test_config_dir,
+            'map_name': '.',
+            'config_file': 'test_mapoi_config.yaml',
+        }],
+    )
+
+    mapoi_nav2_bridge_node = launch_ros.actions.Node(
+        package='mapoi_server',
+        executable='mapoi_nav2_bridge',
+        name='mapoi_nav2_bridge',
+        parameters=[{
+            'tolerance_check_hz': 10.0,
+            'map_frame': 'map',
+            'base_frame': 'base_link',
+            'stopped_dwell_time_sec': STOPPED_DWELL_TIME_SEC,
+        }],
+    )
+
+    return launch.LaunchDescription([
+        mapoi_server_node,
+        mapoi_nav2_bridge_node,
+        launch_testing.actions.ReadyToTest(),
+    ]), {'mapoi_server': mapoi_server_node, 'mapoi_nav2_bridge': mapoi_nav2_bridge_node}
+
+
+class FakeFollowWaypointsServer:
+    """Nav2 ``follow_waypoints`` の最小 mock。
+
+    bridge が ROUTE mode を維持できるよう、accept した goal を cancel まで
+    EXECUTING で保持する。``execute_callback`` は cancel 待ちの polling loop を
+    回す都合で blocking するため、test 本体の rclpy spin とは分離が必要。
+    また goal acceptance / cancel request / execute_callback を 1 thread に
+    押し込むと acceptance response が client に届く前に execute_callback で
+    詰まり、bridge 側 ``goal_response_callback`` が永遠に来ない事象が起きる
+    (humble / jazzy 両方で観測)。回避のため ReentrantCallbackGroup +
+    ``MultiThreadedExecutor`` を daemon thread で回し、acceptance / cancel /
+    execute を並列に処理させる。
+
+    feedback (current_waypoint 進行) は publish しない: bridge の event 発火は TF
+    由来であり、``feedback_callback`` の更新は cancel 時の paused_waypoints slice
+    にのみ影響するが、本 test は cancel 後の resume を扱わないので無視できる。
+    """
+
+    def __init__(self):
+        self._node = rclpy.create_node('fake_follow_waypoints_server')
+        # ReentrantCallbackGroup で acceptance / cancel / execute_callback を並列化。
+        # MutuallyExclusive だと execute_callback の polling loop が他 callback を blocking する。
+        callback_group = ReentrantCallbackGroup()
+        self._action_server = ActionServer(
+            self._node, FollowWaypoints, 'follow_waypoints',
+            execute_callback=self._execute_callback,
+            cancel_callback=lambda gh: CancelResponse.ACCEPT,
+            handle_accepted_callback=lambda gh: gh.execute(),
+            callback_group=callback_group,
+        )
+        # execute_callback が long-running polling のため、acceptance / cancel と並列で
+        # 動かせる thread 数 (>=2) が必要。余裕を見て 4。
+        self._executor = MultiThreadedExecutor(num_threads=4)
+        self._executor.add_node(self._node)
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+        self._thread.start()
+
+    def _spin(self):
+        while rclpy.ok() and not self._stop_event.is_set():
+            self._executor.spin_once(timeout_sec=0.05)
+
+    def _execute_callback(self, goal_handle):
+        # cancel 要求が来るまで EXECUTING 状態を維持。tearDownClass で stop_event を
+        # set すると executor が止まるので、生存中の goal は ROS2 が abort する。
+        while (rclpy.ok() and not self._stop_event.is_set()
+               and not goal_handle.is_cancel_requested):
+            time.sleep(0.05)
+        if goal_handle.is_cancel_requested:
+            goal_handle.canceled()
+        else:
+            # shutdown 経路: rclpy が落ちる前に明示的に abort する。
+            goal_handle.abort()
+        return FollowWaypoints.Result()
+
+    def shutdown(self):
+        self._stop_event.set()
+        # daemon thread を join しても rclpy 側は context shutdown でまとめて掃除される。
+        # spin_once が timeout=0.05s なので最大 50ms で抜ける。
+        self._thread.join(timeout=1.0)
+        try:
+            self._executor.shutdown()
+        finally:
+            self._node.destroy_node()
+
+
+class TestPoiEventRouteIntegration(unittest.TestCase):
+    """ROUTE mode で ENTER / PAUSED / EXIT が新仕様 (#220) どおり発火する positive 経路。
+
+    mock action server を立てて bridge を ROUTE mode に押し込み、TF / cmd_vel を
+    test 側から動かして event 発火を観測する。各 test 後は cancel + 遠ざけで
+    bridge 内 state を IDLE / inside=false に戻す。
+    """
+
+    EVENT_WAIT_TIMEOUT = 5.0
+    NAV_STATUS_WAIT_TIMEOUT = 5.0
+    TF_PUBLISH_INTERVAL = 0.05
+    CMD_VEL_PUBLISH_INTERVAL = 0.05
+    FAR_AWAY_XY = (100.0, 100.0)
+    DEFAULT_ROUTE_NAME = 'route_a'
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('test_poi_event_route_node')
+        cls.received_events = []
+        cls.received_nav_status = []
+        cls.inside_state = {}
+
+        cls.event_sub = cls.node.create_subscription(
+            PoiEvent, 'mapoi/events', cls._event_callback, 10)
+        # mapoi/nav/status は bridge 側 publisher が transient_local (mapoi_nav2_bridge.cpp:51)。
+        # default (volatile) subscriber では QoS 不整合で全メッセージが drop される。
+        nav_status_qos = QoSProfile(
+            depth=10,
+            history=QoSHistoryPolicy.KEEP_LAST,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+        )
+        cls.nav_status_sub = cls.node.create_subscription(
+            String, 'mapoi/nav/status', cls._nav_status_callback, nav_status_qos)
+        cls.tf_broadcaster = TransformBroadcaster(cls.node)
+        cls.cmd_vel_pub = cls.node.create_publisher(Twist, 'cmd_vel', 10)
+        cls.route_pub = cls.node.create_publisher(String, 'mapoi/nav/route', 1)
+        cls.cancel_pub = cls.node.create_publisher(String, 'mapoi/nav/cancel', 1)
+
+        cls._robot_xy = cls.FAR_AWAY_XY
+        cls._cmd_vel_linear_x = 0.2
+        cls._cmd_vel_angular_z = 0.0
+        cls._tf_timer = cls.node.create_timer(
+            cls.TF_PUBLISH_INTERVAL, cls._tf_publish_callback)
+        cls._cmd_vel_timer = cls.node.create_timer(
+            cls.CMD_VEL_PUBLISH_INTERVAL, cls._cmd_vel_publish_callback)
+
+        # Nav2 mock を最後に立てる: 上記 publisher / subscription の discovery と並行で
+        # action server discovery を流して試験開始までの wait を短縮する。
+        cls.fake_server = FakeFollowWaypointsServer()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.fake_server.shutdown()
+        finally:
+            try:
+                cls.node.destroy_timer(cls._cmd_vel_timer)
+                cls.node.destroy_timer(cls._tf_timer)
+                cls.node.destroy_node()
+            finally:
+                rclpy.shutdown()
+
+    @classmethod
+    def _tf_publish_callback(cls):
+        x, y = cls._robot_xy
+        t = TransformStamped()
+        t.header.stamp = cls.node.get_clock().now().to_msg()
+        t.header.frame_id = 'map'
+        t.child_frame_id = 'base_link'
+        t.transform.translation.x = x
+        t.transform.translation.y = y
+        t.transform.translation.z = 0.0
+        t.transform.rotation.w = 1.0
+        cls.tf_broadcaster.sendTransform(t)
+
+    @classmethod
+    def _cmd_vel_publish_callback(cls):
+        msg = Twist()
+        msg.linear.x = cls._cmd_vel_linear_x
+        msg.angular.z = cls._cmd_vel_angular_z
+        cls.cmd_vel_pub.publish(msg)
+
+    @classmethod
+    def _event_callback(cls, msg):
+        cls.received_events.append(msg)
+        if msg.event_type == PoiEvent.EVENT_ENTER:
+            cls.inside_state[msg.poi.name] = True
+        elif msg.event_type == PoiEvent.EVENT_EXIT:
+            cls.inside_state[msg.poi.name] = False
+
+    @classmethod
+    def _nav_status_callback(cls, msg):
+        cls.received_nav_status.append(msg.data)
+
+    def setUp(self):
+        # 全 POI から十分遠い位置で開始し、ROUTE 起動前の inside ENTER を防ぐ。
+        self._set_robot_pose(*self.FAR_AWAY_XY)
+        self._set_cmd_vel(0.2, 0.0)
+        self.received_events.clear()
+        self.received_nav_status.clear()
+        # POI list の初期 fetch + tag definitions の取得まで bridge が落ち着くのを待つ。
+        # 1 度のみ実行: 2 回目以降の test では subscriber は既に揃っている。
+        self.assertTrue(self._wait_for_subscriber('mapoi/nav/route'),
+                        'mapoi_nav2_bridge subscribed mapoi/nav/route が見えない')
+
+    def tearDown(self):
+        """次 test の干渉を消して bridge 内 state を IDLE / inside=false に戻す。
+
+        bridge の ``mapoi_cancel_cb`` は cancel 不要時 (handle が pause 経路で既に
+        reset 済等) でも ``reset_nav_state()`` を呼ぶため、cancel publish だけで
+        ``nav_mode_`` / ``poi_inside_state_`` / ``is_paused_`` は IDLE にリセット
+        される。``"canceled"`` status は経路によっては publish されない (pause 後の
+        2 度目 cancel 等) ので待たない (浪費)。代わりに 1 周期分 spin して
+        reset_nav_state の効果が反映されるのを待つ。
+
+        test 側の ``inside_state`` (subscriber 視点) は EVENT_EXIT 受信で更新する
+        が、cancel 後は bridge が ``current_route_poi_names_`` を空にしているため
+        ``is_route_poi=false`` で EXIT も発火しない (#220 lifecycle 保護)。よって
+        test 側 tracker を bridge の reset と整合させるため明示クリアする。
+        """
+        self._publish_cancel()
+        self._spin_for(0.3)
+        type(self).inside_state.clear()
+        self.received_events.clear()
+        self.received_nav_status.clear()
+        self._set_cmd_vel(0.2, 0.0)
+        self._set_robot_pose(*self.FAR_AWAY_XY)
+
+    # --- helpers ---
+
+    def _set_robot_pose(self, x, y):
+        type(self)._robot_xy = (x, y)
+
+    def _set_cmd_vel(self, linear_x, angular_z):
+        type(self)._cmd_vel_linear_x = linear_x
+        type(self)._cmd_vel_angular_z = angular_z
+
+    def _spin_for(self, duration_sec):
+        end_time = time.monotonic() + duration_sec
+        while time.monotonic() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+
+    def _wait_for_subscriber(self, topic_name, timeout_sec=5.0):
+        end_time = time.monotonic() + timeout_sec
+        while time.monotonic() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+            if self.node.count_subscribers(topic_name) > 0:
+                return True
+        return False
+
+    def _wait_for_event(self, predicate, timeout_sec=None):
+        if timeout_sec is None:
+            timeout_sec = self.EVENT_WAIT_TIMEOUT
+        end_time = time.monotonic() + timeout_sec
+        while time.monotonic() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if any(predicate(e) for e in self.received_events):
+                return True
+        return False
+
+    def _wait_for_nav_status(self, status, timeout_sec=None):
+        """``status`` の publish を観測したら True。
+
+        bridge の publish_nav_status は ``status:target`` 形式 (target 有り) または
+        ``status`` 単独 (target 空) で出る (mapoi_nav2_bridge.cpp:728)。``status``
+        prefix で startswith マッチして target 文字列の差を吸収する。
+        """
+        if timeout_sec is None:
+            timeout_sec = self.NAV_STATUS_WAIT_TIMEOUT
+        end_time = time.monotonic() + timeout_sec
+        while time.monotonic() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if any(s == status or s.startswith(status + ':')
+                   for s in self.received_nav_status):
+                return True
+        return False
+
+    def _count_events(self, predicate):
+        return sum(1 for e in self.received_events if predicate(e))
+
+    def _compute_inside_pois(self):
+        return {name for name, inside in type(self).inside_state.items() if inside}
+
+    def _publish_route(self, route_name=None):
+        msg = String()
+        msg.data = route_name if route_name is not None else self.DEFAULT_ROUTE_NAME
+        self.route_pub.publish(msg)
+
+    def _publish_cancel(self):
+        msg = String()
+        msg.data = ''
+        self.cancel_pub.publish(msg)
+
+    def _activate_route(self, route_name=None):
+        """Route を投入し、bridge が ROUTE mode に入る (= "navigating" status) まで wait。
+
+        bridge は ``mapoi_route_cb`` → ``get_route_pois`` 待ち → action server readiness
+        判定 → ``async_send_goal`` の流れで ROUTE mode に入る。test 側は wait_for_subscriber
+        では action server discovery を見られないので、nav_status の "navigating" を
+        ROUTE mode 入りの signal として使う。
+        """
+        self._publish_route(route_name)
+        self.assertTrue(
+            self._wait_for_nav_status('navigating'),
+            f"route '{route_name or self.DEFAULT_ROUTE_NAME}' で 'navigating' status を観測できなかった "
+            f"(received: {self.received_nav_status})")
+
+    # --- tests ---
+    # route_a = [poi_goal_only(1,0), poi_with_pause(0,2,pause), poi_with_custom(3,0,audio_info),
+    #            poi_pause_and_custom(0,4,pause+audio_info)]
+
+    def test_enter_event_in_route_mode(self):
+        """ROUTE 走行中に route 登録 POI へ侵入すると EVENT_ENTER が発火する。"""
+        self._activate_route()
+        self._set_robot_pose(1.0, 0.0)  # poi_goal_only
+        self.assertTrue(
+            self._wait_for_event(
+                lambda e: (e.event_type == PoiEvent.EVENT_ENTER
+                           and e.poi.name == 'poi_goal_only')),
+            'route 登録 POI への侵入で EVENT_ENTER が発火するはず')
+
+    def test_exit_event_after_enter(self):
+        """ENTER 後に hysteresis * tolerance を超えて退出すると EVENT_EXIT が発火する。"""
+        self._activate_route()
+        self._set_robot_pose(1.0, 0.0)
+        self.assertTrue(
+            self._wait_for_event(
+                lambda e: (e.event_type == PoiEvent.EVENT_ENTER
+                           and e.poi.name == 'poi_goal_only')),
+            '前提: ENTER の発火')
+        self._set_robot_pose(*self.FAR_AWAY_XY)
+        self.assertTrue(
+            self._wait_for_event(
+                lambda e: (e.event_type == PoiEvent.EVENT_EXIT
+                           and e.poi.name == 'poi_goal_only')),
+            'POI から十分離れたら EVENT_EXIT が発火するはず')
+
+    def test_paused_event_in_pause_poi(self):
+        """pause タグ付き route POI 内で cmd_vel が dwell すると EVENT_PAUSED が 1 回発火する。"""
+        self._activate_route()
+        self._set_robot_pose(0.0, 2.0)  # poi_with_pause
+        self.assertTrue(
+            self._wait_for_event(
+                lambda e: (e.event_type == PoiEvent.EVENT_ENTER
+                           and e.poi.name == 'poi_with_pause')),
+            '前提: pause POI への ENTER')
+        # cmd_vel を 0 にして dwell 経過させる
+        self._set_cmd_vel(0.0, 0.0)
+        self.assertTrue(
+            self._wait_for_event(
+                lambda e: (e.event_type == PoiEvent.EVENT_PAUSED
+                           and e.poi.name == 'poi_with_pause')),
+            'pause POI + cmd_vel dwell で EVENT_PAUSED が発火するはず')
+        # 同 visit 中 (inside のまま) 余分な dwell が続いても 2 回目は出ない
+        self._spin_for(0.5)
+        paused_count = self._count_events(
+            lambda e: (e.event_type == PoiEvent.EVENT_PAUSED
+                       and e.poi.name == 'poi_with_pause'))
+        self.assertEqual(
+            paused_count, 1,
+            f'同 visit 内で EVENT_PAUSED は 1 回のみ (実際: {paused_count} 回)')
+
+    def test_no_paused_event_in_non_pause_poi(self):
+        """pause タグ無しの route POI では cmd_vel dwell でも EVENT_PAUSED は発火しない。"""
+        self._activate_route()
+        self._set_robot_pose(1.0, 0.0)  # poi_goal_only (pause タグ無し)
+        self.assertTrue(
+            self._wait_for_event(
+                lambda e: (e.event_type == PoiEvent.EVENT_ENTER
+                           and e.poi.name == 'poi_goal_only')),
+            '前提: ENTER の発火')
+        self._set_cmd_vel(0.0, 0.0)
+        # dwell threshold + 余裕分 spin して PAUSED が来ないことを確認
+        self._spin_for(STOPPED_DWELL_TIME_SEC + 0.5)
+        paused = self._count_events(
+            lambda e: (e.event_type == PoiEvent.EVENT_PAUSED
+                       and e.poi.name == 'poi_goal_only'))
+        self.assertEqual(
+            paused, 0,
+            f'pause タグ無しの POI で EVENT_PAUSED は発火しないはず (実際: {paused} 回)')
+
+    def test_re_enter_after_cancel_and_re_route(self):
+        """cancel + 再 route で同じ POI から再度 EVENT_ENTER が発火する (lifecycle invariant)。
+
+        bridge は cancel 時 (``mapoi_cancel_cb`` → ``reset_nav_state``) で
+        ``current_route_poi_names_`` / ``poi_inside_state_`` を clear する。これは
+        再 route 開始時に「既に inside=true で ENTER が発火しない」状態を防ぐための
+        保護 (#220)。本 test は cancel 後の 2 度目 ENTER がきちんと発火することで
+        この clear が効いていることを示す。
+
+        Note: cancel 直後に robot を遠ざけても EVENT_EXIT は発火しない (cancel 後は
+        ``nav_mode_=IDLE`` / route POI set 空で ``is_route_poi=false``、bridge の
+        lifecycle 保護で state を書き換えない)。EXIT を経由せずとも内部 state が
+        clear されているため、再 route 後の ENTER で十分検証できる。
+        """
+        self._activate_route()
+        self._set_robot_pose(1.0, 0.0)
+        self.assertTrue(
+            self._wait_for_event(
+                lambda e: (e.event_type == PoiEvent.EVENT_ENTER
+                           and e.poi.name == 'poi_goal_only')),
+            '前提: 1 回目の ENTER')
+        # cancel して route を畳む。cancel result が反映されるまで余裕を持って待つ。
+        self._publish_cancel()
+        self._wait_for_nav_status('canceled', timeout_sec=2.0)
+        self._spin_for(0.3)
+        self.received_events.clear()
+        self.received_nav_status.clear()
+        # 再 route 投入 + 同じ POI への再侵入で ENTER が再発火することを確認。
+        # 既に robot は (1.0, 0.0) のまま (= inside POI 上) だが、bridge 内
+        # poi_inside_state_ は cancel で clear 済なので新規 ENTER として観測されるはず。
+        self._activate_route()
+        self.assertTrue(
+            self._wait_for_event(
+                lambda e: (e.event_type == PoiEvent.EVENT_ENTER
+                           and e.poi.name == 'poi_goal_only')),
+            '再 route 後に同じ POI から再 ENTER が発火するはず')

--- a/mapoi_server/test/test_poi_event_route_integration.py
+++ b/mapoi_server/test/test_poi_event_route_integration.py
@@ -140,7 +140,12 @@ class FakeFollowWaypointsServer:
         try:
             self._executor.shutdown()
         finally:
-            self._node.destroy_node()
+            # ActionServer は Node.destroy_node() で waitable が確実に掃除されないため
+            # (humble の rclpy examples も destroy() を明示)、先に明示破棄する。
+            try:
+                self._action_server.destroy()
+            finally:
+                self._node.destroy_node()
 
 
 class TestPoiEventRouteIntegration(unittest.TestCase):
@@ -243,6 +248,11 @@ class TestPoiEventRouteIntegration(unittest.TestCase):
         # 全 POI から十分遠い位置で開始し、ROUTE 起動前の inside ENTER を防ぐ。
         self._set_robot_pose(*self.FAR_AWAY_XY)
         self._set_cmd_vel(0.2, 0.0)
+        # tearDown の cancel が遅延配送されて新 route を kill する race を防ぐ
+        # 防御 cancel + spin。idempotent (bridge 側 ``mapoi_cancel_cb`` は active
+        # goal 不在でも reset_nav_state() のみ呼ぶ)。
+        self._publish_cancel()
+        self._spin_for(0.2)
         self.received_events.clear()
         self.received_nav_status.clear()
         # POI list の初期 fetch + tag definitions の取得まで bridge が落ち着くのを待つ。
@@ -257,8 +267,11 @@ class TestPoiEventRouteIntegration(unittest.TestCase):
         reset 済等) でも ``reset_nav_state()`` を呼ぶため、cancel publish だけで
         ``nav_mode_`` / ``poi_inside_state_`` / ``is_paused_`` は IDLE にリセット
         される。``"canceled"`` status は経路によっては publish されない (pause 後の
-        2 度目 cancel 等) ので待たない (浪費)。代わりに 1 周期分 spin して
-        reset_nav_state の効果が反映されるのを待つ。
+        2 度目 cancel 等) ので待たない (浪費)。代わりに 0.5s spin して cancel
+        message が bridge へ届き ``reset_nav_state`` が実行されるのを待つ
+        (local DDS + reliable QoS で sub-ms latency、bridge は default executor
+        で tolerance_check を 100ms 周期で回しているので、tick 間に cancel が
+        処理される。3-5x マージン)。後段 setUp 側でも防御 cancel を打つ。
 
         test 側の ``inside_state`` (subscriber 視点) は EVENT_EXIT 受信で更新する
         が、cancel 後は bridge が ``current_route_poi_names_`` を空にしているため
@@ -266,7 +279,7 @@ class TestPoiEventRouteIntegration(unittest.TestCase):
         test 側 tracker を bridge の reset と整合させるため明示クリアする。
         """
         self._publish_cancel()
-        self._spin_for(0.3)
+        self._spin_for(0.5)
         type(self).inside_state.clear()
         self.received_events.clear()
         self.received_nav_status.clear()
@@ -325,9 +338,6 @@ class TestPoiEventRouteIntegration(unittest.TestCase):
     def _count_events(self, predicate):
         return sum(1 for e in self.received_events if predicate(e))
 
-    def _compute_inside_pois(self):
-        return {name for name, inside in type(self).inside_state.items() if inside}
-
     def _publish_route(self, route_name=None):
         msg = String()
         msg.data = route_name if route_name is not None else self.DEFAULT_ROUTE_NAME
@@ -383,7 +393,14 @@ class TestPoiEventRouteIntegration(unittest.TestCase):
             'POI から十分離れたら EVENT_EXIT が発火するはず')
 
     def test_paused_event_in_pause_poi(self):
-        """pause タグ付き route POI 内で cmd_vel が dwell すると EVENT_PAUSED が 1 回発火する。"""
+        """pause タグ付き route POI 内で cmd_vel が dwell すると EVENT_PAUSED が 1 回発火する。
+
+        EVENT_PAUSED 単独の assertion だけだと、auto-pause / FollowWaypoints cancel
+        の経路が壊れていても (TF + cmd_vel 由来の判定で) PAUSED は発火しうる。
+        bridge は pause タグ POI に ENTER した瞬間 ``mapoi_pause_cb`` 経由で
+        ``"paused"`` nav status を発行する (mapoi_nav2_bridge.cpp:903) ので、その
+        observation を併せて確認することで auto-pause regression も検出する。
+        """
         self._activate_route()
         self._set_robot_pose(0.0, 2.0)  # poi_with_pause
         self.assertTrue(
@@ -391,6 +408,11 @@ class TestPoiEventRouteIntegration(unittest.TestCase):
                 lambda e: (e.event_type == PoiEvent.EVENT_ENTER
                            and e.poi.name == 'poi_with_pause')),
             '前提: pause POI への ENTER')
+        # ENTER 直後に bridge が auto-pause を発火し "paused" nav status を出すはず。
+        # ここを assert することで auto-pause / cancel 経路の regression も検出する。
+        self.assertTrue(
+            self._wait_for_nav_status('paused', timeout_sec=2.0),
+            'pause POI への ENTER 直後に bridge が auto-pause で "paused" status を出すはず')
         # cmd_vel を 0 にして dwell 経過させる
         self._set_cmd_vel(0.0, 0.0)
         self.assertTrue(


### PR DESCRIPTION
## Summary
- PR #225 で deferred とした ROUTE-mode 経路の PoiEvent (ENTER / PAUSED / EXIT) 発火を launch_testing で固定
- bridge は Nav2 ``follow_waypoints`` action server 不在だと ROUTE mode に入れず IDLE に戻るため、最小 mock action server を test 内に同梱
- ``test_mapoi_config.yaml`` の ``route_a`` を活用し新規 5 test を追加

## 設計メモ

### Mock action server
- ``MultiThreadedExecutor + ReentrantCallbackGroup`` を daemon thread で回し、goal acceptance / cancel / EXECUTING 保持を並列化
- 単一 thread + ``MutuallyExclusive`` だと ``execute_callback`` の polling loop が他 callback を blocking し、bridge 側 ``goal_response_callback`` が永遠に来ない事象を回避
- feedback (``current_waypoint`` 進行) は publish しない: bridge の event 発火は TF 由来で十分

### 既知の落とし穴と対処
- ``mapoi/nav/status`` は bridge 側 ``transient_local`` publisher。default subscriber では QoS 不整合で全 drop されるため subscriber 側も ``RELIABLE + TRANSIENT_LOCAL`` で揃える
- ``publish_nav_status`` は ``"status:target"`` 形式 (target 有り) または ``"status"`` (target 空)。比較は prefix で吸収
- cancel 後は ``current_route_poi_names_`` / ``poi_inside_state_`` が clear され、route 外 POI は ``is_route_poi=false`` で event 発火しない (lifecycle 保護)。test_re_enter_after_cancel_and_re_route はこの保護があることを「再 ENTER が出る = state がリセットされている」で検証

### 検証シナリオ (5 test)
- ``test_enter_event_in_route_mode``: ROUTE 中の route POI 侵入で EVENT_ENTER
- ``test_exit_event_after_enter``: ENTER 後の遠ざけで EVENT_EXIT
- ``test_paused_event_in_pause_poi``: pause タグ + cmd_vel dwell で EVENT_PAUSED 1 回のみ
- ``test_no_paused_event_in_non_pause_poi``: pause タグ無し POI では cmd_vel dwell でも PAUSED 発火せず
- ``test_re_enter_after_cancel_and_re_route``: cancel + 再 route で同 POI から再 ENTER

## Test plan
- [x] humble docker で ``colcon test --packages-select mapoi_server`` 全 10 test pass (新規 5 含む) を確認
- [x] jazzy docker で ``colcon test --packages-select mapoi_server`` 全 10 test pass (新規 5 含む) を確認
- [x] 新規 launch_test 単体実行 ~5s/distro