### PR TITLE
test(turtlebot3_example): camera_node に gtest 基盤 + capture_duration_sec 検証 (refs #248)

### DIFF
--- a/mapoi_turtlebot3_example/CMakeLists.txt
+++ b/mapoi_turtlebot3_example/CMakeLists.txt
@@ -51,4 +51,18 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  # camera_node の挙動を pin する unit test (#248)。
+  # UNIT_TEST マクロで camera_node.cpp の main() を抜き、テスト fixture を
+  # friend に許可した状態で再 compile する (mapoi_server の test_nav2_bridge_unit
+  # と同じパターン)。
+  ament_auto_add_gtest(test_camera_node
+    test/test_camera_node.cpp
+    src/camera_node.cpp
+  )
+  target_compile_definitions(test_camera_node PRIVATE UNIT_TEST)
+endif()
+
 ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/camera_node.hpp
+++ b/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/camera_node.hpp
@@ -22,17 +22,22 @@ class CameraNode : public rclcpp::Node
 {
 public:
   // capture_duration_sec の安全範囲。
-  //   - 下限 0 は "撮影しないで即 resume" になるため弾く。実機 capture も常に正値。
-  //   - 上限 600s は demo / 試験で想定されるカメラ露光の最大値。これを超える値は
+  //   - 下限 1ms (0.001s): 0 以下は "撮影しないで即 resume" になるため当然弾くが、
+  //     極小正値 (0.0001s 等) も static_cast<int64_t>(v * 1000.0) = 0ms タイマー化
+  //     して create_wall_timer(0ms) 相当の即時発火になり、撮影 mock として意味を
+  //     成さない。`μs と s の単位ミス` typo も同じく弾く。
+  //   - 上限 600s: demo / 試験で想定されるカメラ露光の最大値。これを超える値は
   //     大抵 typo (秒/ミリ秒の単位ミス) なので WARN して default に落とす。
   static constexpr double kCaptureDurationDefaultSec = 1.5;
+  static constexpr double kCaptureDurationMinSec = 0.001;
   static constexpr double kCaptureDurationMaxSec = 600.0;
 
   explicit CameraNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   // capture_duration_sec の入力値を安全な範囲に正規化する純関数。
-  //   - NaN / inf / 0 以下 / kCaptureDurationMaxSec 超 → kCaptureDurationDefaultSec
-  //   - それ以外はそのまま返す
+  //   - NaN / inf / kCaptureDurationMinSec 未満 / kCaptureDurationMaxSec 超
+  //     → kCaptureDurationDefaultSec
+  //   - それ以外はそのまま返す (min / max は inclusive)
   // 純関数として切り出しているのは unit test で境界条件を pin するため。
   static double sanitize_capture_duration_sec(double v);
 
@@ -51,8 +56,10 @@ private:
 #ifdef UNIT_TEST
   friend class CameraNodeTestFixture;
   FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationAcceptsPositive);
+  FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationAcceptsBoundary);
   FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsZero);
   FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsNegative);
+  FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsSubMillisecond);
   FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsNaN);
   FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsInfinity);
   FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsTooLarge);

