### PR TITLE
test(nav2_bridge): cmd_vel_msg_type の constructor 分岐 test と doc 追加 (Close #251)

### DIFF
--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -137,7 +137,27 @@ POI 名を指定した自律走行と、POI 半径イベント検知を行うノ
 | `base_frame` | `string` | `base_link` | TF の子フレーム |
 | `auto_resume_timeout_sec` | `double` | `0.0` | `EVENT_PAUSED` 発火後の auto-resume timeout (秒、#231)。`0.0` で disabled (現行仕様、外部 `/mapoi/nav/resume` を無限待ち)。正値で「PAUSED から N 秒後に内部 resume を呼ぶ」demo / 自動運転シナリオ向け opt-in 動作を有効化。負値は起動時に `0.0` へ clamp。動的 reconfigure 非対応 |
 | `cmd_vel_topic` | `string` | `cmd_vel` | `EVENT_PAUSED` 判定用 `cmd_vel` の subscribe 先 topic 名。Nav2 と同じ topic を見る前提 (停止判定 source) |
-| `cmd_vel_msg_type` | `string` | `auto` | `cmd_vel` の message 型 (#249 / #251)。`twist` = `geometry_msgs/Twist` (humble Nav2 互換)、`twist_stamped` = `geometry_msgs/TwistStamped` (jazzy 以降 Nav2: `collision_monitor` / `docking_server` 等が TwistStamped 化済)、`auto` (default) = `ROS_DISTRO` 環境変数で自動選択 (`humble` → `twist`、それ以外 / 未設定 → `twist_stamped`)。同 topic に違う型の sub を作ると rcl が crash するため、`auto` を上書きする必要があるのは下記ケース: (a) jazzy 上で自前 controller が Twist のまま publish する混在構成 → `twist` を明示、(b) humble 上で自前 controller が TwistStamped を先取りしている構成 → `twist_stamped` を明示、(c) 最小 CI / 自作 container で `ROS_DISTRO` が unset の環境で humble を使う場合 → `twist` を明示 (default fallback は `twist_stamped`)。未知値 (typo) は WARN を出した上で `ROS_DISTRO` ベースで安全側にフォールバック |
+| `cmd_vel_msg_type` | `string` | `auto` | `cmd_vel` の message 型 (#249 / #251)。`twist` / `twist_stamped` / `auto` (default = `ROS_DISTRO` から自動選択)。詳細と override が必要なケースは下記サブセクション参照 |
+
+##### `cmd_vel_msg_type` の値と override が必要な構成 (#249 / #251)
+
+`cmd_vel` の publisher 型は ROS 2 distro / 採用 controller によって `geometry_msgs/Twist` と `geometry_msgs/TwistStamped` に分かれる:
+
+- `twist` — `geometry_msgs/Twist` で subscribe (humble Nav2 互換)
+- `twist_stamped` — `geometry_msgs/TwistStamped` で subscribe (jazzy 以降 Nav2: `collision_monitor` / `docking_server` 等が TwistStamped 化済)
+- `auto` (default) — `ROS_DISTRO` 環境変数で自動選択 (`humble` → `twist`、それ以外 / 未設定 → `twist_stamped`)
+
+**型不一致は単に subscribe が空になるのではなく process が落ちる**: 同じ topic に違う型の subscriber を 2 つ作ると rcl が `invalid allocator` で crash する (#249 で実機再発)。`auto` の選ぶ型と実際に流れる publisher 型を揃えるのが大前提。
+
+`auto` を override する必要があるのは下記の混在構成:
+
+| ケース | override |
+| --- | --- |
+| jazzy 上で自前 controller が Twist のまま publish | `cmd_vel_msg_type: "twist"` を明示 |
+| humble 上で自前 controller が TwistStamped を先取りしている | `cmd_vel_msg_type: "twist_stamped"` を明示 |
+| 最小 CI / 自作 container で `ROS_DISTRO` が unset、かつ humble を使う | `cmd_vel_msg_type: "twist"` を明示 (default fallback は `twist_stamped` のため) |
+
+未知値 (typo) は WARN を出した上で `ROS_DISTRO` ベースで安全側にフォールバックする。
 
 #### サブスクライバー
 

--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -136,6 +136,8 @@ POI 名を指定した自律走行と、POI 半径イベント検知を行うノ
 | `map_frame` | `string` | `map` | TF の親フレーム |
 | `base_frame` | `string` | `base_link` | TF の子フレーム |
 | `auto_resume_timeout_sec` | `double` | `0.0` | `EVENT_PAUSED` 発火後の auto-resume timeout (秒、#231)。`0.0` で disabled (現行仕様、外部 `/mapoi/nav/resume` を無限待ち)。正値で「PAUSED から N 秒後に内部 resume を呼ぶ」demo / 自動運転シナリオ向け opt-in 動作を有効化。負値は起動時に `0.0` へ clamp。動的 reconfigure 非対応 |
+| `cmd_vel_topic` | `string` | `cmd_vel` | `EVENT_PAUSED` 判定用 `cmd_vel` の subscribe 先 topic 名。Nav2 と同じ topic を見る前提 (停止判定 source) |
+| `cmd_vel_msg_type` | `string` | `auto` | `cmd_vel` の message 型 (#249 / #251)。`twist` = `geometry_msgs/Twist` (humble Nav2 互換)、`twist_stamped` = `geometry_msgs/TwistStamped` (jazzy 以降 Nav2: `collision_monitor` / `docking_server` 等が TwistStamped 化済)、`auto` (default) = `ROS_DISTRO` 環境変数で自動選択 (`humble` → `twist`、それ以外 / 未設定 → `twist_stamped`)。同 topic に違う型の sub を作ると rcl が crash するため、`auto` を上書きする必要があるのは下記ケース: (a) jazzy 上で自前 controller が Twist のまま publish する混在構成 → `twist` を明示、(b) humble 上で自前 controller が TwistStamped を先取りしている構成 → `twist_stamped` を明示、(c) 最小 CI / 自作 container で `ROS_DISTRO` が unset の環境で humble を使う場合 → `twist` を明示 (default fallback は `twist_stamped`)。未知値 (typo) は WARN を出した上で `ROS_DISTRO` ベースで安全側にフォールバック |
 
 #### サブスクライバー
 

--- a/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
@@ -331,6 +331,8 @@ private:
   FRIEND_TEST(Nav2BridgeTestFixture, ConstructorTwistParamCreatesTwistSub);
   FRIEND_TEST(Nav2BridgeTestFixture, ConstructorUnknownParamJazzyFallsBackToStampedSub);
   FRIEND_TEST(Nav2BridgeTestFixture, ConstructorUnknownParamHumbleFallsBackToTwistSub);
+  FRIEND_TEST(Nav2BridgeTestFixture, ConstructorAutoParamJazzyCreatesStampedSub);
+  FRIEND_TEST(Nav2BridgeTestFixture, ConstructorAutoParamHumbleCreatesTwistSub);
 #endif
 };
 

--- a/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
@@ -329,7 +329,8 @@ private:
   FRIEND_TEST(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback);
   FRIEND_TEST(Nav2BridgeTestFixture, ConstructorTwistStampedParamCreatesStampedSub);
   FRIEND_TEST(Nav2BridgeTestFixture, ConstructorTwistParamCreatesTwistSub);
-  FRIEND_TEST(Nav2BridgeTestFixture, ConstructorUnknownParamFallsBackToDistroBranch);
+  FRIEND_TEST(Nav2BridgeTestFixture, ConstructorUnknownParamJazzyFallsBackToStampedSub);
+  FRIEND_TEST(Nav2BridgeTestFixture, ConstructorUnknownParamHumbleFallsBackToTwistSub);
 #endif
 };
 

--- a/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
@@ -333,6 +333,7 @@ private:
   FRIEND_TEST(Nav2BridgeTestFixture, ConstructorUnknownParamHumbleFallsBackToTwistSub);
   FRIEND_TEST(Nav2BridgeTestFixture, ConstructorAutoParamJazzyCreatesStampedSub);
   FRIEND_TEST(Nav2BridgeTestFixture, ConstructorAutoParamHumbleCreatesTwistSub);
+  FRIEND_TEST(Nav2BridgeTestFixture, ConstructorAutoParamUnsetDistroCreatesStampedSub);
 #endif
 };
 

--- a/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
@@ -327,6 +327,9 @@ private:
   FRIEND_TEST(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeExplicit);
   FRIEND_TEST(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeAutoByDistro);
   FRIEND_TEST(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback);
+  FRIEND_TEST(Nav2BridgeTestFixture, ConstructorTwistStampedParamCreatesStampedSub);
+  FRIEND_TEST(Nav2BridgeTestFixture, ConstructorTwistParamCreatesTwistSub);
+  FRIEND_TEST(Nav2BridgeTestFixture, ConstructorUnknownParamFallsBackToDistroBranch);
 #endif
 };
 

--- a/mapoi_server/launch/mapoi_bringup.launch.yaml
+++ b/mapoi_server/launch/mapoi_bringup.launch.yaml
@@ -79,6 +79,19 @@ launch:
       opt-in 動作を有効化。負値は bridge 側で 0.0 に clamp。
 
 - arg:
+    name: cmd_vel_msg_type
+    default: "auto"
+    description: >
+      mapoi_nav2_bridge の cmd_vel_msg_type parameter forward (#249 / #251)。
+      twist = geometry_msgs/Twist (humble Nav2 互換)、
+      twist_stamped = geometry_msgs/TwistStamped (jazzy 以降 Nav2)、
+      auto (default) = ROS_DISTRO で自動選択 (humble → twist、それ以外 / unset → twist_stamped)。
+      auto を override する必要があるのは下記の混在構成:
+        - jazzy 上で自前 controller が Twist のまま publish (= twist 明示)
+        - humble 上で自前 controller が TwistStamped 先取り (= twist_stamped 明示)
+        - ROS_DISTRO 未設定環境で humble を使う (= default fallback が twist_stamped のため twist 明示)
+
+- arg:
     name: with_amcl_localization_bridge
     default: "true"
     description: >
@@ -106,6 +119,7 @@ launch:
     exec: mapoi_nav2_bridge
     param:
       - {name: auto_resume_timeout_sec, value: $(var auto_resume_timeout_sec)}
+      - {name: cmd_vel_msg_type, value: "$(var cmd_vel_msg_type)"}
     if: $(var with_nav2_bridge)
 
 - node:

--- a/mapoi_server/launch/mapoi_bringup.launch.yaml
+++ b/mapoi_server/launch/mapoi_bringup.launch.yaml
@@ -85,7 +85,7 @@ launch:
       mapoi_nav2_bridge の cmd_vel_msg_type parameter forward (#249 / #251)。
       twist = geometry_msgs/Twist (humble Nav2 互換)、
       twist_stamped = geometry_msgs/TwistStamped (jazzy 以降 Nav2)、
-      auto (default) = ROS_DISTRO で自動選択 (humble → twist、それ以外 / unset → twist_stamped)。
+      auto (default) = ROS_DISTRO で自動選択 (humble → twist、それ以外 / 未設定 → twist_stamped)。
       auto を override する必要があるのは下記の混在構成:
         - jazzy 上で自前 controller が Twist のまま publish (= twist 明示)
         - humble 上で自前 controller が TwistStamped 先取り (= twist_stamped 明示)

--- a/mapoi_server/launch/mapoi_bringup.launch.yaml
+++ b/mapoi_server/launch/mapoi_bringup.launch.yaml
@@ -92,6 +92,16 @@ launch:
         - ROS_DISTRO 未設定環境で humble を使う (= default fallback が twist_stamped のため twist 明示)
 
 - arg:
+    name: cmd_vel_topic
+    default: "cmd_vel"
+    description: >
+      mapoi_nav2_bridge の cmd_vel_topic parameter forward (#249)。
+      EVENT_PAUSED 判定用に subscribe する cmd_vel 互換 topic 名。
+      Nav2 と同じ topic を見る前提 (停止判定 source として一致が必要)。
+      default は標準的な Nav2 命名 'cmd_vel'。namespace 化 / multi-robot 構成で
+      上書き必要時に override する。
+
+- arg:
     name: with_amcl_localization_bridge
     default: "true"
     description: >
@@ -120,6 +130,7 @@ launch:
     param:
       - {name: auto_resume_timeout_sec, value: $(var auto_resume_timeout_sec)}
       - {name: cmd_vel_msg_type, value: "$(var cmd_vel_msg_type)"}
+      - {name: cmd_vel_topic, value: "$(var cmd_vel_topic)"}
     if: $(var with_nav2_bridge)
 
 - node:

--- a/mapoi_server/test/test_nav2_bridge_unit.cpp
+++ b/mapoi_server/test/test_nav2_bridge_unit.cpp
@@ -352,6 +352,12 @@ TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeExplicit)
   EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("twist_stamped"), "twist_stamped");
 }
 
+// **本 test binary は ROS_DISTRO を setenv/unsetenv で書き換える** ため、gtest を並列実行
+// (`--gtest_parallel` / ctest `-j` で他 test と同居) すると env race の温床になる。現状の
+// colcon 構成は逐次実行前提で問題ないが、将来 parallel に切替える場合は本 binary を
+// シングル process に固定 (例: `RUN_SERIAL TRUE`) するか、ROS_DISTRO 依存テストを別 binary に
+// 分割する必要がある (#252 round 2 review medium #3 メモ)。
+
 // RAII guard for ROS_DISTRO env: テスト中の setenv/unsetenv が EXPECT 失敗 / 例外 / 早期 return で
 // 復元漏れになり、後続テスト (特に "auto" 解決を含む test) へリークするのを防ぐ (#251 review medium)。
 // destructor で必ず元値へ戻す。
@@ -495,6 +501,22 @@ TEST_F(Nav2BridgeTestFixture, ConstructorAutoParamHumbleCreatesTwistSub)
   auto node = std::make_shared<MapoiNav2Bridge>(options);
   EXPECT_NE(node->cmd_vel_sub_, nullptr);
   EXPECT_EQ(node->cmd_vel_stamped_sub_, nullptr);
+}
+
+TEST_F(Nav2BridgeTestFixture, ConstructorAutoParamUnsetDistroCreatesStampedSub)
+{
+  // ROS_DISTRO 未設定 + auto: README / launch description で「未設定 → twist_stamped」と運用上の
+  // 重要ケースとして明記している経路。最小 CI / 自作 container 等で env が落ちた状態で
+  // bridge を起動するシナリオの constructor 側を pin する (#252 round 3 review medium #1)。
+  ScopedRosDistro distro_guard;
+  unsetenv("ROS_DISTRO");
+
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("cmd_vel_msg_type", std::string("auto"));
+  options.append_parameter_override("cmd_vel_topic", std::string("test_cmd_vel_auto_unset_branch"));
+  auto node = std::make_shared<MapoiNav2Bridge>(options);
+  EXPECT_NE(node->cmd_vel_stamped_sub_, nullptr);
+  EXPECT_EQ(node->cmd_vel_sub_, nullptr);
 }
 
 TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback)

--- a/mapoi_server/test/test_nav2_bridge_unit.cpp
+++ b/mapoi_server/test/test_nav2_bridge_unit.cpp
@@ -465,6 +465,38 @@ TEST_F(Nav2BridgeTestFixture, ConstructorUnknownParamHumbleFallsBackToTwistSub)
   EXPECT_EQ(node->cmd_vel_stamped_sub_, nullptr);
 }
 
