### PR TITLE
feat(camera_node): atomic 化 / timer cancel / POI 名付き resume / shutdown cleanup (refs #248)

### DIFF
--- a/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/camera_node.hpp
+++ b/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/camera_node.hpp
@@ -6,6 +6,7 @@
 #endif
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -34,6 +35,12 @@ public:
 
   explicit CameraNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
+  // shutdown 時に pending な resume_timer_ を明示 cancel する。
+  // 通常 destructor で shared_ptr<Timer> が破棄されれば良いが、callback が
+  // 別 thread で発火する寸前のタイミングで node 内部 state が壊れた状態を
+  // 触らせない安全側の挙動 (#248 項目 7)。
+  ~CameraNode() override;
+
   // capture_duration_sec の入力値を安全な範囲に正規化する純関数。
   //   - NaN / inf / kCaptureDurationMinSec 未満 / kCaptureDurationMaxSec 超
   //     → kCaptureDurationDefaultSec
@@ -51,7 +58,11 @@ private:
   rclcpp::Subscription<mapoi_interfaces::msg::PoiEvent>::SharedPtr poi_event_sub_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr resume_pub_;
   rclcpp::TimerBase::SharedPtr resume_timer_;
-  bool capture_in_flight_{false};
+  // MultiThreadedExecutor / Reentrant callback_group での同時 2 発火に耐える
+  // ように atomic + compare_exchange で「false → true」遷移を取れたスレッド
+  // だけが capture を実行する。SingleThreadedExecutor 前提でも race を作らない
+  // 防御 (#248 項目 3)。
+  std::atomic<bool> capture_in_flight_{false};
 
 #ifdef UNIT_TEST
   friend class CameraNodeTestFixture;
@@ -69,6 +80,8 @@ private:
   FRIEND_TEST(CameraNodeTestFixture, IgnoresEventsWithoutCaptureTriggerTag);
   FRIEND_TEST(CameraNodeTestFixture, CapturesAndPublishesResumeAfterDuration);
   FRIEND_TEST(CameraNodeTestFixture, IgnoresSecondPausedWhileCaptureInFlight);
+  FRIEND_TEST(CameraNodeTestFixture, ResumeMessageIncludesPoiName);
+  FRIEND_TEST(CameraNodeTestFixture, DestructorCancelsPendingResumeTimer);
 #endif
 };
 

--- a/mapoi_turtlebot3_example/src/camera_node.cpp
+++ b/mapoi_turtlebot3_example/src/camera_node.cpp
@@ -55,6 +55,19 @@ CameraNode::CameraNode(const rclcpp::NodeOptions & options)
     "camera_node started; waiting for EVENT_PAUSED on POIs tagged 'capture_trigger'.");
 }
 