--- a/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/camera_node.hpp
+++ b/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/camera_node.hpp
@@ -1,0 +1,70 @@
+#ifndef MAPOI_TURTLEBOT3_EXAMPLE__CAMERA_NODE_HPP_
+#define MAPOI_TURTLEBOT3_EXAMPLE__CAMERA_NODE_HPP_
+
+#ifdef UNIT_TEST
+#include <gtest/gtest.h>
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <mapoi_interfaces/msg/poi_event.hpp>
+
+namespace mapoi_turtlebot3_example
+{
+
+class CameraNode : public rclcpp::Node
+{
+public:
+  // capture_duration_sec の安全範囲。
+  //   - 下限 0 は "撮影しないで即 resume" になるため弾く。実機 capture も常に正値。
+  //   - 上限 600s は demo / 試験で想定されるカメラ露光の最大値。これを超える値は
+  //     大抵 typo (秒/ミリ秒の単位ミス) なので WARN して default に落とす。
+  static constexpr double kCaptureDurationDefaultSec = 1.5;
+  static constexpr double kCaptureDurationMaxSec = 600.0;
+
+  explicit CameraNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  // capture_duration_sec の入力値を安全な範囲に正規化する純関数。
+  //   - NaN / inf / 0 以下 / kCaptureDurationMaxSec 超 → kCaptureDurationDefaultSec
+  //   - それ以外はそのまま返す
+  // 純関数として切り出しているのは unit test で境界条件を pin するため。
+  static double sanitize_capture_duration_sec(double v);
+
+private:
+  void on_poi_event(const mapoi_interfaces::msg::PoiEvent::SharedPtr msg);
+  void do_capture(const std::string & poi_name, const std::string & description);
+  void publish_resume(const std::string & poi_name);
+
+  static bool has_tag(const std::vector<std::string> & tags, const std::string & target);
+
+  rclcpp::Subscription<mapoi_interfaces::msg::PoiEvent>::SharedPtr poi_event_sub_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr resume_pub_;
+  rclcpp::TimerBase::SharedPtr resume_timer_;
+  bool capture_in_flight_{false};
+
+#ifdef UNIT_TEST
+  friend class CameraNodeTestFixture;
+  FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationAcceptsPositive);
+  FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsZero);
+  FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsNegative);
+  FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsNaN);
+  FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsInfinity);
+  FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsTooLarge);
+  FRIEND_TEST(CameraNodeTestFixture, HasTagFindsExisting);
+  FRIEND_TEST(CameraNodeTestFixture, HasTagSkipsAbsent);
+  FRIEND_TEST(CameraNodeTestFixture, IgnoresNonPausedEvents);
+  FRIEND_TEST(CameraNodeTestFixture, IgnoresEventsWithoutCaptureTriggerTag);
+  FRIEND_TEST(CameraNodeTestFixture, CapturesAndPublishesResumeAfterDuration);
+  FRIEND_TEST(CameraNodeTestFixture, IgnoresSecondPausedWhileCaptureInFlight);
+#endif
+};
+
+}  // namespace mapoi_turtlebot3_example
+
+#endif  // MAPOI_TURTLEBOT3_EXAMPLE__CAMERA_NODE_HPP_

--- a/mapoi_turtlebot3_example/package.xml
+++ b/mapoi_turtlebot3_example/package.xml
@@ -36,6 +36,7 @@
   
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/mapoi_turtlebot3_example/src/camera_node.cpp
+++ b/mapoi_turtlebot3_example/src/camera_node.cpp
@@ -21,113 +21,125 @@
 // できるが、camera_node は「撮影 mock が完了してから resume」という order を
 // demo するのが目的なので独立して resume を publish する。両方有効でも resume が
 // 二重発火するだけで実害はない (mapoi_server は idempotent な resume を受ける)。
-#include <algorithm>
-#include <chrono>
-#include <memory>
-#include <string>
+//
+// **Trust domain**: `mapoi/events` の真正性は同一 DDS domain 上のノードを信頼する
+// 前提で運用する (#248)。同 domain 上の任意 publisher が偽 PoiEvent を流せば
+// 撮影 mock を強制起動でき、resume publish 経由で route を進められる。
+// 公開環境で運用する場合は SROS2 / domain 分離 / authentication 等で publisher
+// 側を絞ること。本 mock はあくまで信頼境界内の demo 用。
+#include "mapoi_turtlebot3_example/camera_node.hpp"
 