+// "auto" 自身の constructor 経路も両 distro で pin する (#252 round 2 review medium #1)。
+// 純関数 ResolveCmdVelMsgTypeAutoByDistro は解決ロジックだけを見ているため、constructor 内で
+// 「auto を渡したときに resolve 結果へ正しく分岐する」部分が壊れても (例: リファクタで auto
+// 経路だけ解決結果を無視するような typo) 検知できない余地が残る。default param が "auto" で
+// あることと合わせて、本番運用パスの回帰検知として両 distro 分を pin する。
+
+TEST_F(Nav2BridgeTestFixture, ConstructorAutoParamJazzyCreatesStampedSub)
+{
+  ScopedRosDistro distro_guard;
+  setenv("ROS_DISTRO", "jazzy", 1);
+
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("cmd_vel_msg_type", std::string("auto"));
+  options.append_parameter_override("cmd_vel_topic", std::string("test_cmd_vel_auto_jazzy_branch"));
+  auto node = std::make_shared<MapoiNav2Bridge>(options);
+  EXPECT_NE(node->cmd_vel_stamped_sub_, nullptr);
+  EXPECT_EQ(node->cmd_vel_sub_, nullptr);
+}
+
+TEST_F(Nav2BridgeTestFixture, ConstructorAutoParamHumbleCreatesTwistSub)
+{
+  ScopedRosDistro distro_guard;
+  setenv("ROS_DISTRO", "humble", 1);
+
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("cmd_vel_msg_type", std::string("auto"));
+  options.append_parameter_override("cmd_vel_topic", std::string("test_cmd_vel_auto_humble_branch"));
+  auto node = std::make_shared<MapoiNav2Bridge>(options);
+  EXPECT_NE(node->cmd_vel_sub_, nullptr);
+  EXPECT_EQ(node->cmd_vel_stamped_sub_, nullptr);
+}
+
 TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback)
 {
   // 未知値 (typo / 設定ミス) は auto と同じく ROS_DISTRO ベースでフォールバック。

--- a/mapoi_server/test/test_nav2_bridge_unit.cpp
+++ b/mapoi_server/test/test_nav2_bridge_unit.cpp
@@ -352,13 +352,40 @@ TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeExplicit)
   EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("twist_stamped"), "twist_stamped");
 }
 