+CameraNode::~CameraNode()
+{
+  // node 終了時に pending な timer を明示 cancel + reset (#248 項目 7)。
+  // rclcpp::shutdown 経由で SharedPtr 連鎖が落ちる流れでも通常は問題無いが、
+  // 「callback 発火直前 / 別 thread での timer 内部 state 破棄」の競合を
+  // 避けるため明示する。Reentrant callback_group + MultiThreadedExecutor
+  // 利用時の安全側挙動。
+  if (resume_timer_) {
+    resume_timer_->cancel();
+    resume_timer_.reset();
+  }
+}
+
 double CameraNode::sanitize_capture_duration_sec(double v)
 {
   if (!std::isfinite(v) || v < kCaptureDurationMinSec || v > kCaptureDurationMaxSec) {
@@ -71,9 +84,13 @@ void CameraNode::on_poi_event(const mapoi_interfaces::msg::PoiEvent::SharedPtr m
   if (!has_tag(msg->poi.tags, "capture_trigger")) {
     return;
   }
-  if (capture_in_flight_) {
-    // 連続 EVENT_PAUSED で同 capture 進行中に重ねて発火するのを防ぐ。実機
-    // ではカメラ device の二重起動を避ける意味でも単線化したい。
+  // compare_exchange で「false → true」遷移を取れたスレッドだけが capture を実行する。
+  // 旧実装の `if (capture_in_flight_) { ... } else { capture_in_flight_ = true; }` は
+  // check と set の間にギャップがあるため、MultiThreadedExecutor / Reentrant
+  // callback_group では 2 thread が両方 check を通過して二重 capture に至る race
+  // が成立した (#248 項目 3)。実機ではカメラ device の二重起動を避ける意味でも単線化したい。
+  bool expected = false;
+  if (!capture_in_flight_.compare_exchange_strong(expected, true)) {
     RCLCPP_WARN(this->get_logger(),
       "[CAMERA] capture already in flight; ignoring EVENT_PAUSED for poi='%s'",
       msg->poi.name.c_str());
@@ -89,12 +106,25 @@ bool CameraNode::has_tag(const std::vector<std::string> & tags, const std::strin
 
 void CameraNode::do_capture(const std::string & poi_name, const std::string & description)
 {
+  // capture_in_flight_ は on_poi_event 側で compare_exchange により true 化済み
+  // (do_capture 単独で flag を立てない)。on_poi_event 経由以外から do_capture
+  // を直接呼ぶ test ケース等の存在を許容するため、念のため最終 true 化を行う。
+  capture_in_flight_.store(true);
+
+  // 既存 resume_timer_ が残っていれば明示 cancel + reset する (#248 項目 4)。
+  // capture_in_flight_ flag による単線化が破れた場合 (フラグ管理バグ / 将来の
+  // リファクタで CAS が外れた等) でも、古いタイマーが生きたまま新タイマーで
+  // 上書きされて二重 resume publish に至る余地を消す防御。
+  if (resume_timer_) {
+    resume_timer_->cancel();
+    resume_timer_.reset();
+  }
+
   // mock 撮影: 実機では image_transport publish / 画像保存に差し替える。
   RCLCPP_INFO(this->get_logger(),
     "[CAMERA] capture: poi='%s' desc='%s'",
     poi_name.c_str(), description.c_str());
 
-  capture_in_flight_ = true;
   const auto raw_duration = this->get_parameter("capture_duration_sec").as_double();
   const auto duration_sec = sanitize_capture_duration_sec(raw_duration);
   if (duration_sec != raw_duration) {
@@ -129,13 +159,14 @@ void CameraNode::publish_resume(const std::string & poi_name)
   }
   std_msgs::msg::String msg;
   // mapoi_server の resume は data 内容を「resume 要求元 identifier」として log に
-  // 残すだけで意味解釈はしない (cancel / pause も同じ regime)。camera_node 由来で
-  // あることを debug 時に追えるよう identifier を入れる。
-  msg.data = "camera_node";
+  // 残すだけで意味解釈はしない (cancel / pause も同じ regime)。camera_node 由来 +
+  // どの POI の capture から発火した resume かを debug 時に topic 側で追えるよう
+  // `camera_node:<poi_name>` 形式で identifier を入れる (#248 項目 5)。
+  msg.data = "camera_node:" + poi_name;
   resume_pub_->publish(msg);
   RCLCPP_INFO(this->get_logger(),
     "[CAMERA] capture done; resume published for poi='%s'", poi_name.c_str());
-  capture_in_flight_ = false;
+  capture_in_flight_.store(false);
 }
 
 }  // namespace mapoi_turtlebot3_example

--- a/mapoi_turtlebot3_example/src/camera_node.cpp
+++ b/mapoi_turtlebot3_example/src/camera_node.cpp
@@ -62,6 +62,12 @@ CameraNode::~CameraNode()
   // 「callback 発火直前 / 別 thread での timer 内部 state 破棄」の競合を
   // 避けるため明示する。Reentrant callback_group + MultiThreadedExecutor
   // 利用時の安全側挙動。
+  // **限界**: `cancel()` は「未実行 callback の発火を止める」意図であり、
+  // 既に別 thread で callback が走り始めた直後の競合 (`publish_resume` が
+  // `this` を触る最中の destructor 進行) までは完全には排除できない。
+  // 本 mock の用途 (demo / 試験) ではこの残り race は許容する。実機での厳密
+  // な lifecycle 制御が必要な場合は executor 停止 + node 破棄の順序を呼び出し
+  // 側で保証するか、weak_from_this パターンを併用する。
   if (resume_timer_) {
     resume_timer_->cancel();
     resume_timer_.reset();
@@ -106,10 +112,11 @@ bool CameraNode::has_tag(const std::vector<std::string> & tags, const std::strin
 
 void CameraNode::do_capture(const std::string & poi_name, const std::string & description)
 {
-  // capture_in_flight_ は on_poi_event 側で compare_exchange により true 化済み
-  // (do_capture 単独で flag を立てない)。on_poi_event 経由以外から do_capture
-  // を直接呼ぶ test ケース等の存在を許容するため、念のため最終 true 化を行う。
-  capture_in_flight_.store(true);
+  // **呼び出し契約**: do_capture を呼ぶ前に capture_in_flight_ が true 化されている
+  // こと (= on_poi_event の compare_exchange で獲得済) を前提とする。
+  // do_capture 側で再度 store(true) すると CAS の「獲得できた thread だけが
+  // capture する」という排他根拠が弱まるため、do_capture では flag を触らない。
+  // do_capture を直接呼ぶ test ケースもこの契約に合わせて事前 true 化する。
 
   // 既存 resume_timer_ が残っていれば明示 cancel + reset する (#248 項目 4)。
   // capture_in_flight_ flag による単線化が破れた場合 (フラグ管理バグ / 将来の

--- a/mapoi_turtlebot3_example/test/test_camera_node.cpp
+++ b/mapoi_turtlebot3_example/test/test_camera_node.cpp
@@ -215,7 +215,7 @@ TEST_F(CameraNodeTestFixture, IgnoresNonPausedEvents)
   auto ev = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
     mapoi_interfaces::msg::PoiEvent::EVENT_ENTER, "poi_a", {"capture_trigger"}));
   node_->on_poi_event(ev);
-  EXPECT_FALSE(node_->capture_in_flight_);
+  EXPECT_FALSE(node_->capture_in_flight_.load());
   spin_until(200ms);
   EXPECT_TRUE(resume_messages_.empty());
 }
@@ -225,7 +225,7 @@ TEST_F(CameraNodeTestFixture, IgnoresEventsWithoutCaptureTriggerTag)
   auto ev = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
     mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "poi_a", {"pause"}));
   node_->on_poi_event(ev);
-  EXPECT_FALSE(node_->capture_in_flight_);
+  EXPECT_FALSE(node_->capture_in_flight_.load());
   spin_until(200ms);
   EXPECT_TRUE(resume_messages_.empty());
 }
@@ -235,13 +235,14 @@ TEST_F(CameraNodeTestFixture, CapturesAndPublishesResumeAfterDuration)
   auto ev = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
     mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "poi_a", {"pause", "capture_trigger"}));
   node_->on_poi_event(ev);