-#include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/string.hpp>
-#include <mapoi_interfaces/msg/poi_event.hpp>
+#include <cmath>
+#include <limits>
 
 namespace mapoi_turtlebot3_example
 {
 
-class CameraNode : public rclcpp::Node
+CameraNode::CameraNode(const rclcpp::NodeOptions & options)
+: Node("camera_node", options)
 {
-public:
-  CameraNode()
-  : Node("camera_node")
-  {
-    // 撮影 mock の所要時間 (s)。撮影完了 → resume publish までのウェイト。
-    // 実機ではカメラ露光時間 + 画像 IO の典型値に合わせて調整する想定。
-    this->declare_parameter<double>("capture_duration_sec", 1.5);
+  // 撮影 mock の所要時間 (s)。撮影完了 → resume publish までのウェイト。
+  // 実機ではカメラ露光時間 + 画像 IO の典型値に合わせて調整する想定。
+  // 不正値 (負 / 0 / NaN / 極大) は do_capture 内で sanitize されて default に落ちる。
+  this->declare_parameter<double>("capture_duration_sec", kCaptureDurationDefaultSec);
 
-    poi_event_sub_ = this->create_subscription<mapoi_interfaces::msg::PoiEvent>(
-      "mapoi/events", 10,
-      std::bind(&CameraNode::on_poi_event, this, std::placeholders::_1));
+  poi_event_sub_ = this->create_subscription<mapoi_interfaces::msg::PoiEvent>(
+    "mapoi/events", 10,
+    std::bind(&CameraNode::on_poi_event, this, std::placeholders::_1));
 
-    // mapoi_server の resume subscriber は transient_local ではないため、
-    // publisher 側 QoS も default (volatile) で十分。late-joiner 対応は不要。
-    resume_pub_ = this->create_publisher<std_msgs::msg::String>("mapoi/nav/resume", 10);
+  // mapoi_server の resume subscriber は transient_local ではないため、
+  // publisher 側 QoS も default (volatile) で十分。late-joiner 対応は不要。
+  resume_pub_ = this->create_publisher<std_msgs::msg::String>("mapoi/nav/resume", 10);
 
-    RCLCPP_INFO(this->get_logger(),
-      "camera_node started; waiting for EVENT_PAUSED on POIs tagged 'capture_trigger'.");
+  RCLCPP_INFO(this->get_logger(),
+    "camera_node started; waiting for EVENT_PAUSED on POIs tagged 'capture_trigger'.");
+}
+
+double CameraNode::sanitize_capture_duration_sec(double v)
+{
+  if (!std::isfinite(v) || v <= 0.0 || v > kCaptureDurationMaxSec) {
+    return kCaptureDurationDefaultSec;
   }
+  return v;
+}
 
-private:
-  void on_poi_event(const mapoi_interfaces::msg::PoiEvent::SharedPtr msg)
-  {
-    if (msg->event_type != mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED) {
-      return;
-    }
-    if (!has_tag(msg->poi.tags, "capture_trigger")) {
-      return;
-    }
-    if (capture_in_flight_) {
-      // 連続 EVENT_PAUSED で同 capture 進行中に重ねて発火するのを防ぐ。実機
-      // ではカメラ device の二重起動を避ける意味でも単線化したい。
-      RCLCPP_WARN(this->get_logger(),
-        "[CAMERA] capture already in flight; ignoring EVENT_PAUSED for poi='%s'",
-        msg->poi.name.c_str());
-      return;
-    }
-    do_capture(msg->poi.name, msg->poi.description);
+void CameraNode::on_poi_event(const mapoi_interfaces::msg::PoiEvent::SharedPtr msg)
+{
+  if (msg->event_type != mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED) {
+    return;
   }
-
-  static bool has_tag(const std::vector<std::string> & tags, const std::string & target)
-  {
-    return std::find(tags.begin(), tags.end(), target) != tags.end();
+  if (!has_tag(msg->poi.tags, "capture_trigger")) {
+    return;
   }
-
-  void do_capture(const std::string & poi_name, const std::string & description)
-  {
-    // mock 撮影: 実機では image_transport publish / 画像保存に差し替える。
-    RCLCPP_INFO(this->get_logger(),
-      "[CAMERA] capture: poi='%s' desc='%s'",
-      poi_name.c_str(), description.c_str());
-
-    capture_in_flight_ = true;
-    const auto duration_sec = this->get_parameter("capture_duration_sec").as_double();
-    const auto duration_ms =
-      std::chrono::milliseconds(static_cast<int64_t>(duration_sec * 1000.0));
-
-    // one-shot timer: capture_duration_sec 後に resume を publish する。spin
-    // しっぱなしの create_wall_timer に cancel() を組み合わせて one-shot 化。
-    // captured POI 名を log に残すため、timer callback で poi_name をキャプチャ。
-    // timer は node の member なので、`this` は timer 発火時に必ず生きている。
-    resume_timer_ = this->create_wall_timer(
-      duration_ms,
-      [this, poi_name]() {
-        publish_resume(poi_name);
-      });
+  if (capture_in_flight_) {
+    // 連続 EVENT_PAUSED で同 capture 進行中に重ねて発火するのを防ぐ。実機
+    // ではカメラ device の二重起動を避ける意味でも単線化したい。
+    RCLCPP_WARN(this->get_logger(),
+      "[CAMERA] capture already in flight; ignoring EVENT_PAUSED for poi='%s'",
+      msg->poi.name.c_str());
+    return;
   }
+  do_capture(msg->poi.name, msg->poi.description);
+}
 
-  void publish_resume(const std::string & poi_name)
-  {
-    if (resume_timer_) {
-      resume_timer_->cancel();
-      resume_timer_.reset();
-    }
-    std_msgs::msg::String msg;
-    // mapoi_server の resume は data 内容を「resume 要求元 identifier」として log に
-    // 残すだけで意味解釈はしない (cancel / pause も同じ regime)。camera_node 由来で
-    // あることを debug 時に追えるよう identifier を入れる。
-    msg.data = "camera_node";
-    resume_pub_->publish(msg);
-    RCLCPP_INFO(this->get_logger(),
-      "[CAMERA] capture done; resume published for poi='%s'", poi_name.c_str());
-    capture_in_flight_ = false;
+bool CameraNode::has_tag(const std::vector<std::string> & tags, const std::string & target)
+{
+  return std::find(tags.begin(), tags.end(), target) != tags.end();
+}
+
+void CameraNode::do_capture(const std::string & poi_name, const std::string & description)
+{
+  // mock 撮影: 実機では image_transport publish / 画像保存に差し替える。
+  RCLCPP_INFO(this->get_logger(),
+    "[CAMERA] capture: poi='%s' desc='%s'",
+    poi_name.c_str(), description.c_str());
+
+  capture_in_flight_ = true;
+  const auto raw_duration = this->get_parameter("capture_duration_sec").as_double();
+  const auto duration_sec = sanitize_capture_duration_sec(raw_duration);
+  if (duration_sec != raw_duration) {
+    // launch yaml / dynamic set で不正値が来た時に silent に default fallback すると
+    // demo 時に「思ったより短い / 長い」原因を追えなくなるので必ず log を残す
+    // (mapoi_webui_node.py の robot_radius と同じ defense-in-depth 方針、#248)。
+    RCLCPP_WARN(this->get_logger(),
+      "[CAMERA] capture_duration_sec=%.6f は不正値です (NaN/inf/<=0/>%.1fs)。"
+      "default %.3fs を使います。",
+      raw_duration, kCaptureDurationMaxSec, kCaptureDurationDefaultSec);
   }
+  const auto duration_ms =
+    std::chrono::milliseconds(static_cast<int64_t>(duration_sec * 1000.0));
 
-  rclcpp::Subscription<mapoi_interfaces::msg::PoiEvent>::SharedPtr poi_event_sub_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr resume_pub_;
-  rclcpp::TimerBase::SharedPtr resume_timer_;
-  bool capture_in_flight_{false};
-};
+  // one-shot timer: capture_duration_sec 後に resume を publish する。spin
+  // しっぱなしの create_wall_timer に cancel() を組み合わせて one-shot 化。
+  // captured POI 名を log に残すため、timer callback で poi_name をキャプチャ。
+  // timer は node の member なので、`this` は timer 発火時に必ず生きている。
+  resume_timer_ = this->create_wall_timer(
+    duration_ms,
+    [this, poi_name]() {
+      publish_resume(poi_name);
+    });
+}
+
+void CameraNode::publish_resume(const std::string & poi_name)
+{
+  if (resume_timer_) {
+    resume_timer_->cancel();
+    resume_timer_.reset();
+  }
+  std_msgs::msg::String msg;
+  // mapoi_server の resume は data 内容を「resume 要求元 identifier」として log に
+  // 残すだけで意味解釈はしない (cancel / pause も同じ regime)。camera_node 由来で
+  // あることを debug 時に追えるよう identifier を入れる。
+  msg.data = "camera_node";
+  resume_pub_->publish(msg);
+  RCLCPP_INFO(this->get_logger(),
+    "[CAMERA] capture done; resume published for poi='%s'", poi_name.c_str());
+  capture_in_flight_ = false;
+}
 
 }  // namespace mapoi_turtlebot3_example
 
+#ifndef UNIT_TEST
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
@@ -135,3 +147,4 @@ int main(int argc, char ** argv)
   rclcpp::shutdown();
   return 0;
 }
+#endif

--- a/mapoi_turtlebot3_example/src/camera_node.cpp
+++ b/mapoi_turtlebot3_example/src/camera_node.cpp
@@ -57,7 +57,7 @@ CameraNode::CameraNode(const rclcpp::NodeOptions & options)
 
 double CameraNode::sanitize_capture_duration_sec(double v)
 {
-  if (!std::isfinite(v) || v <= 0.0 || v > kCaptureDurationMaxSec) {
+  if (!std::isfinite(v) || v < kCaptureDurationMinSec || v > kCaptureDurationMaxSec) {
     return kCaptureDurationDefaultSec;
   }
   return v;
@@ -102,9 +102,10 @@ void CameraNode::do_capture(const std::string & poi_name, const std::string & de
     // demo 時に「思ったより短い / 長い」原因を追えなくなるので必ず log を残す
     // (mapoi_webui_node.py の robot_radius と同じ defense-in-depth 方針、#248)。
     RCLCPP_WARN(this->get_logger(),
-      "[CAMERA] capture_duration_sec=%.6f は不正値です (NaN/inf/<=0/>%.1fs)。"
+      "[CAMERA] capture_duration_sec=%.6f は不正値です (NaN/inf/<%.3fs/>%.1fs)。"
       "default %.3fs を使います。",
-      raw_duration, kCaptureDurationMaxSec, kCaptureDurationDefaultSec);
+      raw_duration, kCaptureDurationMinSec, kCaptureDurationMaxSec,
+      kCaptureDurationDefaultSec);
   }
   const auto duration_ms =
     std::chrono::milliseconds(static_cast<int64_t>(duration_sec * 1000.0));

--- a/mapoi_turtlebot3_example/test/test_camera_node.cpp
+++ b/mapoi_turtlebot3_example/test/test_camera_node.cpp
@@ -121,6 +121,18 @@ TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationAcceptsPositive)
   EXPECT_DOUBLE_EQ(CameraNode::sanitize_capture_duration_sec(60.0), 60.0);
 }
 
+TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationAcceptsBoundary)
+{
+  // min / max は inclusive。境界値が retain されることを pin する
+  // (boundary off-by-one regression 防止)。
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(CameraNode::kCaptureDurationMinSec),
+    CameraNode::kCaptureDurationMinSec);
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(CameraNode::kCaptureDurationMaxSec),
+    CameraNode::kCaptureDurationMaxSec);
+}
+
 TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationRejectsZero)
 {
   EXPECT_DOUBLE_EQ(
@@ -135,6 +147,23 @@ TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationRejectsNegative)
     CameraNode::kCaptureDurationDefaultSec);
   EXPECT_DOUBLE_EQ(
     CameraNode::sanitize_capture_duration_sec(-0.001),
+    CameraNode::kCaptureDurationDefaultSec);
+}
+
+TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationRejectsSubMillisecond)
+{
+  // 極小正値 (< 1ms) は static_cast<int64_t>(v * 1000.0) で 0ms タイマー化されて
+  // create_wall_timer(0ms) 相当の即時発火になるため、撮影 mock として意味が無い。
+  // μs と s の単位ミス typo (例: 0.0001) も同じ経路で弾く。
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(0.0001),
+    CameraNode::kCaptureDurationDefaultSec);
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(std::numeric_limits<double>::denorm_min()),
+    CameraNode::kCaptureDurationDefaultSec);
+  // 0.001 直下 (0.0009) も拒否されることを確認 (inclusive minimum の確認)
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(0.0009),
     CameraNode::kCaptureDurationDefaultSec);
 }
 

