### PR TITLE
fix(nav2_bridge): jazzy で cmd_vel TwistStamped 化に追従し EVENT_PAUSED 発火を復活 (Close #249)

### DIFF
--- a/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
@@ -19,6 +19,7 @@
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav2_msgs/action/follow_waypoints.hpp>
 #include <nav2_msgs/action/navigate_to_pose.hpp>
 #include <nav2_msgs/srv/load_map.hpp>
@@ -217,8 +218,31 @@ private:
   // 前提: 採用 controller が navigation 停止中も cmd_vel = 0 を継続 publish すること
   // (Nav2 default の挙動)。controller が静止時に cmd_vel publish を止める実装の場合、
   // EVENT_PAUSED は発火しない。
+  // cmd_vel は ROS 2 distro / controller によって型が分かれる (#249):
+  //   - Humble Nav2 等: geometry_msgs::msg::Twist
+  //   - Jazzy 以降の Nav2: geometry_msgs::msg::TwistStamped (collision_monitor /
+  //     docking_server などが TwistStamped 化済)
+  // どちらか一方だけを subscribe する: 同じ topic に違う型の subscriber を 2 つ
+  // 作ると rcl が `invalid allocator` で crash するため (DDS の type registry が
+  // 型不一致を受け付けない)。`cmd_vel_msg_type` parameter で選択する:
+  //   - "twist":         Twist で subscribe (humble デフォルト互換)
+  //   - "twist_stamped": TwistStamped で subscribe (jazzy 以降 Nav2 互換)
+  //   - "auto" (default): ROS_DISTRO 環境変数を見て自動選択
+  //     ROS_DISTRO=humble → twist、それ以外 (jazzy, kilted, ...) → twist_stamped
+  // 一方しか作らないので shared_ptr の片方は nullptr のまま。
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_vel_stamped_sub_;
   void cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
+  void cmd_vel_stamped_callback(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
+  // zero-velocity 判定の本体 (両 callback の共通実装、#249)。linear_x/y/z + angular_z を
+  // 渡せば Twist / TwistStamped どちらでも同じ閾値判定で `zero_velocity_active_` /
+  // `last_zero_velocity_start_` を更新する。
+  void update_zero_velocity_state(
+    double linear_x, double linear_y, double linear_z, double angular_z);
+  // `cmd_vel_msg_type` parameter を実 type 名 ("twist" or "twist_stamped") に解決する (#249)。
+  // "auto" は ROS_DISTRO env を見て humble なら "twist"、それ以外 (jazzy 以降) は
+  // "twist_stamped"。未知値は安全側で "twist" にフォールバック。
+  static std::string resolve_cmd_vel_msg_type(const std::string & param_value);
   // 速度が閾値以下になり始めた時刻 (steady_clock)。閾値超えに戻ったら reset。
   std::chrono::steady_clock::time_point last_zero_velocity_start_ {};
   bool zero_velocity_active_ {false};
@@ -297,6 +321,12 @@ private:
   FRIEND_TEST(Nav2BridgeTestFixture, AutoResumeTimeoutNonFiniteClampedToZero);
   FRIEND_TEST(Nav2BridgeTestFixture, CancelAutoResumeTimerIsIdempotent);
   FRIEND_TEST(Nav2BridgeTestFixture, ResetNavStateCancelsAutoResumeTimer);
+  FRIEND_TEST(Nav2BridgeTestFixture, CmdVelTwistCallbackUpdatesZeroVelocityState);
+  FRIEND_TEST(Nav2BridgeTestFixture, CmdVelTwistStampedCallbackUpdatesZeroVelocityState);
+  FRIEND_TEST(Nav2BridgeTestFixture, CmdVelNonZeroClearsZeroVelocityState);
+  FRIEND_TEST(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeExplicit);
+  FRIEND_TEST(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeAutoByDistro);
+  FRIEND_TEST(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback);
 #endif
 };
 

--- a/mapoi_server/src/mapoi_nav2_bridge.cpp
+++ b/mapoi_server/src/mapoi_nav2_bridge.cpp
@@ -136,8 +136,19 @@ MapoiNav2Bridge::MapoiNav2Bridge(const rclcpp::NodeOptions & options)
   // ため、必ず片方のみ)。
   this->declare_parameter<std::string>("cmd_vel_msg_type", "auto");
   const std::string cmd_vel_topic = this->get_parameter("cmd_vel_topic").as_string();
-  const std::string cmd_vel_msg_type = resolve_cmd_vel_msg_type(
-    this->get_parameter("cmd_vel_msg_type").as_string());
+  const std::string cmd_vel_msg_type_param =
+    this->get_parameter("cmd_vel_msg_type").as_string();
+  const std::string cmd_vel_msg_type = resolve_cmd_vel_msg_type(cmd_vel_msg_type_param);
+  // 既知の 3 値 (twist / twist_stamped / auto) 以外は WARN: 黙って distro fallback すると
+  // typo を見逃す。Cursor review #250 medium #1 対応。
+  if (cmd_vel_msg_type_param != "twist"
+      && cmd_vel_msg_type_param != "twist_stamped"
+      && cmd_vel_msg_type_param != "auto") {
+    RCLCPP_WARN(this->get_logger(),
+      "cmd_vel_msg_type='%s' は未知の値です。ROS_DISTRO ベースで '%s' にフォールバックしました。"
+      " 有効値: 'twist' / 'twist_stamped' / 'auto'",
+      cmd_vel_msg_type_param.c_str(), cmd_vel_msg_type.c_str());
+  }
   if (cmd_vel_msg_type == "twist_stamped") {
     cmd_vel_stamped_sub_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
       cmd_vel_topic, 10,
@@ -1259,16 +1270,16 @@ std::string MapoiNav2Bridge::resolve_cmd_vel_msg_type(const std::string & param_
   if (param_value == "twist" || param_value == "twist_stamped") {
     return param_value;
   }
-  if (param_value == "auto") {
-    const char * distro = std::getenv("ROS_DISTRO");
-    if (distro && std::string(distro) == "humble") {
-      return "twist";
-    }
-    // jazzy / kilted / それ以降は TwistStamped。env が unset の場合も今後の主流に倣う。
-    return "twist_stamped";
+  // "auto" / 未知値はどちらも ROS_DISTRO ベースで自動判定する (#249 cursor review medium #1)。
+  // 未知値を無条件 "twist" にフォールバックすると jazzy 以降の本番で再び silent に
+  // subscribe 不成立 → EVENT_PAUSED 不発火の bug が復活する。auto と同じ判定にして
+  // 「不一致だが distro 適合型を選んだ」という意図に揃える (WARN log は caller 側で出す)。
+  const char * distro = std::getenv("ROS_DISTRO");
+  if (distro && std::string(distro) == "humble") {
+    return "twist";
   }
-  // 未知値は安全側で Twist 互換にフォールバック (例: typo)。
-  return "twist";
+  // jazzy / kilted / それ以降は TwistStamped。env が unset の場合も今後の主流に倣う。
+  return "twist_stamped";
 }
 
 void MapoiNav2Bridge::update_zero_velocity_state(

--- a/mapoi_server/src/mapoi_nav2_bridge.cpp
+++ b/mapoi_server/src/mapoi_nav2_bridge.cpp
@@ -1,6 +1,7 @@
 #include "mapoi_server/mapoi_nav2_bridge.hpp"
 
 #include <chrono>
+#include <cstdlib>
 #include <functional>
 #include <cmath>
 #include <thread>
@@ -129,12 +130,28 @@ MapoiNav2Bridge::MapoiNav2Bridge(const rclcpp::NodeOptions & options)
     "mapoi/config_path", rclcpp::QoS(1).transient_local(),
     std::bind(&MapoiNav2Bridge::on_config_path_changed, this, _1));
 
-  // cmd_vel subscribe (#140): STOPPED 判定の source の一つ (もう一つは Nav2 SUCCEEDED)。
-  // QoS は Nav2 の cmd_vel publisher と同じ default (reliable, depth=10)。
+  // cmd_vel subscribe (#140 / #249): STOPPED 判定 source。QoS は Nav2 publisher と同じ
+  // default (reliable, depth=10)。distro 移行で publisher 型が変わるため subscription 型を
+  // 選択する (同じ topic に 2 種類の sub を作ると rcl が invalid allocator で crash する
+  // ため、必ず片方のみ)。
+  this->declare_parameter<std::string>("cmd_vel_msg_type", "auto");
   const std::string cmd_vel_topic = this->get_parameter("cmd_vel_topic").as_string();
-  cmd_vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
-    cmd_vel_topic, 10,
-    std::bind(&MapoiNav2Bridge::cmd_vel_callback, this, _1));
+  const std::string cmd_vel_msg_type = resolve_cmd_vel_msg_type(
+    this->get_parameter("cmd_vel_msg_type").as_string());
+  if (cmd_vel_msg_type == "twist_stamped") {
+    cmd_vel_stamped_sub_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
+      cmd_vel_topic, 10,
+      std::bind(&MapoiNav2Bridge::cmd_vel_stamped_callback, this, _1));
+    RCLCPP_INFO(this->get_logger(),
+      "cmd_vel subscribed as TwistStamped (msg_type=%s)", cmd_vel_msg_type.c_str());
+  } else {
+    // "twist" / 未知の値は安全側で Twist にフォールバック (humble 互換)。
+    cmd_vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+      cmd_vel_topic, 10,
+      std::bind(&MapoiNav2Bridge::cmd_vel_callback, this, _1));
+    RCLCPP_INFO(this->get_logger(),
+      "cmd_vel subscribed as Twist (msg_type=%s)", cmd_vel_msg_type.c_str());
+  }
 
   tag_defs_client_ = this->create_client<mapoi_interfaces::srv::GetTagDefinitions>("get_tag_definitions");
   fetch_system_tags();
