### PR TITLE
fix(webui): POI Save に楽観的競合検出を追加 (Close #241)

### DIFF
--- a/mapoi_webui/CMakeLists.txt
+++ b/mapoi_webui/CMakeLists.txt
@@ -32,6 +32,11 @@ if(BUILD_TESTING)
     test/test_yaml_handler_round.py
     TIMEOUT 10
   )
+  # yaml_handler.compute_config_version の決定性 / 変化検出 pin (#241 楽観的競合検出)。
+  ament_add_pytest_test(test_yaml_handler_version
+    test/test_yaml_handler_version.py
+    TIMEOUT 10
+  )
 endif()
 
 ament_package()

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -26,7 +26,10 @@ import tf2_ros
 
 from flask import Flask, jsonify, request, send_from_directory, Response
 
-from mapoi_webui.yaml_handler import load_config, save_pois, save_routes, save_custom_tags, get_pois, get_routes
+from mapoi_webui.yaml_handler import (
+    compute_config_version, get_pois, get_routes,
+    load_config, save_custom_tags, save_pois, save_routes,
+)
 from mapoi_webui.map_image import get_map_metadata, get_map_png
 
 
@@ -688,7 +691,12 @@ class MapoiWebNode(Node):
             if not os.path.exists(config_path):
                 return jsonify({'error': 'Config not found'}), 404
             pois = get_pois(config_path)
-            return jsonify({'pois': pois, 'map_name': node.map_name_})
+            return jsonify({
+                'pois': pois,
+                'map_name': node.map_name_,
+                # 楽観的競合検出のため frontend に渡す yaml 内容ハッシュ (#241)。
+                'config_version': compute_config_version(config_path),
+            })
 
         @app.route('/api/pois', methods=['POST'])
         def api_save_pois():
@@ -710,16 +718,31 @@ class MapoiWebNode(Node):
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
                 return jsonify({'error': 'Config not found'}), 404
+            # 楽観的競合検出 (#241): frontend が GET 時に受け取った version を `expected_version`
+            # として送り返す。current version と不一致なら 409 を返し、frontend に reload を促す。
+            # `expected_version` 不在 (旧クライアント / curl) の場合は check をスキップ。
+            expected_version = data.get('expected_version')
+            if expected_version is not None:
+                current_version = compute_config_version(config_path)
+                if current_version is not None and current_version != expected_version:
+                    return jsonify({
+                        'error': 'yaml file has been modified externally; '
+                                 'please reload to fetch the latest state before saving',
+                        'code': 'version_mismatch',
+                        'current_version': current_version,
+                    }), 409
             try:
                 save_pois(config_path, data['pois'])
+                new_version = compute_config_version(config_path)
                 reloaded = node.call_reload_map_info()
                 if not reloaded:
                     return jsonify({
                         'success': True,
+                        'config_version': new_version,
                         'warning': 'YAML は保存しましたが、mapoi_server の reload_map_info '
                                    'service が応答しなかったか失敗しました。詳細はログを確認してください'
                     })
-                return jsonify({'success': True})
+                return jsonify({'success': True, 'config_version': new_version})
             except Exception as e:
                 node.get_logger().error(f'Failed to save POIs: {e}')
                 return jsonify({'error': str(e)}), 500

