### PR TITLE
refactor(turtlebot3_example): has_tag 共通化 + capture_duration_sec launch arg 化 (Close #248)

### DIFF
--- a/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/camera_node.hpp
+++ b/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/camera_node.hpp
@@ -16,6 +16,8 @@
 #include <std_msgs/msg/string.hpp>
 #include <mapoi_interfaces/msg/poi_event.hpp>
 
+#include "mapoi_turtlebot3_example/poi_event_utils.hpp"
+
 namespace mapoi_turtlebot3_example
 {
 
@@ -53,8 +55,6 @@ private:
   void do_capture(const std::string & poi_name, const std::string & description);
   void publish_resume(const std::string & poi_name);
 
-  static bool has_tag(const std::vector<std::string> & tags, const std::string & target);
-
   rclcpp::Subscription<mapoi_interfaces::msg::PoiEvent>::SharedPtr poi_event_sub_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr resume_pub_;
   rclcpp::TimerBase::SharedPtr resume_timer_;
@@ -74,8 +74,6 @@ private:
   FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsNaN);
   FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsInfinity);
   FRIEND_TEST(CameraNodeTestFixture, SanitizeCaptureDurationRejectsTooLarge);
-  FRIEND_TEST(CameraNodeTestFixture, HasTagFindsExisting);
-  FRIEND_TEST(CameraNodeTestFixture, HasTagSkipsAbsent);
   FRIEND_TEST(CameraNodeTestFixture, IgnoresNonPausedEvents);
   FRIEND_TEST(CameraNodeTestFixture, IgnoresEventsWithoutCaptureTriggerTag);
   FRIEND_TEST(CameraNodeTestFixture, CapturesAndPublishesResumeAfterDuration);

--- a/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/poi_event_utils.hpp
+++ b/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/poi_event_utils.hpp
@@ -10,8 +10,7 @@ namespace mapoi_turtlebot3_example
 
 // PoiEvent.poi.tags に target tag が含まれるかを判定する共通ユーティリティ。
 // camera_node / audio_guide_node が同型の実装を重複保持していたのを集約した