--- a/mapoi_turtlebot3_example/test/test_camera_node.cpp
+++ b/mapoi_turtlebot3_example/test/test_camera_node.cpp
@@ -1,0 +1,240 @@
+// UNIT_TEST マクロは CMakeLists.txt の target_compile_definitions で定義する
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <mapoi_interfaces/msg/poi_event.hpp>
+#include <mapoi_interfaces/msg/point_of_interest.hpp>
+
+#include "mapoi_turtlebot3_example/camera_node.hpp"
+
+using namespace std::chrono_literals;
+
+// 注: fixture / test class は camera_node.hpp の friend 宣言と
+// 一致させるため namespace mapoi_turtlebot3_example の中に置く。
+// (FRIEND_TEST マクロが生成する `friend class Fixture_X_Test` は
+// CameraNode の所属 namespace に解決されるため、global namespace に
+// fixture を置くと private アクセスを得られない。)
+namespace mapoi_turtlebot3_example
+{
+
+namespace
+{
+// 撮影 mock の duration を短くして resume timer 発火を test 時間内に観測する。
+// 50ms あれば spin_some の反復で十分 timer 発火を拾える。
+constexpr double kTestCaptureDurationSec = 0.05;
+
+mapoi_interfaces::msg::PoiEvent make_event(
+  uint8_t event_type,
+  const std::string & poi_name,
+  const std::vector<std::string> & tags)
+{
+  mapoi_interfaces::msg::PoiEvent ev;
+  ev.event_type = event_type;
+  ev.poi.name = poi_name;
+  ev.poi.description = "desc-" + poi_name;
+  ev.poi.tags = tags;
+  return ev;
+}
+}  // namespace
+
+class CameraNodeTestFixture : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+
+    rclcpp::NodeOptions opts;
+    opts.parameter_overrides({rclcpp::Parameter("capture_duration_sec", kTestCaptureDurationSec)});
+    node_ = std::make_shared<CameraNode>(opts);
+
+    // resume publish を観測する subscriber。on_poi_event は同 process 内で呼ぶので
+    // PoiEvent publisher は不要 (テストから直接 on_poi_event を叩く)。
+    helper_ = rclcpp::Node::make_shared("camera_node_test_helper");
+    resume_sub_ = helper_->create_subscription<std_msgs::msg::String>(
+      "mapoi/nav/resume", 10,
+      [this](const std_msgs::msg::String::SharedPtr msg) {
+        resume_messages_.push_back(msg->data);
+      });
+
+    exec_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    exec_->add_node(node_);
+    exec_->add_node(helper_);
+
+    // discovery 安定待ち: publisher と subscriber が同 process 内で生成された
+    // 直後に publish しても受信できないことがあるため、matched event を待つ。
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (std::chrono::steady_clock::now() < deadline &&
+           resume_sub_->get_publisher_count() == 0)
+    {
+      exec_->spin_some(10ms);
+      std::this_thread::sleep_for(10ms);
+    }
+  }
+
+  void TearDown() override
+  {
+    exec_.reset();
+    resume_sub_.reset();
+    helper_.reset();
+    node_.reset();
+    resume_messages_.clear();
+  }
+
+  // exec_->spin_some を timeout / 期待 message 数まで反復する helper。
+  // 0.05s の resume timer 発火を待つには 200ms あれば十分。
+  void spin_until(std::chrono::milliseconds timeout, size_t expected_count = 0)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      exec_->spin_some(10ms);
+      if (expected_count > 0 && resume_messages_.size() >= expected_count) {
+        return;
+      }
+      std::this_thread::sleep_for(5ms);
+    }
+  }
+
+  std::shared_ptr<CameraNode> node_;
+  rclcpp::Node::SharedPtr helper_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr resume_sub_;
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> exec_;
+  std::vector<std::string> resume_messages_;
+};
+
+// --- sanitize_capture_duration_sec ---------------------------------------
+
+TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationAcceptsPositive)
+{
+  EXPECT_DOUBLE_EQ(CameraNode::sanitize_capture_duration_sec(1.5), 1.5);
+  EXPECT_DOUBLE_EQ(CameraNode::sanitize_capture_duration_sec(0.1), 0.1);
+  EXPECT_DOUBLE_EQ(CameraNode::sanitize_capture_duration_sec(60.0), 60.0);
+}
+
+TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationRejectsZero)
+{
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(0.0),
+    CameraNode::kCaptureDurationDefaultSec);
+}
+
+TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationRejectsNegative)
+{
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(-1.0),
+    CameraNode::kCaptureDurationDefaultSec);
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(-0.001),
+    CameraNode::kCaptureDurationDefaultSec);
+}
+
+TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationRejectsNaN)
+{
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(std::nan("")),
+    CameraNode::kCaptureDurationDefaultSec);
+}
+
+TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationRejectsInfinity)
+{
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(std::numeric_limits<double>::infinity()),
+    CameraNode::kCaptureDurationDefaultSec);
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(-std::numeric_limits<double>::infinity()),
+    CameraNode::kCaptureDurationDefaultSec);
+}
+
+TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationRejectsTooLarge)
+{
+  // 600s 超は typo (ms と s の取り違え等) と看做して default fallback。
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(600.001),
+    CameraNode::kCaptureDurationDefaultSec);
+  EXPECT_DOUBLE_EQ(
+    CameraNode::sanitize_capture_duration_sec(1.0e9),
+    CameraNode::kCaptureDurationDefaultSec);
+}
+
+// --- has_tag --------------------------------------------------------------
+
+TEST_F(CameraNodeTestFixture, HasTagFindsExisting)
+{
+  EXPECT_TRUE(CameraNode::has_tag({"pause", "capture_trigger"}, "capture_trigger"));
+}
+
+TEST_F(CameraNodeTestFixture, HasTagSkipsAbsent)
+{
+  EXPECT_FALSE(CameraNode::has_tag({"pause"}, "capture_trigger"));
+  EXPECT_FALSE(CameraNode::has_tag({}, "capture_trigger"));
+}
+
+// --- on_poi_event behavior -----------------------------------------------
+
+TEST_F(CameraNodeTestFixture, IgnoresNonPausedEvents)
+{
+  auto ev = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
+    mapoi_interfaces::msg::PoiEvent::EVENT_ENTER, "poi_a", {"capture_trigger"}));
+  node_->on_poi_event(ev);
+  EXPECT_FALSE(node_->capture_in_flight_);
+  spin_until(200ms);
+  EXPECT_TRUE(resume_messages_.empty());
+}
+
+TEST_F(CameraNodeTestFixture, IgnoresEventsWithoutCaptureTriggerTag)
+{
+  auto ev = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
+    mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "poi_a", {"pause"}));
+  node_->on_poi_event(ev);
+  EXPECT_FALSE(node_->capture_in_flight_);
+  spin_until(200ms);
+  EXPECT_TRUE(resume_messages_.empty());
+}
+
+TEST_F(CameraNodeTestFixture, CapturesAndPublishesResumeAfterDuration)
+{
+  auto ev = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
+    mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "poi_a", {"pause", "capture_trigger"}));
+  node_->on_poi_event(ev);
+  EXPECT_TRUE(node_->capture_in_flight_);
+
+  // wall timer は 50ms 後に発火する想定。500ms は十分なマージン。
+  spin_until(500ms, 1);
+  ASSERT_EQ(resume_messages_.size(), 1u);
+  EXPECT_EQ(resume_messages_[0], "camera_node");
+  EXPECT_FALSE(node_->capture_in_flight_);
+}
+
+TEST_F(CameraNodeTestFixture, IgnoresSecondPausedWhileCaptureInFlight)
+{
+  // 1 回目: capture を仕掛ける (timer 未発火のまま待つ)
+  auto ev1 = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
+    mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "poi_a", {"pause", "capture_trigger"}));
+  node_->on_poi_event(ev1);
+  ASSERT_TRUE(node_->capture_in_flight_);
+
+  // 2 回目: capture_in_flight_ の間に来た EVENT_PAUSED は弾かれる。
+  // resume_timer_ が上書きされていないことも publish 回数で間接確認する。
+  auto ev2 = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
+    mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "poi_b", {"pause", "capture_trigger"}));
+  node_->on_poi_event(ev2);
+
+  // timer 発火を待つ。capture が 1 回だけなら resume publish も 1 回。
+  spin_until(500ms, 1);
+  ASSERT_EQ(resume_messages_.size(), 1u);
+  // capture 完了後にさらに spin しても 2 回目の resume は来ない。
+  spin_until(200ms);
+  EXPECT_EQ(resume_messages_.size(), 1u);
+}
+
+}  // namespace mapoi_turtlebot3_example