@@ -1226,14 +1243,43 @@ double MapoiNav2Bridge::distance_2d(const geometry_msgs::msg::Pose & poi_pose, d
 
 void MapoiNav2Bridge::cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg)
 {
+  update_zero_velocity_state(
+    msg->linear.x, msg->linear.y, msg->linear.z, msg->angular.z);
+}
+
+void MapoiNav2Bridge::cmd_vel_stamped_callback(
+  const geometry_msgs::msg::TwistStamped::SharedPtr msg)
+{
+  update_zero_velocity_state(
+    msg->twist.linear.x, msg->twist.linear.y, msg->twist.linear.z, msg->twist.angular.z);
+}
+
+std::string MapoiNav2Bridge::resolve_cmd_vel_msg_type(const std::string & param_value)
+{
+  if (param_value == "twist" || param_value == "twist_stamped") {
+    return param_value;
+  }
+  if (param_value == "auto") {
+    const char * distro = std::getenv("ROS_DISTRO");
+    if (distro && std::string(distro) == "humble") {
+      return "twist";
+    }
+    // jazzy / kilted / それ以降は TwistStamped。env が unset の場合も今後の主流に倣う。
+    return "twist_stamped";
+  }
+  // 未知値は安全側で Twist 互換にフォールバック (例: typo)。
+  return "twist";
+}
+
+void MapoiNav2Bridge::update_zero_velocity_state(
+  double linear_x, double linear_y, double linear_z, double angular_z)
+{
   // 線速ノルム (3D) と角速度絶対値 (yaw 軸) の両方が閾値以下のとき「停止」とみなす。
   // 撮影シナリオでは「その場旋回も停止扱いしない」前提のため、angular.z も判定に含める。
   // 単位が異なるが同一閾値を使う割り切り (param 説明参照、#140)。
   const double linear_norm = std::sqrt(
-    msg->linear.x * msg->linear.x +
-    msg->linear.y * msg->linear.y +
-    msg->linear.z * msg->linear.z);
-  const double angular_norm = std::abs(msg->angular.z);
+    linear_x * linear_x + linear_y * linear_y + linear_z * linear_z);
+  const double angular_norm = std::abs(angular_z);
   const bool zero_now =
     (linear_norm < stopped_speed_threshold_) && (angular_norm < stopped_speed_threshold_);
   if (zero_now) {

--- a/mapoi_server/test/test_nav2_bridge_unit.cpp
+++ b/mapoi_server/test/test_nav2_bridge_unit.cpp
@@ -299,6 +299,95 @@ TEST_F(Nav2BridgeTestFixture, ResetNavStateCancelsAutoResumeTimer)
   EXPECT_TRUE(node_->auto_resume_target_poi_.empty());
 }
 