+// RAII guard for ROS_DISTRO env: テスト中の setenv/unsetenv が EXPECT 失敗 / 例外 / 早期 return で
+// 復元漏れになり、後続テスト (特に "auto" 解決を含む test) へリークするのを防ぐ (#251 review medium)。
+// destructor で必ず元値へ戻す。
+class ScopedRosDistro
+{
+public:
+  ScopedRosDistro()
+  {
+    const char * original = std::getenv("ROS_DISTRO");
+    if (original != nullptr) {
+      saved_ = original;
+      was_set_ = true;
+    }
+  }
+  ~ScopedRosDistro()
+  {
+    if (was_set_) {
+      setenv("ROS_DISTRO", saved_.c_str(), 1);
+    } else {
+      unsetenv("ROS_DISTRO");
+    }
+  }
+  ScopedRosDistro(const ScopedRosDistro &) = delete;
+  ScopedRosDistro & operator=(const ScopedRosDistro &) = delete;
+
+private:
+  std::string saved_;
+  bool was_set_ {false};
+};
+
 TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeAutoByDistro)
 {
   // "auto" は ROS_DISTRO 環境変数で決まる: humble → twist、それ以外 → twist_stamped。
-  // 既存の ROS_DISTRO 値を保存して復元する (テストが Docker / launch_test 環境を壊さない)。
-  const char * original = std::getenv("ROS_DISTRO");
-  std::string saved = original ? original : "";
-  bool was_unset = (original == nullptr);
+  ScopedRosDistro distro_guard;
 
   setenv("ROS_DISTRO", "humble", 1);
   EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("auto"), "twist");