### PR DESCRIPTION
## Summary

#248 の **Part 1** (3 PR 分割の 1 本目)。Cursor review 残課題のうち、自動テスト基盤と
入力検証、低リスクなコメント追記をまとめて取り込む。

対応項目 (#248):
- **1. camera_node の自動テスト**: `mapoi_turtlebot3_example` に `ament_add_gtest` 基盤を新設し、
  `test_camera_node` (12 test) で挙動を pin。
  - sanitize_capture_duration_sec の境界条件 6 件 (正値 / 0 / 負 / NaN / inf / 極大)
  - has_tag の存在/不在 2 件
  - on_poi_event の挙動 4 件 (非 PAUSED 無視 / tag 無し無視 / 撮影 → resume publish / capture_in_flight_ による二重発火抑止)
- **2. capture_duration_sec の入力検証**: `do_capture` で sanitize → 不正値 (NaN / inf / 0 以下 / 600s 超)
  なら WARN ログを出して default 1.5s に fallback。`mapoi_webui_node.py` の `robot_radius`
  検証パターン (#117) を参照。
- **9. trust domain 前提のコメント**: `camera_node.cpp` のヘッダコメントに「同一 DDS domain 上の
  ノードを信頼する前提」「公開環境では SROS2 / domain 分離 / authentication で publisher 側を絞ること」
  を 1 段落追記。

`#248` を **close しない** (Part 2 / 3 で残項目を消化予定なので `refs #248`)。

## 設計メモ

- `CameraNode` クラスを `include/mapoi_turtlebot3_example/camera_node.hpp` に分離し、
  `src/camera_node.cpp` 側で impl + main()。`mapoi_server/test_nav2_bridge_unit` と同じく
  `UNIT_TEST` マクロで `main()` を外して test target に同 cpp を再 compile する形。
- test fixture は `namespace mapoi_turtlebot3_example` の中に置く。FRIEND_TEST マクロが生成する
  `friend class Fixture_X_Test;` 宣言が `CameraNode` の所属 namespace で解決されるため、global
  namespace に fixture を置くと private アクセスを得られない (実装中に踏んだ落とし穴)。
- `kCaptureDurationDefaultSec = 1.5`, `kCaptureDurationMaxSec = 600.0` を class 内 constexpr
  にして test 側からも参照できる。上限 600s は「秒/ミリ秒の単位ミス typo」を弾く実用閾値。

## 後続 (Issue #248 残項目、別 PR)

- **Part 2**: `capture_in_flight_` atomic 化 (項目 3) / `resume_timer_` cancel 防御 (項目 4) /
  `publish_resume` の POI 名 (項目 5) / shutdown 時 timer cleanup (項目 7)
- **Part 3**: launch arg 露出 (項目 6) / `has_tag` 共通化 (項目 8、audio_guide_node もリファクタ)

## Test plan

- [x] Docker `ROS_DISTRO=jazzy` で `colcon build --packages-up-to mapoi_turtlebot3_example
      --cmake-args -DBUILD_TESTING=ON` + `colcon test` 通過 (12 test PASSED)
- [x] Docker `ROS_DISTRO=humble` で同上 (12 test PASSED)
- [ ] CI green (humble / jazzy)