### PR TITLE
feat(turtlebot3_example): tutorial_01_basic / tutorial_02_landmark route を追加

### DIFF
--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -5,6 +5,17 @@ custom_tags:
 - {name: destination, description: General destination point}
 - {name: audio_info, description: Audio guide trigger (POI 進入で音声再生)}
 route:
+# tutorial_01_basic: 最初に試す基本 demo (#230)。waypoint だけの 3 POI で POI 単発
+# goal / route 走行が動くことを確認する。pause / landmark / custom tag いずれも
+# 持たないので、最小機能の health check 用途。
+- name: tutorial_01_basic
+  waypoints: [meeting_room_a, conference_room, elevator_hall]
+# tutorial_02_landmark: landmark POI の概念 demo (#230)。route.landmarks に列挙した
+# landmark は Nav2 navigate されないが、route 走行中だけ radius event 監視対象になる
+# (#143 検証)。audio_info 等の custom tag は含まない (tutorial_04 で扱う)。
+- name: tutorial_02_landmark
+  waypoints: [meeting_room_a, conference_room]
+  landmarks: [tour_landmark]
 # tour_full: フルツアー。waypoints + landmarks 両方を持ち、連続 pause / 観察対象の
 # 全シナリオを 1 route で踏む (#143 route.landmarks の動作確認用)。
 - name: tour_full

--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -12,9 +12,12 @@ route:
   waypoints: [meeting_room_a, conference_room, elevator_hall]
 # tutorial_02_landmark: landmark POI の概念 demo (#230)。route.landmarks に列挙した
 # landmark は Nav2 navigate されないが、route 走行中だけ radius event 監視対象になる
-# (#143 検証)。audio_info 等の custom tag は含まない (tutorial_04 で扱う)。
+# (#143 検証)。両 landmark (tour_landmark / exhibit_display) の半径を 1 路で通過する
+# 経路を取り、route.landmarks に列挙した tour_landmark のみ EVENT_ENTER が pub され、
+# 同 map 上に存在する exhibit_display は列挙外なので pub されない動作を観測できる。
+# audio_info 等の custom tag は含まない (tutorial_04 で扱う)。
 - name: tutorial_02_landmark
-  waypoints: [meeting_room_a, conference_room]
+  waypoints: [landmark_demo_east, landmark_demo_west]
   landmarks: [tour_landmark]
 # tour_full: フルツアー。waypoints + landmarks 両方を持ち、連続 pause / 観察対象の
 # 全シナリオを 1 route で踏む (#143 route.landmarks の動作確認用)。
@@ -72,6 +75,20 @@ poi:
   pose: {x: -0.5, y: 0.5, yaw: -1.57}
   tolerance: {xy: 0.40, yaw: 0.785}
   tags: [waypoint, audio_info]
+# tutorial_02_landmark 専用の通過点ペア (#230)。東西に直線で抜けると、その間にある
+# tour_landmark (0.0, 0.2) と exhibit_display (-0.3, 0.3) の半径 0.30 内を robot が
+# 両方とも通過する。route.landmarks に列挙する側だけ EVENT_ENTER が pub される
+# コントラスト demo 用なので tour_full からは使わない。
+- description: tutorial_02_landmark 出発点 (両 landmark の東側、yaw 不問)
+  name: landmark_demo_east
+  pose: {x: 0.7, y: 0.4, yaw: 3.14}
+  tolerance: {xy: 0.40, yaw: 3.14}
+  tags: [waypoint]
+- description: tutorial_02_landmark 終点 (両 landmark の西側、yaw 不問)
+  name: landmark_demo_west
+  pose: {x: -0.8, y: 0.2, yaw: 3.14}
+  tolerance: {xy: 0.40, yaw: 3.14}
+  tags: [waypoint]
 # 以下 landmark 群: Nav2 navigation 不可な reference 点 (#85, #143)。
 # tour_full の landmarks: [...] で route 走行中だけ radius event 監視対象として扱う。
 # landmark × pause は排他 (#143 validation で reject) なので組み合わせない。


### PR DESCRIPTION
## Summary
- #230 提案 (https://github.com/shimz-robotics/mapoi/issues/230#issuecomment-4504939726) の最初の PR
- 「機能ごとに 1 route」構成の第一段階
- `tutorial_01_basic` (waypoint 3 点のみの最小 demo) と `tutorial_02_landmark` (route.landmarks の概念 demo) を `turtlebot3_world/mapoi_config.yaml` に追加
- `tutorial_02_landmark` 用に専用 waypoint (`landmark_demo_east` / `landmark_demo_west`) を 2 個追加。両 landmark (`tour_landmark` / `exhibit_display`) の半径 0.30 内を 1 路で通過する経路にし、route.landmarks 列挙の `tour_landmark` のみ EVENT_ENTER が pub される / 列挙外の `exhibit_display` は同 map 上に居ても pub されない、というコントラストが観測可能
- `tutorial_01_basic` は既存 POI (`meeting_room_a` / `conference_room` / `elevator_hall`) を流用

## Test plan
- [x] `python3 scripts/check_sample_yaml_consistency.py` 通過
- [ ] Docker (jazzy) で起動し、WebUI (http://localhost:8765) から動作確認

  ```sh
  cd /path/to/mapoi
  xhost +local:docker
  # host の ROS_DISTRO が humble の場合でも prefix で jazzy を強制
  ROS_DISTRO=jazzy docker compose run --rm dev
  # 中で
  cd /ros2_ws
  rosdep install --from-paths src --ignore-src -r -y    # 初回 or 依存変化時
  colcon build --symlink-install
  source install/setup.bash
  ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml
  ```

- [ ] `tutorial_01_basic` 選択 → `meeting_room_a → conference_room → elevator_hall` を順に走破して完走
- [ ] `tutorial_02_landmark` 選択 → `landmark_demo_east → landmark_demo_west` を走行
  - 別 terminal で `ros2 topic echo /mapoi/events` を流し、**`tour_landmark` の EVENT_ENTER / EVENT_EXIT のみが pub され、`exhibit_display` は同経路上に居ても一切 pub されない** ことを確認
  - 別 terminal は `ROS_DISTRO=jazzy docker compose run --rm dev` で別 container を起動して入る (host network 経由で同 DDS domain)

Refs #230