--- a/mapoi_webui/mapoi_webui/yaml_handler.py
+++ b/mapoi_webui/mapoi_webui/yaml_handler.py
@@ -4,9 +4,25 @@ Reads/writes mapoi_config.yaml, replacing only the 'poi' section
 while preserving 'map' and 'route' sections and unknown fields.
 """
 
+import hashlib
 import math
 
 import yaml
+
+
+def compute_config_version(config_path):
+    """Return a content-derived version string (sha256 hex) for the yaml file (#241).
+
+    POI Save 時の楽観的競合検出に使う: frontend が GET 時に受け取った version を
+    POST 時に送り返し、backend で current version と一致しなければ 409 を返す。
+    内容ベースなので mtime 解像度 (1 秒) や外部 git checkout 等にも安定して反応する。
+    ファイル不在時は None を返し、caller 側で「version check 不可」として 200 OK 経路に流す。
+    """
+    try:
+        with open(config_path, 'rb') as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except FileNotFoundError:
+        return None
 
 
 # yaml 書き出し時の有効桁数 (#242)。frontend (web/js/poi-filter.js) と必ず一致させる。

--- a/mapoi_webui/test/test_yaml_handler_version.py
+++ b/mapoi_webui/test/test_yaml_handler_version.py
@@ -1,0 +1,64 @@
+"""Unit test for yaml_handler.compute_config_version (#241).
+
+WebUI Save 時の楽観的競合検出に使う content-derived version (sha256 hex)。
+frontend が GET 時に受け取った version を POST 時に送り返し、backend は current
+version と一致しなければ 409 を返す。本 test は version 計算の決定性 / 変化検出 /
+ファイル不在時の None 返却 / save_pois 経由の version 遷移を pin する。
+"""
+import os
+import tempfile
+import unittest
+
+import yaml
+
+from mapoi_webui.yaml_handler import compute_config_version, save_pois
+
+
+class TestComputeConfigVersion(unittest.TestCase):
+
+    def test_returns_none_for_missing_file(self):
+        """ファイル不在 → None。caller 側で 'version check 不可' として扱う."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(compute_config_version(os.path.join(tmp, 'absent.yaml')))
+
+    def test_same_content_same_version(self):
+        """同一内容なら version は同じ (sha256 deterministic, hex 64 文字)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = os.path.join(tmp, 'a.yaml')
+            with open(p, 'w') as f:
+                f.write('poi: []\nroute: []\n')
+            v1 = compute_config_version(p)
+            v2 = compute_config_version(p)
+            self.assertEqual(v1, v2)
+            self.assertEqual(len(v1), 64)
+
+    def test_different_content_different_version(self):
+        """内容が違えば version は変わる → 競合検出が成立する."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p1 = os.path.join(tmp, 'a.yaml')
+            p2 = os.path.join(tmp, 'b.yaml')
+            with open(p1, 'w') as f:
+                f.write('poi: []\n')
+            with open(p2, 'w') as f:
+                f.write('poi: [{name: x}]\n')
+            self.assertNotEqual(compute_config_version(p1), compute_config_version(p2))
+
+    def test_version_changes_after_save_pois(self):
+        """save_pois 後は version が変わる → frontend が新 version を pin する経路."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = os.path.join(tmp, 'cfg.yaml')
+            with open(p, 'w') as f:
+                yaml.safe_dump({'map': {}, 'poi': [], 'route': []}, f)
+            v_before = compute_config_version(p)
+            save_pois(p, [{
+                'name': 'p1',
+                'pose': {'x': 0.1, 'y': 0.2, 'yaw': 0.0},
+                'tolerance': {'xy': 0.5, 'yaw': 0.785},
+                'tags': ['waypoint'],
+            }])
+            v_after = compute_config_version(p)
+            self.assertNotEqual(v_before, v_after)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mapoi_webui/web/js/api.js
+++ b/mapoi_webui/web/js/api.js
@@ -39,13 +39,28 @@ const MapoiApi = {
     return res.json();
   },
 
-  async savePois(pois) {
+  /**
+   * POST /api/pois (#241): 楽観的競合検出のため expected_version を必ず送る。
+   * 受信側 (mapoi_webui_node) は yaml の sha256 と比較し、不一致なら 409 を返す。
+   * 返値は backend JSON に { ok, status, conflict } を付加して呼び出し側に渡す:
+   *   - ok === true: 通常 success (status 200)
+   *   - conflict === true: version 不一致 (status 409)、reload して再試行を促す
+   *   - ok === false かつ conflict !== true: その他のエラー (validation 400 / 500 等)
+   * 呼び出し側は ok=false 時に `result.error` をユーザーに表示する。
+   */
+  async savePois(pois, expectedVersion) {
     const res = await fetch('/api/pois', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ pois }),
+      body: JSON.stringify({ pois, expected_version: expectedVersion }),
     });
-    return res.json();
+    const body = await res.json().catch(() => ({}));
+    return {
+      ok: res.ok,
+      status: res.status,
+      conflict: res.status === 409,
+      ...body,
+    };
   },
 
   async getTagDefinitions() {

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -157,7 +157,8 @@
   // --- Load POIs ---
   async function loadPois() {
     const data = await MapoiApi.getPois();
-    poiEditor.loadPois(data.pois || []);
+    // config_version は楽観的競合検出 token (#241): backend から受け取り、save() で送り返す。
+    poiEditor.loadPois(data.pois || [], data.config_version);
     mapViewer.showPois(poiEditor.pois, poiEditor.visiblePois);
     populateNavGoalSelect(data.pois || []);
     populateInitialPoseSelect(data.pois || []);
@@ -303,6 +304,14 @@
       mapViewer.showPois(poiEditor.pois, poiEditor.visiblePois);
       loadRoutes();
     }
+  };
+
+  // 409 version_mismatch 受信時の全体 reload (#241)。POI だけ再 load しても route 側
+  // の参照が壊れる可能性があるため、loadTagDefinitions → loadPois → loadRoutes を一括で。
+  poiEditor.onConflictReload = async () => {
+    await loadTagDefinitions();
+    await loadPois();
+    await loadRoutes();
   };
 
   // Route click on map

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -10,12 +10,17 @@ class PoiEditor {
     this.editingIndex = -1;  // -1 = closed, >=0 = editing existing, -2 = new POI
     this.placingMode = false;
     this.visiblePois = new Set(); // indices of visible POIs
+    // 楽観的競合検出用 yaml ハッシュ (#241)。GET 時に backend から受け取り、Save 時に送り返す。
+    this.configVersion = null;
 
     this.tagDefinitions = [];  // [{name, description, is_system}, ...]
     this.onDirtyChange = null;     // callback(isDirty)
     this.onSelectionChange = null; // callback(index)
     this.onPlacingModeChange = null; // callback(isPlacing)
     this.onVisibilityChange = null;  // callback(visibleSet)
+    // 409 受信時に app.js 側で全体 reload (loadMaps → loadPois/Routes) を発火させるためのフック。
+    // poi-editor 単独では route-editor の state を巻き戻せないため、解決は呼び出し側に委ねる (#241)。
+    this.onConflictReload = null;  // async callback() — full reload on version_mismatch
 
     // DOM references
     this.listEl = document.getElementById('poi-list');
@@ -47,12 +52,14 @@ class PoiEditor {
   /**
    * Load POIs from server response and reset state.
    */
-  loadPois(pois) {
+  loadPois(pois, configVersion) {
     this.pois = JSON.parse(JSON.stringify(pois));
     this.originalPois = JSON.parse(JSON.stringify(pois));
     this.selectedIndex = -1;
     this.editingIndex = -1;
     this.visiblePois = new Set(pois.map((_, i) => i));
+    // 楽観的競合検出 token (#241)。後続の save() で backend に送り返す。
+    this.configVersion = configVersion || null;
     this.setDirty(false);
     this.hideForm();
     this.renderList();
@@ -475,9 +482,27 @@ class PoiEditor {
     if (!this.dirty) return;
     this.btnSave.textContent = 'Saving...';
     try {
-      const result = await MapoiApi.savePois(this.pois);
-      if (result.success) {
+      const result = await MapoiApi.savePois(this.pois, this.configVersion);
+      // 409 (version_mismatch): yaml が外部 (yaml 直編集 / 他クライアント) で変わった (#241)。
+      // 黙って上書きせず、user に reload するかどうか確認する。
+      // reload を選んだら未保存の dirty 編集は失われる旨を明示。
+      if (result.conflict) {
+        this.btnSave.textContent = 'Save';
+        const shouldReload = window.confirm(
+          'YAML ファイルが外部で変更されています (例: 手動編集 + git pull / 他端末からの保存)。'
+          + '\n上書き保存すると最新の変更が失われます。'
+          + '\n\n[OK] 最新を再 load する (未保存の編集は破棄されます)'
+          + '\n[キャンセル] そのまま編集を続ける (再度 Save 時に同じ警告)'
+        );
+        if (shouldReload && this.onConflictReload) {
+          await this.onConflictReload();
+        }
+        return;
+      }
+      if (result.ok && result.success) {
         this.originalPois = JSON.parse(JSON.stringify(this.pois));
+        // backend が再計算した最新 version を frontend に反映 (#241)。
+        if (result.config_version) this.configVersion = result.config_version;
         this.setDirty(false);
         this.btnSave.textContent = 'Saved!';
         setTimeout(() => { this.btnSave.textContent = 'Save'; }, 1500);


### PR DESCRIPTION
## Summary

- `GET /api/pois` で yaml 内容の sha256 を `config_version` として返す
- `POST /api/pois` で `expected_version` を受け取り、current version と不一致なら **409 + `code: 'version_mismatch'`**
- frontend は 409 受信時に `confirm()` で reload するか確認、OK なら `onConflictReload` で全 section (tag_defs / pois / routes) を再 fetch
- 後方互換: `expected_version` 不在 (curl 等の旧 client) なら check スキップ

## Background

PR #235 後、`mapoi_config.yaml` を手動で rename + git push → WebUI 経由で POI 位置を Save すると yaml の POI `name` が rename 前に戻る事故が発生 (#241)。原因は WebUI 起動時に yaml を 1 回 read してメモリ保持し、Save 時にメモリ上の (古い) name で上書きしていたこと。

## 設計判断

「ID 化」「reload ボタン」「mtime 比較」を検討した結果、内容ベース sha256 の **楽観的競合検出** を採用:

- ID 化: 既存 yaml schema 互換性破壊、scope 過大
- reload ボタン: user が押し忘れる前提なら未解決
- mtime: 1 秒解像度では同秒内編集の検出漏れ、外部 git checkout 等で不安定
- sha256: 内容ベースなので決定的、外部編集 / 他クライアント保存どちらも検出、低コスト

## Test plan

- [x] pytest: `test_yaml_handler_version.py` 新規 4 tests (決定性 / 変化検出 / save 後遷移 / 不在時 None) → 全 pass
- [x] pytest: 既存 `test_yaml_handler_round.py` 7 tests も全 pass
- [x] vitest: 45 tests 全 pass (regress なし)
- [ ] 手動: WebUI で POI 編集中に host 側で yaml を直接 rename + commit → Save → 409 dialog 表示 → reload で latest 反映
- [ ] 手動: 既存 sample yaml を未編集で Save → 200 OK で正常書き込み

## Scope の判断

- `/api/routes` / `/api/custom_tags` も同 yaml に書くが「他 section 保全」設計のため #241 の直接 bug は発生しない
- routes が renamed POI 参照を残す stale state バグ等は別 issue で follow-up 候補

Closes #241