-// (#248 項目 8)。3 つ目以降の PoiEvent 駆動 subscriber を足す時もこれを使う。
-// header-only inline: 純粋関数 1 つのためだけに lib target を切らない。
+// (#248 項目 8)。PoiEvent 駆動 subscriber 全般で再利用する。
 inline bool has_tag(const std::vector<std::string> & tags, const std::string & target)
 {
   return std::find(tags.begin(), tags.end(), target) != tags.end();

--- a/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/poi_event_utils.hpp
+++ b/mapoi_turtlebot3_example/include/mapoi_turtlebot3_example/poi_event_utils.hpp
@@ -1,0 +1,22 @@
+#ifndef MAPOI_TURTLEBOT3_EXAMPLE__POI_EVENT_UTILS_HPP_
+#define MAPOI_TURTLEBOT3_EXAMPLE__POI_EVENT_UTILS_HPP_
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace mapoi_turtlebot3_example
+{
+
+// PoiEvent.poi.tags に target tag が含まれるかを判定する共通ユーティリティ。
+// camera_node / audio_guide_node が同型の実装を重複保持していたのを集約した
+// (#248 項目 8)。3 つ目以降の PoiEvent 駆動 subscriber を足す時もこれを使う。
+// header-only inline: 純粋関数 1 つのためだけに lib target を切らない。
+inline bool has_tag(const std::vector<std::string> & tags, const std::string & target)
+{
+  return std::find(tags.begin(), tags.end(), target) != tags.end();
+}
+
+}  // namespace mapoi_turtlebot3_example
+
+#endif  // MAPOI_TURTLEBOT3_EXAMPLE__POI_EVENT_UTILS_HPP_

--- a/mapoi_turtlebot3_example/launch/mapoi_event_samples.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/mapoi_event_samples.launch.yaml
@@ -15,7 +15,7 @@ launch:
 
 # camera_node の撮影 mock 所要時間 (s)。撮影完了 → /mapoi/nav/resume publish までの
 # ウェイト。demo 時に launch arg で調整できるよう露出する (#248 項目 6)。
-# 不正値 (負/0/NaN/極大) は camera_node 側で default 1.5s に sanitize される。
+# 不正値は camera_node 側で default に sanitize される (条件は camera_node.hpp 参照)。
 - arg:
     name: capture_duration_sec
     default: "1.5"

--- a/mapoi_turtlebot3_example/launch/mapoi_event_samples.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/mapoi_event_samples.launch.yaml
@@ -5,12 +5,21 @@
 #
 # 使い方:
 #   ros2 launch mapoi_turtlebot3_example mapoi_event_samples.launch.yaml
+#   ros2 launch mapoi_turtlebot3_example mapoi_event_samples.launch.yaml capture_duration_sec:=3.0
 #
 # 本 launch は `turtlebot3_navigation.launch.yaml` (集約 demo launch) からは独立しており、
 # base navigation / Nav2 / mapoi_server / WebUI を立ち上げた別 shell でこの launch を
 # 追加で叩く想定 (#238 で分離した)。subscriber を立ち上げずに /mapoi/events だけ確認
 # したい場合は本 launch を起動せず `ros2 topic echo /mapoi/events` を使う。
 launch:
+
+# camera_node の撮影 mock 所要時間 (s)。撮影完了 → /mapoi/nav/resume publish までの
+# ウェイト。demo 時に launch arg で調整できるよう露出する (#248 項目 6)。
+# 不正値 (負/0/NaN/極大) は camera_node 側で default 1.5s に sanitize される。
+- arg:
+    name: capture_duration_sec
+    default: "1.5"
+    description: "camera_node capture mock duration in seconds (pause -> capture -> auto-resume wait)"
 
 - node:
     pkg: mapoi_turtlebot3_example
@@ -21,3 +30,9 @@ launch:
     pkg: mapoi_turtlebot3_example
     exec: camera_node
     name: camera_node
+    param:
+      # type: float を明示。CLI override `capture_duration_sec:=2` のような整数表記が
+      # int に coerce されると declare_parameter<double> と型不一致になる
+      # (mapoi_webui の robot_radius と同じ罠、#126)。launch frontend の有効型識別子は
+      # "float" のみで "double" は parse 失敗する点に注意。
+      - {name: capture_duration_sec, value: "$(var capture_duration_sec)", type: "float"}

--- a/mapoi_turtlebot3_example/src/audio_guide_node.cpp
+++ b/mapoi_turtlebot3_example/src/audio_guide_node.cpp
@@ -11,12 +11,13 @@
 //   - `EVENT_ENTER` は route 走行中 + route 登録 POI のみ発火 (v0.5.0+ の PoiEvent 仕様)。
 //   - `audio_info` tag を持つ POI で EVENT_ENTER 受信 → ガイド再生 trigger。
 //   - 同 POI で EXIT までは再 trigger しない (lifecycle 上 1 visit = 1 ENTER で十分)。
-#include <algorithm>
 #include <memory>
 #include <string>
 
 #include <rclcpp/rclcpp.hpp>
 #include <mapoi_interfaces/msg/poi_event.hpp>
+
+#include "mapoi_turtlebot3_example/poi_event_utils.hpp"
 
 namespace mapoi_turtlebot3_example
 {
@@ -44,11 +45,6 @@ private:
       return;
     }
     play_guide(msg->poi.name, msg->poi.description);
-  }
-
-  static bool has_tag(const std::vector<std::string> & tags, const std::string & target)
-  {
-    return std::find(tags.begin(), tags.end(), target) != tags.end();
   }
 
   void play_guide(const std::string & poi_name, const std::string & description)

--- a/mapoi_turtlebot3_example/src/camera_node.cpp
+++ b/mapoi_turtlebot3_example/src/camera_node.cpp
@@ -105,11 +105,6 @@ void CameraNode::on_poi_event(const mapoi_interfaces::msg::PoiEvent::SharedPtr m
   do_capture(msg->poi.name, msg->poi.description);
 }
 