@@ -371,13 +398,6 @@ TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeAutoByDistro)
 
   unsetenv("ROS_DISTRO");
   EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("auto"), "twist_stamped");
-
-  // restore
-  if (was_unset) {
-    unsetenv("ROS_DISTRO");
-  } else {
-    setenv("ROS_DISTRO", saved.c_str(), 1);
-  }
 }
 
 // Constructor の分岐自体 (declare_parameter → if (msg_type == "twist_stamped") { ... } else { ... })
@@ -385,6 +405,10 @@ TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeAutoByDistro)
 // 解決ロジックだけを見ているため、constructor で「解決後の型に対応する sub を 1 本だけ作る」
 // 部分を独立に検証しないと、リファクタで if 分岐の typo / どちらかの create_subscription が
 // 漏れても unit test が緑のまま通る余地が残る。
+//
+// 本 test 群が確認するのは「create_subscription が呼ばれて該当 member が non-null になる」
+// ことのみで、subscription が実際に message を受信できるかは scope 外 (それは
+// CmdVel*CallbackUpdatesZeroVelocityState / route_integration launch_test で別途 pin)。
 //
 // 同 process の fixture node が default 設定で `/cmd_vel` に sub を貼っているため、本 test 群は
 // 必ず専用 `cmd_vel_topic` を割り当てる: 同 topic に違う型の sub を作ると rcl が