-  EXPECT_TRUE(node_->capture_in_flight_);
+  EXPECT_TRUE(node_->capture_in_flight_.load());
 
   // wall timer は 50ms 後に発火する想定。500ms は十分なマージン。
   spin_until(500ms, 1);
   ASSERT_EQ(resume_messages_.size(), 1u);
-  EXPECT_EQ(resume_messages_[0], "camera_node");
-  EXPECT_FALSE(node_->capture_in_flight_);
+  // resume identifier に POI 名を含める (#248 項目 5)
+  EXPECT_EQ(resume_messages_[0], "camera_node:poi_a");
+  EXPECT_FALSE(node_->capture_in_flight_.load());
 }
 
 TEST_F(CameraNodeTestFixture, IgnoresSecondPausedWhileCaptureInFlight)
@@ -250,10 +251,11 @@ TEST_F(CameraNodeTestFixture, IgnoresSecondPausedWhileCaptureInFlight)
   auto ev1 = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
     mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "poi_a", {"pause", "capture_trigger"}));
   node_->on_poi_event(ev1);
-  ASSERT_TRUE(node_->capture_in_flight_);
+  ASSERT_TRUE(node_->capture_in_flight_.load());
 
-  // 2 回目: capture_in_flight_ の間に来た EVENT_PAUSED は弾かれる。
-  // resume_timer_ が上書きされていないことも publish 回数で間接確認する。
+  // 2 回目: capture_in_flight_ の間に来た EVENT_PAUSED は compare_exchange で
+  // 弾かれる (#248 項目 3)。resume_timer_ が上書きされていないことも publish
+  // 回数で間接確認する。
   auto ev2 = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
     mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "poi_b", {"pause", "capture_trigger"}));
   node_->on_poi_event(ev2);
@@ -261,9 +263,50 @@ TEST_F(CameraNodeTestFixture, IgnoresSecondPausedWhileCaptureInFlight)
   // timer 発火を待つ。capture が 1 回だけなら resume publish も 1 回。
   spin_until(500ms, 1);
   ASSERT_EQ(resume_messages_.size(), 1u);
+  // 識別子は最初に capture を取った poi_a のみ。poi_b は弾かれている。
+  EXPECT_EQ(resume_messages_[0], "camera_node:poi_a");
   // capture 完了後にさらに spin しても 2 回目の resume は来ない。
   spin_until(200ms);
   EXPECT_EQ(resume_messages_.size(), 1u);