-bool CameraNode::has_tag(const std::vector<std::string> & tags, const std::string & target)
-{
-  return std::find(tags.begin(), tags.end(), target) != tags.end();
-}
-
 void CameraNode::do_capture(const std::string & poi_name, const std::string & description)
 {
   // **呼び出し契約**: do_capture を呼ぶ前に capture_in_flight_ が true 化されている

--- a/mapoi_turtlebot3_example/test/test_camera_node.cpp
+++ b/mapoi_turtlebot3_example/test/test_camera_node.cpp
@@ -195,17 +195,17 @@ TEST_F(CameraNodeTestFixture, SanitizeCaptureDurationRejectsTooLarge)
     CameraNode::kCaptureDurationDefaultSec);
 }
 
-// --- has_tag --------------------------------------------------------------
+// --- has_tag (共通ユーティリティ #248 項目 8) ------------------------------
 
 TEST_F(CameraNodeTestFixture, HasTagFindsExisting)
 {
-  EXPECT_TRUE(CameraNode::has_tag({"pause", "capture_trigger"}, "capture_trigger"));
+  EXPECT_TRUE(has_tag({"pause", "capture_trigger"}, "capture_trigger"));
 }
 
 TEST_F(CameraNodeTestFixture, HasTagSkipsAbsent)
 {
-  EXPECT_FALSE(CameraNode::has_tag({"pause"}, "capture_trigger"));
-  EXPECT_FALSE(CameraNode::has_tag({}, "capture_trigger"));
+  EXPECT_FALSE(has_tag({"pause"}, "capture_trigger"));
+  EXPECT_FALSE(has_tag({}, "capture_trigger"));
 }
 
 // --- on_poi_event behavior -----------------------------------------------


### PR DESCRIPTION
## Summary

#248 の **Part 3** (3 PR 分割の最終)。Part 1 (#254) / Part 2 (#255) で残った Low 2 項目を
消化し、本 PR で **#248 を close** する。

対応項目 (#248):
- **8. `has_tag` の重複解消**: `camera_node` / `audio_guide_node` が同型に重複保持していた
  `static bool has_tag(...)` を `poi_event_utils.hpp` の inline 自由関数へ集約。3 つ目以降の
  PoiEvent 駆動 subscriber でも再利用できる。純関数 1 つのため lib target は切らず header-only。
- **6. `capture_duration_sec` の launch arg 露出**: `mapoi_event_samples.launch.yaml` に
  `capture_duration_sec` arg を追加し camera_node に param 渡し。demo 時に
  `ros2 launch ... capture_duration_sec:=3.0` で調整可能になる。

## 設計メモ

- `has_tag` は `mapoi_turtlebot3_example` namespace の inline 自由関数。両 node の
  `on_poi_event` は unqualified 呼び出しのまま ADL/namespace 解決で新関数に解決される。
- launch param は `type: "float"` を明示。`capture_duration_sec:=2` のような整数表記 CLI
  override が int に coerce されると `declare_parameter<double>` と型不一致になるため
  (mapoi_webui の robot_radius と同じ罠、#126)。launch frontend の有効型識別子は `"float"` のみ
  (`"double"` は parse 失敗)。

## テスト

ローカル `Docker compose run --rm dev` で humble / jazzy 両 distro で 16 test PASSED。

- `HasTagFindsExisting` / `HasTagSkipsAbsent` を共通自由関数 `has_tag(...)` 呼び出しに更新。
  `CameraNode::has_tag` が消えたため camera_node.hpp の HasTag FRIEND_TEST も削除 (free
  function は friend 不要)。
- 既存の sanitize / on_poi_event / resume / destructor 系テストは変更なしで通過。

### 手動検証 (launch arg flow)

jazzy container で実際に launch して param 反映を確認:

```
$ ros2 launch mapoi_turtlebot3_example mapoi_event_samples.launch.yaml capture_duration_sec:=4.2
$ ros2 param get /camera_node capture_duration_sec
Double value is: 4.2
```

`--show-args` でも arg が default 1.5 + description 付きで認識されることを確認済。

## Test plan

- [x] Docker `ROS_DISTRO=jazzy` で colcon build + test 通過 (16 test PASSED)
- [x] Docker `ROS_DISTRO=humble` で同上 (16 test PASSED)
- [x] launch arg override が camera_node の param に double として反映されることを手動確認
- [ ] CI green (humble / jazzy)