### PR TITLE
test(webui): /api/pois POST 楽観的競合検出の Flask endpoint test 追加 (Close #246)

### DIFF
--- a/mapoi_webui/CMakeLists.txt
+++ b/mapoi_webui/CMakeLists.txt
@@ -37,6 +37,12 @@ if(BUILD_TESTING)
     test/test_yaml_handler_version.py
     TIMEOUT 10
   )
+  # Flask endpoint レベルでの `/api/pois` POST 楽観的競合検出契約 (#241 / #246)。
+  # 純関数 test (test_yaml_handler_version) と分けて、409 + code + current_version 経路を pin。
+  ament_add_pytest_test(test_api_save_pois_version_conflict
+    test/test_api_save_pois_version_conflict.py
+    TIMEOUT 10
+  )
 endif()
 
 ament_package()

--- a/mapoi_webui/README.md
+++ b/mapoi_webui/README.md
@@ -81,30 +81,7 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 | POST | `/api/nav/switch-map` | Navigation map switch。`mapoi/nav/switch_map` に map 名を publish |
 | GET | `/api/mode` | navigation 機能の検出結果 (`navigation_available`, topic subscriber 数) |
 
-### `POST /api/pois` の楽観的競合検出 (#241)
-
-外部編集 (別 WebUI tab / yaml 直編集 / 別 client からの POST) との衝突を検知するため、`POST /api/pois` は `expected_version` フィールドを受け付ける。
-
-リクエスト body:
-
-```json
-{
-  "pois": [...],
-  "expected_version": "<GET /api/pois で受け取った config_version (sha256 hex 64 桁)>"
-}
-```
-
-挙動:
-
-| `expected_version` | 動作 |
-| --- | --- |
-| 省略 (`null` / 不在) | check skip → 200 OK で保存 (後方互換、旧クライアント / curl 用) |
-| `compute_config_version(yaml)` と一致 | 保存して 200 OK + `config_version: <new>` を返す |
-| 一致しない (`""` 空文字 / 別 hash 値 / 形式不正の文字列等) | **409 Conflict** + `code: "version_mismatch"` + `current_version: <new>` + `error: "...please reload..."` を返す。frontend は reload して新版で再 Save 入力 |
-
-**WebUI 経由なら safe**: poi-editor は GET 時の `config_version` を保持して Save 時に必ず送り返す (#241 frontend 改修)。Save 時に外部編集を踏むと 409 + 警告ダイアログで reload を促す。
-
-**外部 POST (curl / 別 client) は責任ベース**: `expected_version` 省略時は意図的に check を skip するため、外部 client が WebUI 中の編集を knowingly に上書きするのは可能 (旧クライアント / scripted batch update を壊さないための後方互換)。外部 POST 利用者は (a) GET → POST 間の race を避ける運用にする、(b) 必要なら自前で `expected_version` を送って 409 を扱う、のいずれかで責任を負う。
+`POST /api/pois` は楽観的競合検出 (`expected_version` フィールド) に対応 (#241)。WebUI 経由は frontend が自動でハンドリング、外部 POST (curl / 別 client) で `expected_version` 省略時は check skip のため、競合上書きを避けたい場合は呼び出し側が `GET /api/pois` の `config_version` を送り返す責任を負う。詳細仕様は実装コメント (`api_save_pois`) / test (`test_api_save_pois_version_conflict.py`) を参照。
 
 ## 起動方法 (3 つのシナリオ)
 

--- a/mapoi_webui/README.md
+++ b/mapoi_webui/README.md
@@ -81,6 +81,31 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 | POST | `/api/nav/switch-map` | Navigation map switch。`mapoi/nav/switch_map` に map 名を publish |
 | GET | `/api/mode` | navigation 機能の検出結果 (`navigation_available`, topic subscriber 数) |
 
+### `POST /api/pois` の楽観的競合検出 (#241)
+
+外部編集 (別 WebUI tab / yaml 直編集 / 別 client からの POST) との衝突を検知するため、`POST /api/pois` は `expected_version` フィールドを受け付ける。
+
+リクエスト body:
+
+```json
+{
+  "pois": [...],
+  "expected_version": "<GET /api/pois で受け取った config_version (sha256 hex 64 桁)>"
+}
+```
+
+挙動:
+
+| `expected_version` | 動作 |
+| --- | --- |
+| 省略 (`null` / 不在) | check skip → 200 OK で保存 (後方互換、旧クライアント / curl 用) |
+| `compute_config_version(yaml)` と一致 | 保存して 200 OK + `config_version: <new>` を返す |
+| 一致しない | **409 Conflict** + `code: "version_mismatch"` + `current_version: <new>` + `error: "...please reload..."` を返す。frontend は reload して新版で再 Save 入力 |
+
+**WebUI 経由なら safe**: poi-editor は GET 時の `config_version` を保持して Save 時に必ず送り返す (#241 frontend 改修)。Save 時に外部編集を踏むと 409 + 警告ダイアログで reload を促す。
+
+**外部 POST (curl / 別 client) は責任ベース**: `expected_version` 省略時は意図的に check を skip するため、外部 client が WebUI 中の編集を knowingly に上書きするのは可能 (旧クライアント / scripted batch update を壊さないための後方互換)。外部 POST 利用者は (a) GET → POST 間の race を避ける運用にする、(b) 必要なら自前で `expected_version` を送って 409 を扱う、のいずれかで責任を負う。
+
 ## 起動方法 (3 つのシナリオ)
 
 利用目的に応じて 3 つの起動方法を使い分けてください。いずれもブラウザで `http://<ホスト>:8765` にアクセスします。

--- a/mapoi_webui/README.md
+++ b/mapoi_webui/README.md
@@ -100,7 +100,7 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 | --- | --- |
 | 省略 (`null` / 不在) | check skip → 200 OK で保存 (後方互換、旧クライアント / curl 用) |
 | `compute_config_version(yaml)` と一致 | 保存して 200 OK + `config_version: <new>` を返す |
-| 一致しない | **409 Conflict** + `code: "version_mismatch"` + `current_version: <new>` + `error: "...please reload..."` を返す。frontend は reload して新版で再 Save 入力 |
+| 一致しない (`""` 空文字 / 別 hash 値 / 形式不正の文字列等) | **409 Conflict** + `code: "version_mismatch"` + `current_version: <new>` + `error: "...please reload..."` を返す。frontend は reload して新版で再 Save 入力 |
 
 **WebUI 経由なら safe**: poi-editor は GET 時の `config_version` を保持して Save 時に必ず送り返す (#241 frontend 改修)。Save 時に外部編集を踏むと 409 + 警告ダイアログで reload を促す。
 

--- a/mapoi_webui/test/test_api_save_pois_version_conflict.py
+++ b/mapoi_webui/test/test_api_save_pois_version_conflict.py
@@ -1,0 +1,141 @@
+"""Flask endpoint level test for `/api/pois` POST 楽観的競合検出 (#241 / #246).
+
+`test_yaml_handler_version.py` は `compute_config_version` 単体の決定性しか pin して
+いないため、Flask endpoint レベルで以下の `api_save_pois` 仕様契約を独立に固定する:
+
+- `expected_version` 不一致 → 409 + `code: 'version_mismatch'` + `current_version`
+- `expected_version` 省略 → 200 OK (旧クライアント / curl 後方互換)
+- 保存後 response の `config_version` が新値に更新されている
+
+ROS 2 Node を本物で起動すると DDS / service / publisher が絡んで test 重量級になるため、
+`create_flask_app` を duck-typed `FakeNode` に bind して呼び出す (= `MapoiWebNode.create_flask_app`
+は `self` を `node = self` で local capture するだけで、`/api/pois` 経路は
+`node.get_config_path()` / `node.call_reload_map_info()` / `node.get_logger()` の 3 メソッドだけに
+依存する)。他 endpoint の closures は登録時に評価されないため `FakeNode` に該当 attr が無くても
+本 test は影響を受けない。
+"""
+import os
+import tempfile
+import unittest
+
+import yaml
+
+from mapoi_webui.mapoi_webui_node import MapoiWebNode
+
+
+class _NullLogger:
+    """`api_save_pois` の except 経路で `node.get_logger().error()` を呼ぶための最小 stub。"""
+    def error(self, *_args, **_kwargs):
+        pass
+
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def warn(self, *_args, **_kwargs):
+        pass
+
+
+class _FakeNode:
+    """`/api/pois` 経路で参照される最小限の attr / method だけを持つ duck-typed node."""
+
+    def __init__(self, config_path, reload_succeeds=True):
+        self._config_path = config_path
+        self._reload_succeeds = reload_succeeds
+
+    def get_config_path(self, _map_name=None):
+        return self._config_path
+
+    def call_reload_map_info(self):
+        return self._reload_succeeds
+
+    def get_logger(self):
+        return _NullLogger()
+
+
+def _seed_config(path, pois=None):
+    """tmp yaml に最小 schema を書き出す。`pois` 未指定なら空 list。"""
+    with open(path, 'w') as f:
+        yaml.safe_dump({
+            'map': {},
+            'poi': list(pois or []),
+            'route': [],
+        }, f)
+
+
+def _valid_pois_payload():
+    """`_validate_pois_*` 全 check を通る最小 1 POI body."""
+    return [{
+        'name': 'p1',
+        'pose': {'x': 0.1, 'y': 0.2, 'yaw': 0.0},
+        'tolerance': {'xy': 0.5, 'yaw': 0.785},
+        'tags': ['waypoint'],
+    }]
+
+
+class TestApiSavePoisVersionConflict(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.config_path = os.path.join(self._tmp.name, 'cfg.yaml')
+        _seed_config(self.config_path)
+        self.fake_node = _FakeNode(self.config_path)
+        self.app = MapoiWebNode.create_flask_app(self.fake_node)
+        self.client = self.app.test_client()
+
+    def _current_version(self):
+        from mapoi_webui.yaml_handler import compute_config_version
+        return compute_config_version(self.config_path)
+
+    def test_save_with_matching_expected_version_returns_200_with_new_version(self):
+        v_before = self._current_version()
+        self.assertIsNotNone(v_before)
+
+        resp = self.client.post('/api/pois', json={
+            'pois': _valid_pois_payload(),
+            'expected_version': v_before,
+        })
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertTrue(body.get('success'))
+        # 保存後 response の config_version は新値 (= save 後の sha256) に更新されている
+        self.assertIn('config_version', body)
+        self.assertNotEqual(body['config_version'], v_before)
+        self.assertEqual(body['config_version'], self._current_version())
+
+    def test_save_with_mismatched_expected_version_returns_409(self):
+        # GET 時点と POST 時点の間で外部編集が入ったケースをシミュレート: client は古い
+        # version を握ったまま POST するが、backend file は別 client が書き換えて新 version に
+        # なっている → 409 で reject されること、code / current_version フィールドを返すこと。
+        stale_version = 'a' * 64  # 64 桁の偽 sha256
+        self.assertNotEqual(stale_version, self._current_version())
+
+        resp = self.client.post('/api/pois', json={
+            'pois': _valid_pois_payload(),
+            'expected_version': stale_version,
+        })
+        self.assertEqual(resp.status_code, 409, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertEqual(body.get('code'), 'version_mismatch')
+        # frontend が直後の reload で受け取るべき current_version を含むこと
+        self.assertIn('current_version', body)
+        self.assertEqual(body['current_version'], self._current_version())
+        # error フィールドにも reload を促す説明文を含むこと (UI banner で表示する想定)
+        self.assertIn('reload', str(body.get('error', '')).lower())
+
+    def test_save_without_expected_version_returns_200(self):
+        """`expected_version` 省略時は version check をスキップして従来通り保存する
+        (旧クライアント / curl / 別 client からの POST 後方互換、PR #245)。
+        """
+        resp = self.client.post('/api/pois', json={
+            'pois': _valid_pois_payload(),
+            # expected_version を意図的に省略
+        })
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertTrue(body.get('success'))
+        self.assertIn('config_version', body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mapoi_webui/test/test_api_save_pois_version_conflict.py
+++ b/mapoi_webui/test/test_api_save_pois_version_conflict.py
@@ -116,36 +116,44 @@ class TestApiSavePoisVersionConflict(unittest.TestCase):
         self.assertEqual(len(saved_pois), 1)
         self.assertEqual(saved_pois[0]['name'], payload[0]['name'])
 
-    def test_save_with_mismatched_expected_version_returns_409_without_writing(self):
-        # GET 時点と POST 時点の間で外部編集が入ったケースをシミュレート: client は古い
-        # version を握ったまま POST するが、backend file は別 client が書き換えて新 version に
-        # なっている → 409 で reject されること、code / current_version フィールドを返すこと、
-        # かつ **ディスク上の yaml が一切変更されないこと** (= 競合時に誤保存しない契約) を pin。
-        # status_code だけだと「409 返したのに裏で save_pois も呼んでた」回帰を検知できないため、
-        # PR #253 round 1 review medium #1 対応で content / version の不変も併せて assert する。
+    def _assert_409_version_mismatch_without_writing(self, sent_expected_version):
+        """409 経路の共通 assert ヘルパー (PR #253 round 3 review medium #1)。
+
+        全 409 経路 (任意の不一致値 / 空文字 / 等) で同じ契約を pin する:
+        - status 409
+        - code: 'version_mismatch'
+        - current_version: 現在の sha256
+        - error 文言に 'reload' を含む (UI banner 用)
+        - **ディスク上 yaml が一切変更されない** (競合時 non-save 契約)
+        """
         v_before = self._current_version()
         with open(self.config_path, 'rb') as f:
             content_before = f.read()
-        stale_version = 'a' * 64  # 64 桁の偽 sha256 (任意の不一致値)
-        self.assertNotEqual(stale_version, v_before)
 
         resp = self.client.post('/api/pois', json={
             'pois': _valid_pois_payload(),
-            'expected_version': stale_version,
+            'expected_version': sent_expected_version,
         })
         self.assertEqual(resp.status_code, 409, resp.get_data(as_text=True))
         body = resp.get_json()
         self.assertEqual(body.get('code'), 'version_mismatch')
-        # frontend が直後の reload で受け取るべき current_version を含むこと
         self.assertIn('current_version', body)
         self.assertEqual(body['current_version'], v_before)
-        # error フィールドにも reload を促す説明文を含むこと (UI banner で表示する想定)
         self.assertIn('reload', str(body.get('error', '')).lower())
 
         # 競合時に save_pois が呼ばれていないこと: version 不変 + byte 単位で content 不変
         self.assertEqual(self._current_version(), v_before)
         with open(self.config_path, 'rb') as f:
             self.assertEqual(f.read(), content_before)
+
+    def test_save_with_mismatched_expected_version_returns_409_without_writing(self):
+        # GET 時点と POST 時点の間で外部編集が入ったケースをシミュレート: client は古い
+        # version を握ったまま POST するが、backend file は別 client が書き換えて新 version に
+        # なっている → 409 で reject、ディスク上 yaml は一切変更されない (誤保存しない契約)。
+        # PR #253 round 1 review medium #1 対応。
+        stale_version = 'a' * 64  # 64 桁の偽 sha256 (任意の不一致値)
+        self.assertNotEqual(stale_version, self._current_version())
+        self._assert_409_version_mismatch_without_writing(stale_version)
 
     def test_save_without_expected_version_returns_200(self):
         """`expected_version` 省略時は version check をスキップして従来通り保存する
@@ -184,20 +192,15 @@ class TestApiSavePoisVersionConflict(unittest.TestCase):
 
     def test_save_with_explicit_empty_string_expected_version_returns_409(self):
         """`expected_version: ""` (空文字) は省略扱いではなく「明示送信された不一致値」として
-        409 になることを pin (round 2 review medium #2 対応)。
+        409 になることを pin (round 2 review medium #2 対応)。任意の不一致値ケースと同じ
+        contract (current_version 返却 / reload 文言 / non-save) も round 3 review で揃え。
 
         実装は `data.get('expected_version')` の戻り値を `is not None` でしか除外しないため、
         `""` は check に入り、必ず current sha256 (64 桁 hex) と不一致になる。空文字を
         「省略と同じ」と扱う実装にすると意図しない競合バイパス経路ができるため、現実装の
         「明示送信は常に check」契約を test で固定する。
         """
-        resp = self.client.post('/api/pois', json={
-            'pois': _valid_pois_payload(),
-            'expected_version': '',
-        })
-        self.assertEqual(resp.status_code, 409, resp.get_data(as_text=True))
-        body = resp.get_json()
-        self.assertEqual(body.get('code'), 'version_mismatch')
+        self._assert_409_version_mismatch_without_writing('')
 
 
 if __name__ == '__main__':

--- a/mapoi_webui/test/test_api_save_pois_version_conflict.py
+++ b/mapoi_webui/test/test_api_save_pois_version_conflict.py
@@ -103,12 +103,18 @@ class TestApiSavePoisVersionConflict(unittest.TestCase):
         self.assertNotEqual(body['config_version'], v_before)
         self.assertEqual(body['config_version'], self._current_version())
 
-    def test_save_with_mismatched_expected_version_returns_409(self):
+    def test_save_with_mismatched_expected_version_returns_409_without_writing(self):
         # GET 時点と POST 時点の間で外部編集が入ったケースをシミュレート: client は古い
         # version を握ったまま POST するが、backend file は別 client が書き換えて新 version に
-        # なっている → 409 で reject されること、code / current_version フィールドを返すこと。
-        stale_version = 'a' * 64  # 64 桁の偽 sha256
-        self.assertNotEqual(stale_version, self._current_version())
+        # なっている → 409 で reject されること、code / current_version フィールドを返すこと、
+        # かつ **ディスク上の yaml が一切変更されないこと** (= 競合時に誤保存しない契約) を pin。
+        # status_code だけだと「409 返したのに裏で save_pois も呼んでた」回帰を検知できないため、
+        # PR #253 round 1 review medium #1 対応で content / version の不変も併せて assert する。
+        v_before = self._current_version()
+        with open(self.config_path, 'rb') as f:
+            content_before = f.read()
+        stale_version = 'a' * 64  # 64 桁の偽 sha256 (任意の不一致値)
+        self.assertNotEqual(stale_version, v_before)
 
         resp = self.client.post('/api/pois', json={
             'pois': _valid_pois_payload(),
@@ -119,14 +125,20 @@ class TestApiSavePoisVersionConflict(unittest.TestCase):
         self.assertEqual(body.get('code'), 'version_mismatch')
         # frontend が直後の reload で受け取るべき current_version を含むこと
         self.assertIn('current_version', body)
-        self.assertEqual(body['current_version'], self._current_version())
+        self.assertEqual(body['current_version'], v_before)
         # error フィールドにも reload を促す説明文を含むこと (UI banner で表示する想定)
         self.assertIn('reload', str(body.get('error', '')).lower())
+
+        # 競合時に save_pois が呼ばれていないこと: version 不変 + byte 単位で content 不変
+        self.assertEqual(self._current_version(), v_before)
+        with open(self.config_path, 'rb') as f:
+            self.assertEqual(f.read(), content_before)
 
     def test_save_without_expected_version_returns_200(self):
         """`expected_version` 省略時は version check をスキップして従来通り保存する
         (旧クライアント / curl / 別 client からの POST 後方互換、PR #245)。
         """
+        v_before = self._current_version()
         resp = self.client.post('/api/pois', json={
             'pois': _valid_pois_payload(),
             # expected_version を意図的に省略
@@ -135,6 +147,27 @@ class TestApiSavePoisVersionConflict(unittest.TestCase):
         body = resp.get_json()
         self.assertTrue(body.get('success'))
         self.assertIn('config_version', body)
+        # 実際に保存された証拠として version が変わっていること (config_version 存在だけだと
+        # 「response 形だけ整えて中身は書いていない」を検知できない、round 1 review low)。
+        self.assertNotEqual(body['config_version'], v_before)
+        self.assertEqual(body['config_version'], self._current_version())
+
+    def test_save_with_explicit_null_expected_version_returns_200(self):
+        """`expected_version: null` を明示送信した場合も省略時と同じ後方互換挙動 (200 OK + 保存)
+        になることを pin。README には「省略 (null / 不在)」と書いており、frontend が
+        `JSON.stringify({expected_version: null})` 経路でも壊れないことを保証する
+        (round 1 review medium #2 対応)。
+        """
+        v_before = self._current_version()
+        resp = self.client.post('/api/pois', json={
+            'pois': _valid_pois_payload(),
+            'expected_version': None,
+        })
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertTrue(body.get('success'))
+        self.assertNotEqual(body.get('config_version'), v_before)
+        self.assertEqual(body['config_version'], self._current_version())
 
 
 if __name__ == '__main__':

--- a/mapoi_webui/test/test_api_save_pois_version_conflict.py
+++ b/mapoi_webui/test/test_api_save_pois_version_conflict.py
@@ -36,17 +36,21 @@ class _NullLogger:
 
 
 class _FakeNode:
-    """`/api/pois` 経路で参照される最小限の attr / method だけを持つ duck-typed node."""
+    """`/api/pois` 経路で参照される最小限の attr / method だけを持つ duck-typed node.
 
-    def __init__(self, config_path, reload_succeeds=True):
+    `call_reload_map_info()` は常に True を返す: 本 test は競合検出 / 保存契約を pin する
+    のが目的で、reload 失敗時の挙動 (200 + warning フィールド) は scope 外 (`/api/pois` の
+    別 follow-up で扱う、PR #253 round 2 review medium #3 メモ)。
+    """
+
+    def __init__(self, config_path):
         self._config_path = config_path
-        self._reload_succeeds = reload_succeeds
 
     def get_config_path(self, _map_name=None):
         return self._config_path
 
     def call_reload_map_info(self):
-        return self._reload_succeeds
+        return True
 
     def get_logger(self):
         return _NullLogger()
@@ -91,8 +95,9 @@ class TestApiSavePoisVersionConflict(unittest.TestCase):
         v_before = self._current_version()
         self.assertIsNotNone(v_before)
 
+        payload = _valid_pois_payload()
         resp = self.client.post('/api/pois', json={
-            'pois': _valid_pois_payload(),
+            'pois': payload,
             'expected_version': v_before,
         })
         self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
@@ -102,6 +107,14 @@ class TestApiSavePoisVersionConflict(unittest.TestCase):
         self.assertIn('config_version', body)
         self.assertNotEqual(body['config_version'], v_before)
         self.assertEqual(body['config_version'], self._current_version())
+        # 実際にディスクの yaml が新 payload で書き換わっていることを直接確認
+        # (version 系 assert だけだと「config_version は更新したが pois は書かない」回帰を
+        # 検知できない、PR #253 round 2 review medium #1 対応)。
+        with open(self.config_path, 'r') as f:
+            saved = yaml.safe_load(f)
+        saved_pois = saved.get('poi') or []
+        self.assertEqual(len(saved_pois), 1)
+        self.assertEqual(saved_pois[0]['name'], payload[0]['name'])
 
     def test_save_with_mismatched_expected_version_returns_409_without_writing(self):
         # GET 時点と POST 時点の間で外部編集が入ったケースをシミュレート: client は古い
@@ -168,6 +181,23 @@ class TestApiSavePoisVersionConflict(unittest.TestCase):
         self.assertTrue(body.get('success'))
         self.assertNotEqual(body.get('config_version'), v_before)
         self.assertEqual(body['config_version'], self._current_version())
+
+    def test_save_with_explicit_empty_string_expected_version_returns_409(self):
+        """`expected_version: ""` (空文字) は省略扱いではなく「明示送信された不一致値」として
+        409 になることを pin (round 2 review medium #2 対応)。
+
+        実装は `data.get('expected_version')` の戻り値を `is not None` でしか除外しないため、
+        `""` は check に入り、必ず current sha256 (64 桁 hex) と不一致になる。空文字を
+        「省略と同じ」と扱う実装にすると意図しない競合バイパス経路ができるため、現実装の
+        「明示送信は常に check」契約を test で固定する。
+        """
+        resp = self.client.post('/api/pois', json={
+            'pois': _valid_pois_payload(),
+            'expected_version': '',
+        })
+        self.assertEqual(resp.status_code, 409, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertEqual(body.get('code'), 'version_mismatch')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

PR #245 (Closes #241) の Cursor review 残課題 #246 のうち item #1 (API 409 経路の自動テスト) + item #3 (外部 POST 責任ベースの README 明記) を対応。

### 対応した item (#246)
- **item #1**: API レイヤの 409 経路に自動テストが無い
- **item #3**: `expected_version` 省略時のバイパスを README に明記

### 対応見送り
- **item #2** (TOCTOU 理論残): 実害低、fcntl flock / atomic rename 検討は別 follow-up
- **item #4** (409 cancel 後の stale UX banner): UI 改修で別 PR

## 変更内容

### Flask endpoint test 追加 (`test_api_save_pois_version_conflict.py`)

3 件の契約を pin:
- `expected_version` 一致 → 200 OK + 新 `config_version` 返却 + 新値が `compute_config_version` と一致
- `expected_version` 不一致 → 409 + `code: 'version_mismatch'` + `current_version` + error メッセージに `reload` を含む
- `expected_version` 省略 → 200 OK (旧クライアント / curl 後方互換)

**テスト戦略**: ROS 2 Node を本物で立ち上げず、duck-typed `_FakeNode` に `MapoiWebNode.create_flask_app` を bind して Flask test client で叩く。`/api/pois` 経路は `node.get_config_path` / `call_reload_map_info` / `get_logger` の 3 メソッドにしか依存しないため、Node 全体を mock せずに本物の Flask app と検証ロジック (`compute_config_version` / `save_pois` / `_validate_pois_*`) を実走できる。Cursor review の実装案「`create_flask_app()` を Node 非依存に近づけられないか検討、もしくは Flask test client + mock node」のうち後者を選択。

### `mapoi_webui/README.md` 拡張

REST API endpoint 表の直後に「`POST /api/pois` の楽観的競合検出」サブセクションを追加:
- `expected_version` の値ごとの動作を表で整理
- 「WebUI 経由なら safe」「外部 POST (curl / 別 client) は責任ベース」を明記

## Test plan
- [x] Flask test client 3 ケース pass on humble + jazzy
- [x] `colcon test --packages-select mapoi_webui` で 4 tests, 0 failures
- [x] 既存 `test_yaml_handler_version.py` への影響なし (純関数 test と棲み分け)

## 関連
- Closes #246
- 元 PR: #245 (Closes #241)
- Cursor review: https://github.com/shimz-robotics/mapoi/pull/245#issuecomment-4542000435