### PR TITLE
fix(webui): POI Save 経路で float を yaml 桁数に丸める (Close #242)

### DIFF
--- a/mapoi_webui/CMakeLists.txt
+++ b/mapoi_webui/CMakeLists.txt
@@ -26,6 +26,12 @@ if(BUILD_TESTING)
     test/test_resolve_backend_status_for_ui.py
     TIMEOUT 10
   )
+  # yaml_handler._round_poi_floats の桁数契約 pin (#242)。frontend (poi-filter.js
+  # roundTo + POSE_*_DIGITS / TOLERANCE_*_DIGITS) と必ず一致させる。
+  ament_add_pytest_test(test_yaml_handler_round
+    test/test_yaml_handler_round.py
+    TIMEOUT 10
+  )
 endif()
 
 ament_package()

--- a/mapoi_webui/mapoi_webui/yaml_handler.py
+++ b/mapoi_webui/mapoi_webui/yaml_handler.py
@@ -4,7 +4,56 @@ Reads/writes mapoi_config.yaml, replacing only the 'poi' section
 while preserving 'map' and 'route' sections and unknown fields.
 """
 
+import math
+
 import yaml
+
+
+# yaml 書き出し時の有効桁数 (#242)。frontend (web/js/poi-filter.js) と必ず一致させる。
+# xy は mm 精度 (3 桁)、yaw は rad で約 0.006° 精度 (4 桁) — 0.0001 rad ≒ 0.0057°。
+# frontend readForm + backend save_pois の両層で丸めることで、yaml 直編集や非 WebUI
+# クライアントからの POST も含めて yaml の値展開を抑える defense-in-depth。
+_POSE_XY_DIGITS = 3
+_POSE_YAW_DIGITS = 4
+_TOLERANCE_XY_DIGITS = 3
+_TOLERANCE_YAW_DIGITS = 4
+
+
+def _round_finite(value, digits):
+    """Round value to digits decimal places; return value unchanged if not finite."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return value
+    if not math.isfinite(value):
+        return value
+    return round(float(value), digits)
+
+
+def _round_poi_floats(pois):
+    """Round POI pose / tolerance floats in-place before yaml.dump (#242).
+
+    yaml.dump は float をそのまま 17 桁前後の repr で書き出すため、`0.10000038...` の
+    ような ULP ノイズが yaml に残り git diff を汚す。frontend で丸めても yaml 直編集 +
+    非 WebUI クライアントからの POST 経路があるので backend 側でも同じ桁数で丸める。
+    """
+    if not isinstance(pois, list):
+        return
+    for poi in pois:
+        if not isinstance(poi, dict):
+            continue
+        pose = poi.get('pose')
+        if isinstance(pose, dict):
+            if 'x' in pose:
+                pose['x'] = _round_finite(pose['x'], _POSE_XY_DIGITS)
+            if 'y' in pose:
+                pose['y'] = _round_finite(pose['y'], _POSE_XY_DIGITS)
+            if 'yaw' in pose:
+                pose['yaw'] = _round_finite(pose['yaw'], _POSE_YAW_DIGITS)
+        tolerance = poi.get('tolerance')
+        if isinstance(tolerance, dict):
+            if 'xy' in tolerance:
+                tolerance['xy'] = _round_finite(tolerance['xy'], _TOLERANCE_XY_DIGITS)
+            if 'yaw' in tolerance:
+                tolerance['yaw'] = _round_finite(tolerance['yaw'], _TOLERANCE_YAW_DIGITS)
 
 
 def load_config(config_path):