@@ -410,28 +434,35 @@ TEST_F(Nav2BridgeTestFixture, ConstructorTwistParamCreatesTwistSub)
   EXPECT_EQ(node->cmd_vel_stamped_sub_, nullptr);
 }
 
-TEST_F(Nav2BridgeTestFixture, ConstructorUnknownParamFallsBackToDistroBranch)
+TEST_F(Nav2BridgeTestFixture, ConstructorUnknownParamJazzyFallsBackToStampedSub)
 {
-  // 未知値は resolve_cmd_vel_msg_type で ROS_DISTRO 適合型に解決され、対応 sub が 1 本だけ作られる。
-  // caller 側の WARN log は ResolveCmdVelMsgTypeUnknownFallback で pin 済なので、
-  // ここでは「fallback 後に正しい型の sub が wire されているか」だけを見る。
-  const char * original = std::getenv("ROS_DISTRO");
-  std::string saved = original ? original : "";
-  bool was_unset = (original == nullptr);
-
+  // 未知値 + ROS_DISTRO=jazzy: resolve_cmd_vel_msg_type 経由で "twist_stamped" に解決され
+  // TwistStamped sub が wire される。caller 側の WARN log は ResolveCmdVelMsgTypeUnknownFallback
+  // で pin 済なので、ここでは「fallback 後に正しい型の sub が wire されているか」だけを見る。
+  ScopedRosDistro distro_guard;
   setenv("ROS_DISTRO", "jazzy", 1);
+
   rclcpp::NodeOptions options;
   options.append_parameter_override("cmd_vel_msg_type", std::string("Twist"));  // case-sensitive typo
-  options.append_parameter_override("cmd_vel_topic", std::string("test_cmd_vel_unknown_branch"));
+  options.append_parameter_override("cmd_vel_topic", std::string("test_cmd_vel_unknown_jazzy_branch"));
   auto node = std::make_shared<MapoiNav2Bridge>(options);
   EXPECT_NE(node->cmd_vel_stamped_sub_, nullptr);
   EXPECT_EQ(node->cmd_vel_sub_, nullptr);
+}
 