+// --- cmd_vel callback / TwistStamped 互換 (#249) ---
+//
+// jazzy で Nav2 が cmd_vel を TwistStamped で publish するように変わったため、
+// 旧 Twist subscriber だけだと 1 通も受信できず EVENT_PAUSED が永久に発火しない
+// silent regression が起きていた。両 callback が同じ zero-velocity 判定 helper
+// (update_zero_velocity_state) を呼ぶ contract を pin する。
+
+TEST_F(Nav2BridgeTestFixture, CmdVelTwistCallbackUpdatesZeroVelocityState)
+{
+  // Humble 系の Twist publisher: zero 入力で zero_velocity_active_ が true に遷移。
+  EXPECT_FALSE(node_->zero_velocity_active_);
+  auto msg = std::make_shared<geometry_msgs::msg::Twist>();
+  msg->linear.x = 0.0;
+  msg->linear.y = 0.0;
+  msg->linear.z = 0.0;
+  msg->angular.z = 0.0;
+  node_->cmd_vel_callback(msg);
+  EXPECT_TRUE(node_->zero_velocity_active_);
+}
+
+TEST_F(Nav2BridgeTestFixture, CmdVelTwistStampedCallbackUpdatesZeroVelocityState)
+{
+  // Jazzy 系の TwistStamped publisher: 内包 twist を unwrap して同じ判定を通す。
+  EXPECT_FALSE(node_->zero_velocity_active_);
+  auto msg = std::make_shared<geometry_msgs::msg::TwistStamped>();
+  msg->twist.linear.x = 0.0;
+  msg->twist.linear.y = 0.0;
+  msg->twist.linear.z = 0.0;
+  msg->twist.angular.z = 0.0;
+  node_->cmd_vel_stamped_callback(msg);
+  EXPECT_TRUE(node_->zero_velocity_active_);
+}
+
+TEST_F(Nav2BridgeTestFixture, CmdVelNonZeroClearsZeroVelocityState)
+{
+  // zero で active 化 → 非 zero で即 clear。Twist / TwistStamped どちらの経路でも同じ。
+  auto zero = std::make_shared<geometry_msgs::msg::Twist>();
+  node_->cmd_vel_callback(zero);
+  EXPECT_TRUE(node_->zero_velocity_active_);
+
+  auto moving = std::make_shared<geometry_msgs::msg::TwistStamped>();
+  moving->twist.linear.x = 0.5;  // 閾値 0.01 を超える
+  node_->cmd_vel_stamped_callback(moving);
+  EXPECT_FALSE(node_->zero_velocity_active_);
+}
+
+TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeExplicit)
+{
+  // 明示指定はそのまま透過。typo / 未知値は "twist" にフォールバック。
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("twist"), "twist");
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("twist_stamped"), "twist_stamped");
+}
+
+TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeAutoByDistro)
+{
+  // "auto" は ROS_DISTRO 環境変数で決まる: humble → twist、それ以外 → twist_stamped。
+  // 既存の ROS_DISTRO 値を保存して復元する (テストが Docker / launch_test 環境を壊さない)。
+  const char * original = std::getenv("ROS_DISTRO");
+  std::string saved = original ? original : "";
+  bool was_unset = (original == nullptr);
+
+  setenv("ROS_DISTRO", "humble", 1);
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("auto"), "twist");
+
+  setenv("ROS_DISTRO", "jazzy", 1);
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("auto"), "twist_stamped");
+
+  setenv("ROS_DISTRO", "kilted", 1);
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("auto"), "twist_stamped");
+
+  unsetenv("ROS_DISTRO");
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("auto"), "twist_stamped");
+
+  // restore
+  if (was_unset) {
+    unsetenv("ROS_DISTRO");
+  } else {
+    setenv("ROS_DISTRO", saved.c_str(), 1);
+  }
+}
+
+TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback)
+{
+  // 未知値 (typo / 設定ミス) は安全側で Twist 互換にフォールバック。
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("twst"), "twist");
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type(""), "twist");
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("Twist"), "twist");  // case-sensitive
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/mapoi_server/test/test_nav2_bridge_unit.cpp
+++ b/mapoi_server/test/test_nav2_bridge_unit.cpp
@@ -382,10 +382,28 @@ TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeAutoByDistro)
 
 TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback)
 {
-  // 未知値 (typo / 設定ミス) は安全側で Twist 互換にフォールバック。
+  // 未知値 (typo / 設定ミス) は auto と同じく ROS_DISTRO ベースでフォールバック。
+  // 旧仕様 (常に "twist") だと jazzy 本番で誤設定すると subscribe 不成立で
+  // EVENT_PAUSED が再び silent に壊れる回帰につながるため、distro 適合型に揃える。
+  // (caller 側は別途 WARN log で typo を可視化する、cursor review PR #250 medium #1)
+  const char * original = std::getenv("ROS_DISTRO");
+  std::string saved = original ? original : "";
+  bool was_unset = (original == nullptr);
+
+  setenv("ROS_DISTRO", "jazzy", 1);
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("twst"), "twist_stamped");
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type(""), "twist_stamped");
+  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("Twist"), "twist_stamped");  // case-sensitive
+
+  setenv("ROS_DISTRO", "humble", 1);
   EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("twst"), "twist");