@@ -21,6 +70,7 @@ def save_pois(config_path, pois):
         pois: List of POI dicts to write
     """
     config = load_config(config_path)
+    _round_poi_floats(pois)
     config['poi'] = pois
     with open(config_path, 'w') as f:
         yaml.dump(config, f, default_flow_style=None, allow_unicode=True, sort_keys=False)

--- a/mapoi_webui/test/test_yaml_handler_round.py
+++ b/mapoi_webui/test/test_yaml_handler_round.py
@@ -1,0 +1,100 @@
+"""Unit test for yaml_handler._round_poi_floats (#242).
+
+frontend (web/js/poi-editor.readForm + web/js/poi-filter.roundTo) で丸めた値が
+backend に届く前提だが、yaml 直編集や非 WebUI クライアントからの POST 経路でも
+yaml の値展開を抑えるため backend 側でも同じ桁数で丸める。本 test はその桁数
+契約 (frontend 側 POSE_XY_DIGITS=3 / POSE_YAW_DIGITS=4 等) を pin する。
+"""
+import math
+import os
+import tempfile
+import unittest
+
+import yaml
+
+from mapoi_webui.yaml_handler import _round_poi_floats, save_pois
+
+
+class TestRoundPoiFloats(unittest.TestCase):
+
+    def test_pose_xy_rounded_to_three_digits(self):
+        pois = [{
+            'name': 'p',
+            'pose': {'x': 0.10000038482226709, 'y': 1.2345678, 'yaw': 0.0},
+            'tolerance': {'xy': 0.5, 'yaw': 0.785},
+        }]
+        _round_poi_floats(pois)
+        self.assertEqual(pois[0]['pose']['x'], 0.1)
+        self.assertEqual(pois[0]['pose']['y'], 1.235)
+
+    def test_pose_yaw_rounded_to_four_digits(self):
+        pois = [{
+            'name': 'p',
+            'pose': {'x': 0.0, 'y': 0.0, 'yaw': 3.1399991679827224},
+            'tolerance': {'xy': 0.5, 'yaw': 0.785},
+        }]
+        _round_poi_floats(pois)
+        self.assertEqual(pois[0]['pose']['yaw'], 3.14)
+
+    def test_tolerance_yaw_rounded_to_four_digits(self):
+        pois = [{
+            'name': 'p',
+            'pose': {'x': 0.0, 'y': 0.0, 'yaw': 0.0},
+            'tolerance': {'xy': 0.50001, 'yaw': 0.7850002283279937},
+        }]
+        _round_poi_floats(pois)
+        self.assertEqual(pois[0]['tolerance']['xy'], 0.5)
+        self.assertEqual(pois[0]['tolerance']['yaw'], 0.785)
+
+    def test_non_finite_values_preserved(self):
+        """NaN / Infinity / bool / 文字列は丸めず透過する (validator が別途 reject する想定)."""
+        pois = [{
+            'name': 'p',
+            'pose': {'x': math.nan, 'y': math.inf, 'yaw': 'oops'},
+            'tolerance': {'xy': True, 'yaw': 0.785},
+        }]
+        _round_poi_floats(pois)
+        self.assertTrue(math.isnan(pois[0]['pose']['x']))
+        self.assertTrue(math.isinf(pois[0]['pose']['y']))
+        self.assertEqual(pois[0]['pose']['yaw'], 'oops')
+        self.assertIs(pois[0]['tolerance']['xy'], True)
+
+    def test_missing_pose_or_tolerance_keys_safe(self):
+        """pose / tolerance がそもそも dict でない POI は素通り (validator が別途 reject)."""
+        # 1.23456 を使う: 1.2345 (= 半端の境界値) は JS Math.round (half-up) と
+        # Python round (banker's rounding) で結果が分かれるため避ける。frontend で
+        # 既に丸めた値を再丸めする想定なので、実運用では半端境界は来ない。
+        pois = [
+            {'name': 'no_pose'},
+            {'name': 'partial', 'pose': {'x': 1.23456}},
+            {'name': 'broken', 'pose': 'string', 'tolerance': None},
+        ]
+        _round_poi_floats(pois)
+        self.assertEqual(pois[1]['pose']['x'], 1.235)
+
+    def test_non_list_pois_no_raise(self):
+        _round_poi_floats(None)
+        _round_poi_floats({'not': 'a list'})
+
+    def test_save_pois_writes_rounded_yaml(self):
+        """End-to-end: save_pois → yaml.dump 出力 → re-load で桁数が縮まっていること."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'mapoi_config.yaml')
+            with open(path, 'w') as f:
+                yaml.safe_dump({'map': {}, 'poi': [], 'route': []}, f)
+            save_pois(path, [{
+                'name': 'p',
+                'pose': {'x': 0.10000038482226709, 'y': 2.0, 'yaw': 3.1399991679827224},
+                'tolerance': {'xy': 0.5, 'yaw': 0.7850002283279937},
+                'tags': ['waypoint'],
+            }])
+            with open(path) as f:
+                reloaded = yaml.safe_load(f)
+            poi = reloaded['poi'][0]
+            self.assertEqual(poi['pose']['x'], 0.1)
+            self.assertEqual(poi['pose']['yaw'], 3.14)
+            self.assertEqual(poi['tolerance']['yaw'], 0.785)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mapoi_webui/tests/web/poi-filter.test.js
+++ b/mapoi_webui/tests/web/poi-filter.test.js
@@ -22,7 +22,12 @@ const {
   parseTolerance,
   degToRad,
   radToDeg,
+  roundTo,
   TOLERANCE_MIN,
+  POSE_XY_DIGITS,
+  POSE_YAW_DIGITS,
+  TOLERANCE_XY_DIGITS,
+  TOLERANCE_YAW_DIGITS,
 } = filter;
 
 const poi = (name, tags) => ({ name, tags });
@@ -150,6 +155,38 @@ describe('degToRad / radToDeg', () => {
     [0.1, 1, 45, 90, 180, 359].forEach((deg) => {
       expect(radToDeg(degToRad(deg))).toBeCloseTo(deg, 6);
     });
+  });
+});
+
+describe('roundTo (#242)', () => {
+  it('exposes save-path digit constants', () => {
+    // backend yaml_handler._POSE_XY_DIGITS 等と必ず一致させる (両層 defense-in-depth)
+    expect(POSE_XY_DIGITS).toBe(3);
+    expect(POSE_YAW_DIGITS).toBe(4);
+    expect(TOLERANCE_XY_DIGITS).toBe(3);
+    expect(TOLERANCE_YAW_DIGITS).toBe(4);
+  });
+
+  it('rounds finite numbers to the requested digits', () => {
+    expect(roundTo(0.10000038482226709, POSE_XY_DIGITS)).toBe(0.1);
+    expect(roundTo(3.1399991679827224, POSE_YAW_DIGITS)).toBe(3.14);
+    expect(roundTo(0.7850002283279937, TOLERANCE_YAW_DIGITS)).toBe(0.785);
+    expect(roundTo(1.2345, 2)).toBe(1.23);
+    expect(roundTo(1.2355, 2)).toBe(1.24);
+  });
+
+  it('accepts string input alongside numeric', () => {
+    expect(roundTo('1.23456', 3)).toBe(1.235);
+    // 数値文字列 → 丸めた結果が 0 (≒ -0 / +0 区別なく 0 扱い) になることだけを確認
+    expect(roundTo('-0.0049', 2) === 0).toBe(true);
+  });
+
+  it('returns NaN for non-numeric / non-finite input', () => {
+    expect(Number.isNaN(roundTo('', 3))).toBe(true);
+    expect(Number.isNaN(roundTo('abc', 3))).toBe(true);
+    expect(Number.isNaN(roundTo(NaN, 3))).toBe(true);
+    expect(Number.isNaN(roundTo(Infinity, 3))).toBe(true);
+    expect(Number.isNaN(roundTo(-Infinity, 3))).toBe(true);
   });
 });
 

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -242,9 +242,16 @@ class PoiEditor {
 
     const newPoi = {
       name: `poi_${this.pois.length}`,
-      pose: { x: Math.round(x * 100) / 100, y: Math.round(y * 100) / 100, yaw: 0.0 },
+      pose: {
+        x: MapoiPoiFilter.roundTo(x, MapoiPoiFilter.POSE_XY_DIGITS),
+        y: MapoiPoiFilter.roundTo(y, MapoiPoiFilter.POSE_XY_DIGITS),
+        yaw: 0.0,
+      },
       // default tolerance: xy=0.5 m / yaw=π/4 (45°) — sample yaml と整合 (#138)
-      tolerance: { xy: 0.5, yaw: Math.PI / 4 },
+      tolerance: {
+        xy: 0.5,
+        yaw: MapoiPoiFilter.roundTo(Math.PI / 4, MapoiPoiFilter.TOLERANCE_YAW_DIGITS),
+      },
       tags: ['waypoint'],
       description: '',
     };
@@ -315,15 +322,21 @@ class PoiEditor {
   fillForm(poi) {
     this.inputName.value = poi.name || '';
     const pose = poi.pose || {};
-    this.inputX.value = pose.x || 0;
-    this.inputY.value = pose.y || 0;
-    this.inputYaw.value = pose.yaw || 0;
+    // 入力欄表示時点で yaml の有効桁数に丸める (#242)。display と Save 値の不一致を防ぐ。
+    const xRounded = MapoiPoiFilter.roundTo(pose.x, MapoiPoiFilter.POSE_XY_DIGITS);
+    const yRounded = MapoiPoiFilter.roundTo(pose.y, MapoiPoiFilter.POSE_XY_DIGITS);
+    const yawRounded = MapoiPoiFilter.roundTo(pose.yaw, MapoiPoiFilter.POSE_YAW_DIGITS);
+    this.inputX.value = Number.isFinite(xRounded) ? xRounded : 0;
+    this.inputY.value = Number.isFinite(yRounded) ? yRounded : 0;
+    this.inputYaw.value = Number.isFinite(yawRounded) ? yawRounded : 0;
     // tolerance: xy は m そのまま、yaw は rad → deg 変換して UI に表示 (#138)。
     // `||` だと意図的な小さい値も default で上書きされるので Number.isFinite ベースで判定。
     // toFixed(4) で round-trip 精度を 0.0001° (≒ 0.00000175 rad) 以内に抑える
     // (Codex review #139 low 対応: toFixed(2) だと未編集 save で yaml 値が微小に変化する懸念)。
     const xyVal = poi.tolerance && poi.tolerance.xy;
-    this.inputToleranceXy.value = Number.isFinite(xyVal) ? xyVal : 0.5;
+    this.inputToleranceXy.value = Number.isFinite(xyVal)
+      ? MapoiPoiFilter.roundTo(xyVal, MapoiPoiFilter.TOLERANCE_XY_DIGITS)
+      : 0.5;
     const yawValRad = poi.tolerance && poi.tolerance.yaw;
     this.inputToleranceYaw.value = Number.isFinite(yawValRad)
       ? MapoiPoiFilter.radToDeg(yawValRad).toFixed(4)
@@ -337,19 +350,30 @@ class PoiEditor {
    * Read POI data from the form.
    */
   readForm() {
+    // pose / tolerance を yaml の有効桁数に丸めて Save する (#242)。
+    // 丸めないと parseFloat の浮動小数点誤差 (例: 0.1 → 0.10000038...) や
+    // deg ↔ rad 変換の累積誤差で yaml 値が膨らみ、git diff / 可読性が劣化する。
+    // 桁数定数は poi-filter.js に集約し、backend (yaml_handler.save_pois) と一致させる。
+    const xRaw = MapoiPoiFilter.roundTo(this.inputX.value, MapoiPoiFilter.POSE_XY_DIGITS);
+    const yRaw = MapoiPoiFilter.roundTo(this.inputY.value, MapoiPoiFilter.POSE_XY_DIGITS);
+    const yawRaw = MapoiPoiFilter.roundTo(this.inputYaw.value, MapoiPoiFilter.POSE_YAW_DIGITS);
+    // tolerance: xy は m そのまま、yaw は UI deg → rad 変換して dict / yaml に保存 (#138)。
+    // parseTolerance が finite 判定 + min 0.001 強制 (HTML min を bypass する経路の防御) を担う。
+    const tol = MapoiPoiFilter.parseTolerance(
+      this.inputToleranceXy.value,
+      MapoiPoiFilter.degToRad(this.inputToleranceYaw.value),
+    );
     return {
       name: this.inputName.value.trim(),
       pose: {
-        x: parseFloat(this.inputX.value) || 0,
-        y: parseFloat(this.inputY.value) || 0,
-        yaw: parseFloat(this.inputYaw.value) || 0,
+        x: Number.isFinite(xRaw) ? xRaw : 0,
+        y: Number.isFinite(yRaw) ? yRaw : 0,
+        yaw: Number.isFinite(yawRaw) ? yawRaw : 0,
       },
-      // tolerance: xy は m そのまま、yaw は UI deg → rad 変換して dict / yaml に保存 (#138)。
-      // parseTolerance が finite 判定 + min 0.001 強制 (HTML min を bypass する経路の防御) を担う。
-      tolerance: MapoiPoiFilter.parseTolerance(
-        this.inputToleranceXy.value,
-        MapoiPoiFilter.degToRad(this.inputToleranceYaw.value),
-      ),
+      tolerance: {
+        xy: MapoiPoiFilter.roundTo(tol.xy, MapoiPoiFilter.TOLERANCE_XY_DIGITS),
+        yaw: MapoiPoiFilter.roundTo(tol.yaw, MapoiPoiFilter.TOLERANCE_YAW_DIGITS),
+      },
       tags: this.inputTags.value.split(',').map(t => t.trim()).filter(t => t),
       description: this.inputDescription.value.trim(),
     };
@@ -422,8 +446,8 @@ class PoiEditor {
    */
   updateFormPosition(x, y) {
     if (this.editingIndex === -1) return;
-    this.inputX.value = Math.round(x * 100) / 100;
-    this.inputY.value = Math.round(y * 100) / 100;
+    this.inputX.value = MapoiPoiFilter.roundTo(x, MapoiPoiFilter.POSE_XY_DIGITS);
+    this.inputY.value = MapoiPoiFilter.roundTo(y, MapoiPoiFilter.POSE_XY_DIGITS);
   }
 
   /**
@@ -431,7 +455,7 @@ class PoiEditor {
    */
   updateFormYaw(yaw) {
     if (this.editingIndex === -1) return;
-    this.inputYaw.value = Math.round(yaw * 100) / 100;
+    this.inputYaw.value = MapoiPoiFilter.roundTo(yaw, MapoiPoiFilter.POSE_YAW_DIGITS);
   }
 
   setDirty(isDirty) {

--- a/mapoi_webui/web/js/poi-filter.js
+++ b/mapoi_webui/web/js/poi-filter.js
@@ -50,6 +50,29 @@
   // 0 / 負値 は「無反応 POI」を許してしまうため明示的に禁止。
   const TOLERANCE_MIN = 0.001;
 
+  // yaml 書き出し時の有効桁数 (#242)。
+  // xy は mm 精度 (3 桁)、yaw は rad で約 0.006° 精度 (4 桁) — 0.0001 rad ≒ 0.0057°。
+  // frontend readForm と backend save_pois 両方で同じ値を使う defense-in-depth。
+  const POSE_XY_DIGITS = 3;
+  const POSE_YAW_DIGITS = 4;
+  const TOLERANCE_XY_DIGITS = 3;
+  const TOLERANCE_YAW_DIGITS = 4;
+
+  /**
+   * 数値を指定桁数で丸める。非数値 / NaN / Infinity は NaN を返す。
+   * yaml の可読性と git diff の安定性のため、Save 経路で必ず通す (#242)。
+   *
+   * @param {string|number} value 数値 or parse 可能な文字列
+   * @param {number} digits 小数点以下桁数 (>= 0)
+   * @returns {number} 丸めた値、または NaN
+   */
+  function roundTo(value, digits) {
+    const v = parseFloat(value);
+    if (!Number.isFinite(v)) return NaN;
+    const factor = Math.pow(10, digits);
+    return Math.round(v * factor) / factor;
+  }
+
   function degToRad(deg) {
     const v = parseFloat(deg);
     return Number.isFinite(v) ? v * Math.PI / 180.0 : NaN;
@@ -116,7 +139,12 @@
     parseTolerance,
     degToRad,
     radToDeg,
+    roundTo,
     TOLERANCE_MIN,
+    POSE_XY_DIGITS,
+    POSE_YAW_DIGITS,
+    TOLERANCE_XY_DIGITS,
+    TOLERANCE_YAW_DIGITS,
   };
 
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary

- frontend (`poi-editor.readForm` + `fillForm` + map click 経路) と backend (`yaml_handler._round_poi_floats`) の両層で POI Save 時に float を丸めて yaml に書き出す
- 桁数: xy = 3 桁 (mm 精度) / yaw = 4 桁 rad (≒ 0.006° 精度)。桁数定数は `poi-filter.js` に集約し、backend と一致させる defense-in-depth
- 結果: `tolerance.yaw: 3.1399991679827224` のような 16 桁 ULP ノイズが yaml に残らず、git diff / code review が安定する

## Background

PR #235 (#230 最終形) 後、WebUI 経由で POI を Save すると yaml の数値が `0.10000038...` のような full precision で書き戻されていた。`fillForm` / `readForm` 経路で `parseFloat` の結果と `degToRad ↔ radToDeg` の累積誤差をそのまま yaml.dump に流していたのが原因。

## Test plan

- [x] vitest: `poi-filter.test.js` に `roundTo` 4 tests + 桁数定数 pin (`POSE_XY=3 / POSE_YAW=4 / TOL_XY=3 / TOL_YAW=4`) → 全 45 tests pass
- [x] pytest: `test_yaml_handler_round.py` 新規 7 tests (xy/yaw/tolerance 各桁数、非 finite 透過、save_pois end-to-end) → 全 pass
- [ ] 手動: WebUI で POI 位置編集 + Save → yaml の数値が 3-4 桁で書き出されること
- [ ] 手動: 既存 sample yaml (`turtlebot3_world/mapoi_config.yaml`) を未編集で Save しても diff が発生しないこと

## Notes

- C++ 変更なしのため Docker humble/jazzy build test はスキップ
- `parseTolerance` 既存挙動 (min 0.001 clamp) は維持、round は readForm 側で別途適用
- JS `Math.round` (half-up) と Python `round` (banker's) の半端境界差は test で値選択により回避 (frontend で既に丸めた値を再丸めする運用なので実害なし)

Closes #242