-  if (was_unset) {
-    unsetenv("ROS_DISTRO");
-  } else {
-    setenv("ROS_DISTRO", saved.c_str(), 1);
-  }
+TEST_F(Nav2BridgeTestFixture, ConstructorUnknownParamHumbleFallsBackToTwistSub)
+{
+  // 未知値 + ROS_DISTRO=humble: resolve_cmd_vel_msg_type 経由で "twist" に解決され Twist sub
+  // が wire される。jazzy 側と同じく constructor の if/else 漏れを両 distro で潰す。
+  ScopedRosDistro distro_guard;
+  setenv("ROS_DISTRO", "humble", 1);
+
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("cmd_vel_msg_type", std::string("twst"));  // typo
+  options.append_parameter_override("cmd_vel_topic", std::string("test_cmd_vel_unknown_humble_branch"));
+  auto node = std::make_shared<MapoiNav2Bridge>(options);
+  EXPECT_NE(node->cmd_vel_sub_, nullptr);
+  EXPECT_EQ(node->cmd_vel_stamped_sub_, nullptr);
 }
 
 TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback)
@@ -440,9 +471,7 @@ TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback)
   // 旧仕様 (常に "twist") だと jazzy 本番で誤設定すると subscribe 不成立で
   // EVENT_PAUSED が再び silent に壊れる回帰につながるため、distro 適合型に揃える。
   // (caller 側は別途 WARN log で typo を可視化する、cursor review PR #250 medium #1)