-  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type(""), "twist");
-  EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("Twist"), "twist");  // case-sensitive
+
+  // restore
+  if (was_unset) {
+    unsetenv("ROS_DISTRO");
+  } else {
+    setenv("ROS_DISTRO", saved.c_str(), 1);
+  }
 }
 
 int main(int argc, char ** argv)

--- a/mapoi_server/test/test_poi_event_route_integration.py
+++ b/mapoi_server/test/test_poi_event_route_integration.py
@@ -67,6 +67,9 @@ def generate_test_description():
             'map_frame': 'map',
             'base_frame': 'base_link',
             'stopped_dwell_time_sec': STOPPED_DWELL_TIME_SEC,
+            # 本 test は Twist で cmd_vel を publish するため、distro auto-detect (jazzy で
+            # TwistStamped 化) を上書きして Twist 固定 (#249)。
+            'cmd_vel_msg_type': 'twist',
         }],
     )
 


### PR DESCRIPTION
## Summary

- `cmd_vel_msg_type` parameter (`auto` / `twist` / `twist_stamped`) で cmd_vel subscription 型を切替え
- default `auto` は `ROS_DISTRO` 環境変数を読み、`humble` → `twist`、それ以外 (`jazzy`, `kilted`, ...) → `twist_stamped` に自動判定
- 同じ topic に 2 種類の subscriber を同時に作ると rcl が `invalid allocator` で crash するため必ず片方のみ作成
- 共通の zero-velocity 判定ロジックを `update_zero_velocity_state` helper に切り出し、Twist / TwistStamped どちらの callback も同じ判定を通す