+}
+
+TEST_F(CameraNodeTestFixture, ResumeMessageIncludesPoiName)
+{
+  // poi 名違いの 2 連続 capture を sequential に走らせて、それぞれ
+  // `camera_node:<poi_name>` 形式で識別できることを pin する (#248 項目 5)。
+  auto ev1 = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
+    mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "spot_north", {"capture_trigger"}));
+  node_->on_poi_event(ev1);
+  spin_until(500ms, 1);
+  ASSERT_EQ(resume_messages_.size(), 1u);
+  EXPECT_EQ(resume_messages_[0], "camera_node:spot_north");
+
+  auto ev2 = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
+    mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "spot_south", {"capture_trigger"}));
+  node_->on_poi_event(ev2);
+  spin_until(500ms, 2);
+  ASSERT_EQ(resume_messages_.size(), 2u);
+  EXPECT_EQ(resume_messages_[1], "camera_node:spot_south");
+}
+
+TEST_F(CameraNodeTestFixture, DestructorCancelsPendingResumeTimer)
+{
+  // do_capture で timer を仕掛けてから timer 発火前に node を destroy する。
+  // destructor で resume_timer_ が cancel + reset され、その後に
+  // timer callback が走って publish_resume されないことを pin する
+  // (#248 項目 7)。
+  auto ev = std::make_shared<mapoi_interfaces::msg::PoiEvent>(make_event(
+    mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED, "poi_a", {"capture_trigger"}));
+  node_->on_poi_event(ev);
+  ASSERT_TRUE(node_->capture_in_flight_.load());
+
+  // timer 未発火のうちに node を破棄。executor からも外す。
+  exec_->remove_node(node_);
+  node_.reset();
+
+  // destructor 後に十分待っても resume が来ないことを確認する。
+  spin_until(300ms);
+  EXPECT_TRUE(resume_messages_.empty());
 }
 
 }  // namespace mapoi_turtlebot3_example


### PR DESCRIPTION
## Summary

#248 の **Part 2** (3 PR 分割の 2 本目)。Part 1 (#254) で gtest 基盤と入力検証を入れたので、
本 PR は MultiThreadedExecutor / Reentrant callback_group での race 耐性と shutdown 時の
安全性を強化する。

対応項目 (#248):
- **3. `capture_in_flight_` の atomic 化**: `bool` → `std::atomic<bool>`。`on_poi_event` で
  `compare_exchange_strong(false, true)` を使い、check と set の atomic 遷移を取れた
  thread だけが capture を実行する。旧 `if (cap_in_flight) bail; else cap_in_flight = true;`
  は MultiThreadedExecutor で 2 thread が両方 check を通過する race があった。
- **4. `do_capture` 内で既存 `resume_timer_` を明示 cancel**: `capture_in_flight_` flag が
  破れた場合 (flag 管理バグ / 将来の CAS リファクタで再入が起きた等) でも、古い timer
  が生きたまま新 timer で上書きされて二重 resume publish に至る余地を消す防御。
- **5. `publish_resume` の `msg.data` に POI 名**: `"camera_node"` → `"camera_node:" + poi_name`。
  複数 `capture_trigger` POI を将来足した時に topic 側で「どの POI 由来の resume か」を
  debug 時に追える。
- **7. shutdown 時 timer cleanup**: `~CameraNode()` で `resume_timer_->cancel() + reset()`。
  shutdown 直前の callback 発火と publisher / node 内部 state 破棄の race を防ぐ安全側挙動。

`#248` は **close しない** (Part 3 で残項目を消化予定なので `refs #248`)。

## テスト

ローカル `Docker compose run --rm dev` で humble / jazzy 両 distro で 16 test PASSED。

既存テストの期待値更新:
- `CapturesAndPublishesResumeAfterDuration`: resume identifier を `"camera_node:poi_a"` に
- `IgnoresSecondPausedWhileCaptureInFlight`: 同じく `"camera_node:poi_a"` に

新規テスト:
- `ResumeMessageIncludesPoiName`: 2 連続 capture (poi_a / poi_b) でそれぞれ
  `camera_node:spot_north` / `camera_node:spot_south` が publish されることを pin。
- `DestructorCancelsPendingResumeTimer`: timer 未発火状態で node を destroy → 300ms 待っても
  resume publish が来ないことを pin。

> NOTE: atomic CAS の race 耐性そのものは SingleThreadedExecutor 前提の test では完全には
> 観測できない (MultiThreadedExecutor + Reentrant callback_group + 並列 publisher での
> stress test 化は scope 増になるため見送り)。`compare_exchange_strong` の使用自体は読めば
> 自明な防御であり、Part 1 で確立した既存テストでも sequential な二重発火抑止は依然
> 観測可能なため、本 PR では既存テストの維持 + 新規 2 件で十分とする。

## 後続 (Issue #248 残項目)

- **Part 3** (close #248): launch arg 露出 (項目 6) / `has_tag` 共通化 (項目 8、audio_guide_node もリファクタ)

## Test plan

- [x] Docker `ROS_DISTRO=jazzy` で colcon build + test 通過 (16 test PASSED)
- [x] Docker `ROS_DISTRO=humble` で同上 (16 test PASSED)
- [ ] CI green (humble / jazzy)