-  const char * original = std::getenv("ROS_DISTRO");
-  std::string saved = original ? original : "";
-  bool was_unset = (original == nullptr);
+  ScopedRosDistro distro_guard;
 
   setenv("ROS_DISTRO", "jazzy", 1);
   EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("twst"), "twist_stamped");
@@ -451,13 +480,6 @@ TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback)
 
   setenv("ROS_DISTRO", "humble", 1);
   EXPECT_EQ(MapoiNav2Bridge::resolve_cmd_vel_msg_type("twst"), "twist");
-
-  // restore
-  if (was_unset) {
-    unsetenv("ROS_DISTRO");
-  } else {
-    setenv("ROS_DISTRO", saved.c_str(), 1);
-  }
 }
 
 int main(int argc, char ** argv)

--- a/mapoi_server/test/test_nav2_bridge_unit.cpp
+++ b/mapoi_server/test/test_nav2_bridge_unit.cpp
@@ -380,6 +380,60 @@ TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeAutoByDistro)
   }
 }
 
+// Constructor の分岐自体 (declare_parameter → if (msg_type == "twist_stamped") { ... } else { ... })
+// が壊れていないことを pin する (#251 follow-up)。resolve_cmd_vel_msg_type の純関数 test は
+// 解決ロジックだけを見ているため、constructor で「解決後の型に対応する sub を 1 本だけ作る」
+// 部分を独立に検証しないと、リファクタで if 分岐の typo / どちらかの create_subscription が
+// 漏れても unit test が緑のまま通る余地が残る。
+//
+// 同 process の fixture node が default 設定で `/cmd_vel` に sub を貼っているため、本 test 群は
+// 必ず専用 `cmd_vel_topic` を割り当てる: 同 topic に違う型の sub を作ると rcl が
+// `invalid allocator` で crash する (#249 lessons)。
+
+TEST_F(Nav2BridgeTestFixture, ConstructorTwistStampedParamCreatesStampedSub)
+{
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("cmd_vel_msg_type", std::string("twist_stamped"));
+  options.append_parameter_override("cmd_vel_topic", std::string("test_cmd_vel_stamped_branch"));
+  auto node = std::make_shared<MapoiNav2Bridge>(options);
+  EXPECT_NE(node->cmd_vel_stamped_sub_, nullptr);
+  EXPECT_EQ(node->cmd_vel_sub_, nullptr);
+}
+
+TEST_F(Nav2BridgeTestFixture, ConstructorTwistParamCreatesTwistSub)
+{
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("cmd_vel_msg_type", std::string("twist"));
+  options.append_parameter_override("cmd_vel_topic", std::string("test_cmd_vel_twist_branch"));
+  auto node = std::make_shared<MapoiNav2Bridge>(options);
+  EXPECT_NE(node->cmd_vel_sub_, nullptr);
+  EXPECT_EQ(node->cmd_vel_stamped_sub_, nullptr);
+}
+
+TEST_F(Nav2BridgeTestFixture, ConstructorUnknownParamFallsBackToDistroBranch)
+{
+  // 未知値は resolve_cmd_vel_msg_type で ROS_DISTRO 適合型に解決され、対応 sub が 1 本だけ作られる。
+  // caller 側の WARN log は ResolveCmdVelMsgTypeUnknownFallback で pin 済なので、
+  // ここでは「fallback 後に正しい型の sub が wire されているか」だけを見る。
+  const char * original = std::getenv("ROS_DISTRO");
+  std::string saved = original ? original : "";
+  bool was_unset = (original == nullptr);
+
+  setenv("ROS_DISTRO", "jazzy", 1);
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("cmd_vel_msg_type", std::string("Twist"));  // case-sensitive typo
+  options.append_parameter_override("cmd_vel_topic", std::string("test_cmd_vel_unknown_branch"));
+  auto node = std::make_shared<MapoiNav2Bridge>(options);
+  EXPECT_NE(node->cmd_vel_stamped_sub_, nullptr);
+  EXPECT_EQ(node->cmd_vel_sub_, nullptr);
+
+  if (was_unset) {
+    unsetenv("ROS_DISTRO");
+  } else {
+    setenv("ROS_DISTRO", saved.c_str(), 1);
+  }
+}
+
 TEST_F(Nav2BridgeTestFixture, ResolveCmdVelMsgTypeUnknownFallback)
 {
   // 未知値 (typo / 設定ミス) は auto と同じく ROS_DISTRO ベースでフォールバック。


### PR DESCRIPTION
## Summary

PR #250 (Closes #249) の Cursor review 残課題 #251 の medium 2 件 + low 1 件を対応。

### 対応した item (#251)
- **medium #1**: Constructor 経路の subscription 型分岐の自動テスト不足
- **medium #2**: デフォルト `auto` 以外の構成向けドキュメント追記
- **low #3**: `ROS_DISTRO` unset 時の挙動を運用 doc に明記

### 対応見送り
- **low #4** (env 競合リスク): 既存パターンの延長で許容。flake が出たら fixture 隔離検討
- **low #5** (WARN 強化): PR #250 で対応済 (改善余地小)
- **low #6** (`angular.x/y` 判定外): 変更前からの仕様、scope 外

## 変更内容

### gtest 3 件追加 (`test_nav2_bridge_unit.cpp`)
- `ConstructorTwistStampedParamCreatesStampedSub`: `cmd_vel_msg_type=twist_stamped` で TwistStamped sub のみ wire される
- `ConstructorTwistParamCreatesTwistSub`: `cmd_vel_msg_type=twist` で Twist sub のみ wire される
- `ConstructorUnknownParamFallsBackToDistroBranch`: 未知値 (`Twist` 等) は `resolve_cmd_vel_msg_type` 経由で `ROS_DISTRO` 適合型に解決され対応 sub が 1 本だけ作られる

同 process の fixture node が default で `/cmd_vel` を sub するため、本 test 群は専用 `cmd_vel_topic` を割り当てて型衝突を回避 (#249 lessons: 同 topic 多型 sub は rcl `invalid allocator` で crash)。FRIEND_TEST を hpp に追加して private member (`cmd_vel_sub_` / `cmd_vel_stamped_sub_`) にアクセス。

### `mapoi_server/README.md`
`mapoi_nav2_bridge` の param 表に `cmd_vel_topic` / `cmd_vel_msg_type` 行を追加。`auto` を override する必要がある 3 ケースを明記:
- jazzy 上で自前 controller が Twist のまま publish する混在構成 → `twist` 明示
- humble 上で自前 controller が TwistStamped を先取りしている構成 → `twist_stamped` 明示
- `ROS_DISTRO` 未設定環境で humble を使う場合 → default fallback が `twist_stamped` のため `twist` 明示

### `mapoi_bringup.launch.yaml`
`cmd_vel_msg_type` を launch arg として露出し、`mapoi_nav2_bridge` node に forward。include 経由でも上書きできるよう `auto_resume_timeout_sec` と同パターンで対応。

## Test plan
- [x] gtest 3 件 humble Docker で pass
- [x] gtest 3 件 jazzy Docker で pass
- [x] `colcon build --packages-up-to mapoi_server` が humble / jazzy 両方で pass
- [x] 既存 unit test に影響なし (test_nav2_bridge_unit binary 全 pass)

## 関連
- Closes #251
- 元 PR: #250 (Closes #249)
- Cursor review: https://github.com/shimz-robotics/mapoi/pull/250#issuecomment-4551471552