## Background

PR #247 (#238) の動作確認時に発見した silent regression: jazzy Nav2 が cmd_vel を `geometry_msgs/msg/TwistStamped` で publish するように変わった (`collision_monitor` / `docking_server` 等が TwistStamped 化済) のに、`mapoi_nav2_bridge` は `geometry_msgs/msg/Twist` で subscribe していたため 1 通も受信できず、`zero_velocity_dwelled` が永久 false → **`EVENT_PAUSED` が発火しない**。

```
ros2 topic info /cmd_vel -v:
  Publisher (collision_monitor): geometry_msgs/msg/TwistStamped
  Subscription (mapoi_nav2_bridge): geometry_msgs/msg/Twist
  → 型ハッシュ不一致で subscribe 成立せず
```

EVENT_PAUSED が出ないため `camera_node` 等の subscriber が動作せず、`tutorial_03_pause` / `tour_full` route で pause_waypoint に着いた robot が永久停止する。

## 設計判断

最初は両方の subscription を同時に作る案を試したが、ROS 2 rcl は同じ topic に異なる型の subscriber を同時に作ると `invalid allocator` で crash することを test で確認:
```
[mapoi_nav2_bridge-1] invalid allocator, at ./src/rcl/subscription.c:261
[mapoi_nav2_bridge-1] terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
```

そのため param で **1 つの subscription のみ** を作る設計に変更。`auto` は ROS_DISTRO で自動判定するので production では default で動き、test 環境で publisher 型を固定したい場合は param で明示できる。

## Test plan

- [x] **gtest** (`test_nav2_bridge_unit`): Twist / TwistStamped callback の zero-velocity 状態更新、`resolve_cmd_vel_msg_type` の明示値 / auto / 未知値フォールバック 3 ケース → 11/11 passed (humble + jazzy)
- [x] **launch_test** (`test_test_poi_event_route_integration` / `test_test_backend_status_no_nav2` 等): cmd_vel_msg_type=twist 指定で従来挙動維持、bridge 起動 crash なし → 6/6 passed (humble + jazzy)
- [x] **手動 (jazzy + Gazebo + Nav2)**: `tutorial_03_pause` 走行 → `POI PAUSED: pause_waypoint` log + `/mapoi/events` に `event_type: 2` 発火確認 (修正前は 0 件)
- [x] startup log で `cmd_vel subscribed as TwistStamped (msg_type=twist_stamped)` 確認 (jazzy)
- [ ] camera_node 連動の end-to-end は PR #247 (#238) merge 後に再確認

## 関連

- Closes #249
- PR #247 (#238) 動作確認時に発見
- 関連: `PoiEvent.msg` の前提 "Controllers that silently stop publishing cmd_vel will not trigger EVENT_PAUSED" — この前提は jazzy Nav2 controller も満たすが、bridge 側の型不一致が先に subscribe を破綻させていた