### PR TITLE
feat(nav2_bridge): mapoi 主導 waypoint 到達モードを追加 (refs #243)

### DIFF
--- a/mapoi_server/CMakeLists.txt
+++ b/mapoi_server/CMakeLists.txt
@@ -117,6 +117,11 @@ if(BUILD_TESTING)
     test/test_poi_event_route_integration.py
     TIMEOUT 180
   )
+  # mapoi 主導 waypoint 到達モード (#243) は NavigateToPose mock 前提で別ファイルに分離。
+  add_launch_test(
+    test/test_poi_event_route_mapoi_arrival.py
+    TIMEOUT 120
+  )
   add_launch_test(
     test/test_reload_clears_initialpose.py
   )

--- a/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_nav2_bridge.hpp
@@ -81,6 +81,16 @@ private:
   void on_route_received(std::string route_name,
                          rclcpp::Client<mapoi_interfaces::srv::GetRoutePois>::SharedFuture future);
 
+  // --- mapoi 主導 waypoint 到達モードの実行ヘルパ (#243) ---
+  // current_route_pois_[current_waypoint_index_] へ NavigateToPose を送る。index が
+  // 末尾を越えていれば route succeeded として終端処理する。NavigateToPose 不在なら
+  // backend_unavailable で route を放棄。generation を増分して旧 callback を stale 化する。
+  void send_current_waypoint_goal_();
+  // 現 waypoint への到達確定時の遷移 (OR トリガ a: tolerance.xy 進入 / b: Nav2 SUCCEEDED 共通)。
+  //   - pause タグ POI: auto-pause を発火し進めない (resume で次へ)。
+  //   - それ以外: active goal を cancel (進入トリガ時) → index++ → 次 waypoint 送信。
+  void on_waypoint_reached_();
+
   void get_pois_list();
 
   // Action Callbacks (FollowWaypoints — routes)
@@ -122,6 +132,20 @@ private:
   std::vector<geometry_msgs::msg::PoseStamped> current_route_waypoints_;
   uint32_t current_waypoint_index_ = 0;
   std::vector<geometry_msgs::msg::PoseStamped> paused_waypoints_;
+
+  // mapoi 主導 waypoint 到達モード (#243)。route 実行を Nav2 FollowWaypoints 任せ
+  // ("nav2", 既定) にするか、mapoi が tolerance.xy 到達判定で 1 waypoint ずつ
+  // NavigateToPose を送って進める ("mapoi") かを切り替える。constructor で resolve。
+  //   - "nav2":  従来挙動。Nav2 が xy_goal_tolerance で waypoint 進行、mapoi は radius observer。
+  //   - "mapoi": mapoi が「tolerance.xy 進入 ∨ NavigateToPose SUCCEEDED」(OR) で次 waypoint へ。
+  //              最終 goal だけは Nav2 完走 (yaw 厳密着地) を待つ。tolerance.xy < xy_goal_tolerance
+  //              が可能になる (POI を小さくできる)。
+  std::string waypoint_arrival_mode_ {"nav2"};
+  // mapoi モードで進行中の route waypoint POI 列 (順序保持、landmarks は含まない)。
+  // current_waypoint_index_ が指す POI へ NavigateToPose を送る。
+  std::vector<mapoi_interfaces::msg::PointOfInterest> current_route_pois_;
+  // mapoi モードの現 route 名 (status publish / resume の再送 target に使う)。
+  std::string current_route_name_;
 
   // active route の POI 名 set (waypoints + landmarks 両方を含む) (#143)。
   // route 受信 (on_route_received) で set、route 終端 / cancel / GOAL 切替で clear。

--- a/mapoi_server/src/mapoi_nav2_bridge.cpp
+++ b/mapoi_server/src/mapoi_nav2_bridge.cpp
@@ -121,6 +121,24 @@ MapoiNav2Bridge::MapoiNav2Bridge(const rclcpp::NodeOptions & options)
     auto_resume_timeout_sec_ = auto_resume_param;
   }
 
+  // waypoint 到達モード (#243)。"nav2" (既定) は従来の FollowWaypoints 任せ、"mapoi" は
+  // mapoi が tolerance.xy 到達判定で 1 waypoint ずつ NavigateToPose を送って進める。
+  // 起動時 1 回 read してキャッシュ (動的 reconfigure 非対応)。未知値は "nav2" にフォールバック。
+  this->declare_parameter<std::string>("waypoint_arrival_mode", "nav2");
+  const std::string arrival_mode_param =
+    this->get_parameter("waypoint_arrival_mode").as_string();
+  if (arrival_mode_param == "nav2" || arrival_mode_param == "mapoi") {
+    waypoint_arrival_mode_ = arrival_mode_param;
+  } else {
+    RCLCPP_WARN(this->get_logger(),
+      "waypoint_arrival_mode='%s' は未知の値です。'nav2' にフォールバックしました。"
+      " 有効値: 'nav2' / 'mapoi'",
+      arrival_mode_param.c_str());
+    waypoint_arrival_mode_ = "nav2";
+  }
+  RCLCPP_INFO(this->get_logger(),
+    "waypoint_arrival_mode = '%s'", waypoint_arrival_mode_.c_str());
+
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
@@ -558,6 +576,19 @@ void MapoiNav2Bridge::on_route_received(
   current_waypoint_index_ = 0;
   nav_mode_ = NavMode::ROUTE;
   is_paused_ = false;
+
+  // mapoi 主導モード (#243): waypoints を Nav2 に一括投入せず、mapoi が tolerance.xy 到達
+  // 判定で 1 waypoint ずつ NavigateToPose を送って進める。route POI 列を保持し、先頭へ送る。
+  if (waypoint_arrival_mode_ == "mapoi") {
+    current_route_pois_ = route_poi;
+    current_route_name_ = route_name;
+    RCLCPP_INFO(this->get_logger(),
+      "Route '%s' in mapoi-driven mode: %zu waypoints, advancing by tolerance.xy.",
+      route_name.c_str(), current_route_pois_.size());
+    send_current_waypoint_goal_();
+    return;
+  }
+
   // navigation attempt generation を増分し、callback の stale 判定で使う
   // (Codex review #147 round 1 + 2 high)。
   const size_t my_generation = ++nav_attempt_generation_;
@@ -600,6 +631,92 @@ void MapoiNav2Bridge::on_route_received(
     };
 
   this->action_client_->async_send_goal(goal_msg, send_goal_options);
+}
+
+void MapoiNav2Bridge::send_current_waypoint_goal_()
+{
+  // route 終端: 全 waypoint を踏破したので route succeeded で終端処理する (#243)。
+  if (current_waypoint_index_ >= current_route_pois_.size()) {
+    const std::string route_name = current_route_name_;
+    RCLCPP_INFO(this->get_logger(), "Route '%s' completed (mapoi-driven).", route_name.c_str());
+    reset_nav_state();
+    publish_nav_status("succeeded", route_name);
+    return;
+  }
+
+  // NavigateToPose 不在なら route を放棄 (FollowWaypoints 経路と同じ #198 方針)。
+  if (!this->nav_to_pose_client_->action_server_is_ready()) {
+    RCLCPP_ERROR(this->get_logger(),
+      "NavigateToPose action server not available; aborting mapoi-driven route '%s'.",
+      current_route_name_.c_str());
+    publish_nav_status("backend_unavailable", current_route_name_);
+    reset_nav_state();
+    return;
+  }
+
+  const auto & poi = current_route_pois_[current_waypoint_index_];
+  geometry_msgs::msg::PoseStamped goal_pose;
+  goal_pose.header.frame_id = "map";
+  goal_pose.header.stamp = this->now();
+  goal_pose.pose = poi.pose;
+  // resume / pause 用に現 goal pose を保持 (GOAL モードと同じ用途)。
+  paused_goal_pose_ = goal_pose;
+
+  // 各 waypoint 送信は別 action attempt。generation を増分して旧 waypoint の遅延 callback
+  // (cancel result 等) を stale 化する。target は route 名で統一 (status は route 単位)。
+  const size_t my_generation = ++nav_attempt_generation_;
+  const std::string route_name = current_route_name_;
+
+  auto goal_msg = NavigateToPose::Goal();
+  goal_msg.pose = goal_pose;
+
+  auto send_goal_options = rclcpp_action::Client<NavigateToPose>::SendGoalOptions();
+  send_goal_options.goal_response_callback =
+    [this, target = route_name, my_generation](const GoalHandleNavigateToPose::SharedPtr & h) {
+      this->ntp_goal_response_callback(target, my_generation, h);
+    };
+  send_goal_options.result_callback =
+    [this, target = route_name, my_generation](const GoalHandleNavigateToPose::WrappedResult & r) {
+      this->ntp_result_callback(target, my_generation, r);
+    };
+
+  this->nav_to_pose_client_->async_send_goal(goal_msg, send_goal_options);
+  RCLCPP_INFO(this->get_logger(),
+    "mapoi-driven route '%s': navigating to waypoint[%u] '%s' (tolerance.xy=%.2f).",
+    route_name.c_str(), current_waypoint_index_, poi.name.c_str(), poi.tolerance.xy);
+}
+
+void MapoiNav2Bridge::on_waypoint_reached_()
+{
+  if (current_waypoint_index_ >= current_route_pois_.size()) {
+    return;  // 防御: 既に終端
+  }
+  const auto & poi = current_route_pois_[current_waypoint_index_];
+
+  // pause タグ waypoint に到達したら停止して resume を待つ (進めない)。auto-pause は
+  // tolerance_check の ENTER 経路でも発火するが、Nav2 SUCCEEDED 経由 (ENTER 不発) でも
+  // 確実に止めるためここでも idempotent に発火する (mapoi_pause_cb は is_paused_ で多重防御)。
+  bool is_pause = false;
+  for (const auto & tag : poi.tags) {
+    if (tag == "pause") { is_pause = true; break; }
+  }
+  if (is_pause) {
+    if (!is_paused_) {
+      auto trigger = std::make_shared<std_msgs::msg::String>();
+      trigger->data = "poi_event:" + poi.name;
+      mapoi_pause_cb(trigger);
+    }
+    return;  // resume (mapoi_resume_cb) が次 waypoint へ進める
+  }
+
+  // 非 pause waypoint: 進行中の NavigateToPose goal を cancel (tolerance.xy 進入トリガ時。
+  // SUCCEEDED トリガ時は ntp_result_callback で既に reset 済) して次 waypoint へ。
+  if (current_ntp_goal_handle_) {
+    nav_to_pose_client_->async_cancel_goal(current_ntp_goal_handle_);
+    current_ntp_goal_handle_.reset();
+  }
+  ++current_waypoint_index_;
+  send_current_waypoint_goal_();
 }
 
 void MapoiNav2Bridge::goal_response_callback(std::string target, size_t nav_generation,
@@ -721,10 +838,21 @@ void MapoiNav2Bridge::ntp_result_callback(std::string target, size_t nav_generat
   // bound target を使う (#104 race fix)。
   switch (result.code) {
     case rclcpp_action::ResultCode::SUCCEEDED:
-      reset_nav_state();
-      publish_nav_status("succeeded", target);
-      RCLCPP_INFO(this->get_logger(), "NavigateToPose SUCCEEDED!");
-      // #220 で Nav2 SUCCEEDED hook 経由の event publish は撤去。
+      if (nav_mode_ == NavMode::ROUTE && waypoint_arrival_mode_ == "mapoi") {
+        // mapoi 主導 route (#243): Nav2 が現 waypoint に到達 (OR トリガ b)。次 waypoint へ
+        // 進む。最終 goal の場合は on_waypoint_reached_ → send_current_waypoint_goal_ が
+        // index 末尾検出で route succeeded を publish する。最終 goal だけは tolerance.xy
+        // 進入では進めず、この SUCCEEDED (yaw 厳密着地込み) を待つ設計。
+        RCLCPP_INFO(this->get_logger(),
+          "NavigateToPose SUCCEEDED at route waypoint[%u] (mapoi-driven).",
+          current_waypoint_index_);
+        on_waypoint_reached_();
+      } else {
+        reset_nav_state();
+        publish_nav_status("succeeded", target);
+        RCLCPP_INFO(this->get_logger(), "NavigateToPose SUCCEEDED!");
+        // #220 で Nav2 SUCCEEDED hook 経由の event publish は撤去。
+      }
       break;
     case rclcpp_action::ResultCode::ABORTED:
       reset_nav_state();
@@ -835,6 +963,9 @@ void MapoiNav2Bridge::reset_nav_state()
   current_route_waypoints_.clear();
   paused_waypoints_.clear();
   current_waypoint_index_ = 0;
+  // mapoi 主導モードの route 状態も clear (#243)。
+  current_route_pois_.clear();
+  current_route_name_.clear();
   // active route POI set / per-POI 状態をここで clear (#143 / #220)。
   // route 終端 / cancel / failure 等で route が終わったあと、次回 route mode 開始時に
   // 「既に inside / paused 状態」のまま開始されて ENTER / PAUSED が発火しない、
@@ -916,6 +1047,18 @@ void MapoiNav2Bridge::mapoi_pause_cb(const std_msgs::msg::String::SharedPtr msg)
     is_paused_ = true;
     publish_nav_status("paused", current_target_name_);
 
+  } else if (nav_mode_ == NavMode::ROUTE && waypoint_arrival_mode_ == "mapoi") {
+    // mapoi 主導モード (#243): 進行中の NavigateToPose waypoint goal を cancel して停止。
+    // FollowWaypoints の paused_waypoints_ slice は使わず、resume は index++ で次 waypoint を
+    // 送る。current_ntp_goal_handle_ は Nav2 SUCCEEDED 経由 pause で既に null のこともある。
+    RCLCPP_INFO(this->get_logger(),
+      "Pausing mapoi-driven route at waypoint[%u].", current_waypoint_index_);
+    if (current_ntp_goal_handle_) {
+      nav_to_pose_client_->async_cancel_goal(current_ntp_goal_handle_);
+    }
+    is_paused_ = true;
+    publish_nav_status("paused", current_target_name_);
+
   } else if (nav_mode_ == NavMode::ROUTE && current_goal_handle_) {
     uint32_t from = std::min(
       current_waypoint_index_,
@@ -982,6 +1125,21 @@ void MapoiNav2Bridge::mapoi_resume_cb(const std_msgs::msg::String::SharedPtr msg
       };
 
     nav_to_pose_client_->async_send_goal(goal_msg, send_goal_options);
+
+  } else if (nav_mode_ == NavMode::ROUTE && waypoint_arrival_mode_ == "mapoi") {
+    // mapoi 主導モード (#243): pause は「現 waypoint に到達して停止」なので、resume は
+    // 次 waypoint へ進める (index++ → send)。最終 waypoint で pause していた場合は index が
+    // 末尾を越え、send_current_waypoint_goal_ が route succeeded を publish する。
+    if (!nav_to_pose_client_->action_server_is_ready()) {
+      RCLCPP_ERROR(this->get_logger(), "NavigateToPose action server not available for resume.");
+      is_paused_ = true;
+      publish_nav_status("backend_unavailable", current_target_name_);
+      return;
+    }
+    RCLCPP_INFO(this->get_logger(),
+      "Resuming mapoi-driven route: advancing from waypoint[%u].", current_waypoint_index_);
+    ++current_waypoint_index_;
+    send_current_waypoint_goal_();
 
   } else if (nav_mode_ == NavMode::ROUTE) {
     if (paused_waypoints_.empty()) {
@@ -1140,11 +1298,26 @@ void MapoiNav2Bridge::tolerance_check_callback()
   // 重なり等で理論上ありうるが、最後に publish した POI に従う (cancel 上書き含め
   // schedule_auto_resume_ が idempotent に動く)。
   std::string paused_event_poi;
+  // mapoi 主導モード (#243): 現 target waypoint の tolerance.xy 進入で到達したか (OR トリガ a)。
+  // lock 外で on_waypoint_reached_ (cancel + 次 send) を呼ぶための flag。
+  bool mapoi_waypoint_radius_arrival = false;
 
   {
     std::lock_guard<std::mutex> lock(data_mutex_);
     if (event_pois_.empty()) {
       return;
+    }
+
+    // mapoi 主導モードの現 target waypoint 名と「末尾か」を tick 先頭で snapshot。
+    // 末尾 (= 最終 goal) は radius 進入では進めず Nav2 SUCCEEDED (yaw 厳密) を待つので除外する。
+    const bool mapoi_mode =
+      (waypoint_arrival_mode_ == "mapoi" && nav_mode_ == NavMode::ROUTE);
+    std::string mapoi_target_wp_name;
+    bool mapoi_target_is_last = false;
+    if (mapoi_mode && current_waypoint_index_ < current_route_pois_.size()) {
+      mapoi_target_wp_name = current_route_pois_[current_waypoint_index_].name;
+      mapoi_target_is_last =
+        (current_waypoint_index_ + 1 == current_route_pois_.size());
     }
 
     // EVENT_ENTER / EVENT_PAUSED / EVENT_EXIT は route 走行中 + route 登録 POI のみが
@@ -1186,6 +1359,11 @@ void MapoiNav2Bridge::tolerance_check_callback()
         // pauseタグがあれば自動pause対象
         if (is_pause_poi) {
           pause_triggered_poi = poi.name;
+        }
+        // mapoi 主導モード (#243): 現 target waypoint の tolerance.xy に入ったら到達
+        // (OR トリガ a)。最終 goal は除外 (Nav2 SUCCEEDED で yaw 厳密着地を待つ)。
+        if (mapoi_mode && !mapoi_target_is_last && poi.name == mapoi_target_wp_name) {
+          mapoi_waypoint_radius_arrival = true;
         }
       } else if (was_inside && dist > poi.tolerance.xy * hysteresis) {
         // EXIT event
@@ -1234,6 +1412,13 @@ void MapoiNav2Bridge::tolerance_check_callback()
   // mapoi_pause_cb が直前に呼ばれて is_paused_=true になっている前提)。
   if (!paused_event_poi.empty()) {
     schedule_auto_resume_(paused_event_poi);
+  }
+
+  // mapoi 主導モード (#243): 現 waypoint の tolerance.xy 到達で次 waypoint へ進む。
+  // pause トリガの後に置く: pause waypoint の場合は上で is_paused_ が立ち、
+  // on_waypoint_reached_ は pause 判定で進めず resume を待つ (= 二重に進めない)。
+  if (mapoi_waypoint_radius_arrival) {
+    on_waypoint_reached_();
   }
 }
 

--- a/mapoi_server/src/mapoi_nav2_bridge.cpp
+++ b/mapoi_server/src/mapoi_nav2_bridge.cpp
@@ -1057,7 +1057,9 @@ void MapoiNav2Bridge::mapoi_pause_cb(const std_msgs::msg::String::SharedPtr msg)
       nav_to_pose_client_->async_cancel_goal(current_ntp_goal_handle_);
     }
     is_paused_ = true;
-    publish_nav_status("paused", current_target_name_);
+    // mapoi モードの status target は route 名で統一する (waypoint goal の acceptance
+    // タイミングに依存する current_target_name_ ではなく current_route_name_ を使う)。
+    publish_nav_status("paused", current_route_name_);
 
   } else if (nav_mode_ == NavMode::ROUTE && current_goal_handle_) {
     uint32_t from = std::min(
@@ -1133,7 +1135,7 @@ void MapoiNav2Bridge::mapoi_resume_cb(const std_msgs::msg::String::SharedPtr msg
     if (!nav_to_pose_client_->action_server_is_ready()) {
       RCLCPP_ERROR(this->get_logger(), "NavigateToPose action server not available for resume.");
       is_paused_ = true;
-      publish_nav_status("backend_unavailable", current_target_name_);
+      publish_nav_status("backend_unavailable", current_route_name_);
       return;
     }
     RCLCPP_INFO(this->get_logger(),

--- a/mapoi_server/test/test_poi_event_route_mapoi_arrival.py
+++ b/mapoi_server/test/test_poi_event_route_mapoi_arrival.py
@@ -1,0 +1,403 @@
+"""mapoi 主導 waypoint 到達モード (waypoint_arrival_mode=mapoi) の integration test (#243).
+
+既存 `test_poi_event_route_integration.py` は FollowWaypoints mock 前提の "nav2" モード
+(Nav2 が waypoint 進行) を pin する。本 test は "mapoi" モード — mapoi が tolerance.xy
+到達判定で 1 waypoint ずつ NavigateToPose を送って進める経路 — を NavigateToPose mock で
+pin する。
+
+検証する shape:
+- OR トリガ a: 現 waypoint の tolerance.xy 進入で次 waypoint へ進む (mock が次 goal を受信)。
+- OR トリガ b: Nav2 (mock) が現 waypoint を SUCCEEDED にすると、robot が radius に入らずとも
+  次 waypoint へ進む (スタック防止のフォールバック)。
+- pause waypoint 到達で停止 ("paused")、次 goal を送らず resume を待ち、resume で次へ進む。
+- 最終 goal は tolerance.xy 進入では route 完了せず、Nav2 SUCCEEDED (yaw 厳密着地) を待つ。
+
+mock は `navigate_to_pose` action server。受理した goal の pose を順に記録し、test 側が
+「bridge が次 waypoint へ goal を送り直したか」を観測できるようにする。default では goal を
+cancel まで EXECUTING で保持 (= robot が tolerance.xy で到達するまで Nav2 は走り続ける mock)、
+`succeed_current_goal()` で現 goal を SUCCEEDED finalize する (トリガ b / route 終端用)。
+"""
+
+import os
+import threading
+import time
+import unittest
+
+import launch
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+
+import rclpy
+from rclpy.action import ActionServer, CancelResponse
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+from tf2_ros import TransformBroadcaster
+from geometry_msgs.msg import TransformStamped
+from geometry_msgs.msg import Twist
+from mapoi_interfaces.msg import PoiEvent
+from nav2_msgs.action import NavigateToPose
+from ament_index_python.packages import get_package_share_directory
+from std_msgs.msg import String
+
+
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    pkg_share = get_package_share_directory('mapoi_server')
+    test_config_dir = os.path.join(pkg_share, 'test')
+
+    mapoi_server_node = launch_ros.actions.Node(
+        package='mapoi_server',
+        executable='mapoi_server',
+        name='mapoi_server',
+        parameters=[{
+            'maps_path': test_config_dir,
+            'map_name': '.',
+            'config_file': 'test_mapoi_config.yaml',
+        }],
+    )
+
+    mapoi_nav2_bridge_node = launch_ros.actions.Node(
+        package='mapoi_server',
+        executable='mapoi_nav2_bridge',
+        name='mapoi_nav2_bridge',
+        parameters=[{
+            'tolerance_check_hz': 10.0,
+            'map_frame': 'map',
+            'base_frame': 'base_link',
+            'stopped_dwell_time_sec': 0.3,
+            'cmd_vel_msg_type': 'twist',
+            # 本 test の対象: mapoi 主導 waypoint 到達モード (#243)。
+            'waypoint_arrival_mode': 'mapoi',
+        }],
+    )
+
+    return launch.LaunchDescription([
+        mapoi_server_node,
+        mapoi_nav2_bridge_node,
+        launch_testing.actions.ReadyToTest(),
+    ]), {'mapoi_server': mapoi_server_node, 'mapoi_nav2_bridge': mapoi_nav2_bridge_node}
+
+
+class FakeNavigateToPoseServer:
+    """`navigate_to_pose` の最小 mock (mapoi 主導モード用)。
+
+    受理 goal の (x, y) を順に記録し、cancel まで EXECUTING で保持する
+    (= mapoi が tolerance.xy 到達で cancel するまで Nav2 が走り続ける挙動の mock)。
+    `succeed_current_goal()` を呼ぶと、実行中の goal を SUCCEEDED で finalize する
+    (OR トリガ b / 最終 goal の route 完了を起こす用途)。
+
+    FollowWaypoints mock (test_poi_event_route_integration.py) と同様、acceptance /
+    cancel / execute の並列処理に ReentrantCallbackGroup + MultiThreadedExecutor を使う。
+    """
+
+    def __init__(self):
+        self._node = rclpy.create_node('fake_navigate_to_pose_server')
+        callback_group = ReentrantCallbackGroup()
+        self._action_server = ActionServer(
+            self._node, NavigateToPose, 'navigate_to_pose',
+            execute_callback=self._execute_callback,
+            cancel_callback=lambda gh: CancelResponse.ACCEPT,
+            handle_accepted_callback=lambda gh: gh.execute(),
+            callback_group=callback_group,
+        )
+        self._executor = MultiThreadedExecutor(num_threads=4)
+        self._executor.add_node(self._node)
+        self._stop_event = threading.Event()
+        self._succeed_event = threading.Event()
+        self._lock = threading.Lock()
+        self._goals_xy = []
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+        self._thread.start()
+
+    def _spin(self):
+        while rclpy.ok() and not self._stop_event.is_set():
+            self._executor.spin_once(timeout_sec=0.05)
+
+    def _execute_callback(self, goal_handle):
+        p = goal_handle.request.pose.pose.position
+        with self._lock:
+            self._goals_xy.append((p.x, p.y))
+        while (rclpy.ok() and not self._stop_event.is_set()
+               and not goal_handle.is_cancel_requested
+               and not self._succeed_event.is_set()):
+            time.sleep(0.05)
+        if goal_handle.is_cancel_requested:
+            goal_handle.canceled()
+        elif self._succeed_event.is_set():
+            # 1 goal 分の SUCCEEDED 要求を消費する (次 goal は再び保持に戻る)。
+            self._succeed_event.clear()
+            goal_handle.succeed()
+        else:
+            goal_handle.abort()
+        return NavigateToPose.Result()
+
+    def succeed_current_goal(self):
+        self._succeed_event.set()
+
+    def goals_xy(self):
+        with self._lock:
+            return list(self._goals_xy)
+
+    def reset(self):
+        """test 間の状態リセット: 記録 goal と pending succeed 要求を消す。"""
+        self._succeed_event.clear()
+        with self._lock:
+            self._goals_xy.clear()
+
+    def shutdown(self):
+        self._stop_event.set()
+        self._thread.join(timeout=1.0)
+        try:
+            self._executor.shutdown()
+        finally:
+            try:
+                self._action_server.destroy()
+            finally:
+                self._node.destroy_node()
+
+
+class TestPoiEventRouteMapoiArrival(unittest.TestCase):
+    """mapoi 主導 waypoint 到達モード (#243) の advance / pause / route 終端を pin する。"""
+
+    NAV_STATUS_WAIT_TIMEOUT = 5.0
+    GOAL_WAIT_TIMEOUT = 5.0
+    TF_PUBLISH_INTERVAL = 0.05
+    CMD_VEL_PUBLISH_INTERVAL = 0.05
+    FAR_AWAY_XY = (100.0, 100.0)
+
+    # route_a = [poi_goal_only(1,0), poi_with_pause(0,2,pause),
+    #            poi_with_custom(3,0), poi_pause_and_custom(0,4,pause)]
+    WP0 = (1.0, 0.0)   # poi_goal_only (非 pause)
+    WP1 = (0.0, 2.0)   # poi_with_pause (pause)
+    WP2 = (3.0, 0.0)   # poi_with_custom (非 pause)
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = rclpy.create_node('test_poi_event_route_mapoi_node')
+        cls.received_nav_status = []
+
+        nav_status_qos = QoSProfile(
+            depth=10,
+            history=QoSHistoryPolicy.KEEP_LAST,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+        )
+        cls.nav_status_sub = cls.node.create_subscription(
+            String, 'mapoi/nav/status', cls._nav_status_callback, nav_status_qos)
+        cls.event_sub = cls.node.create_subscription(
+            PoiEvent, 'mapoi/events', cls._event_callback, 10)
+        cls.received_events = []
+        cls.tf_broadcaster = TransformBroadcaster(cls.node)
+        cls.cmd_vel_pub = cls.node.create_publisher(Twist, 'cmd_vel', 10)
+        cls.route_pub = cls.node.create_publisher(String, 'mapoi/nav/route', 1)
+        cls.cancel_pub = cls.node.create_publisher(String, 'mapoi/nav/cancel', 1)
+        cls.resume_pub = cls.node.create_publisher(String, 'mapoi/nav/resume', 1)
+
+        cls._robot_xy = cls.FAR_AWAY_XY
+        cls._tf_timer = cls.node.create_timer(
+            cls.TF_PUBLISH_INTERVAL, cls._tf_publish_callback)
+        cls._cmd_vel_timer = cls.node.create_timer(
+            cls.CMD_VEL_PUBLISH_INTERVAL, cls._cmd_vel_publish_callback)
+
+        cls.fake_server = FakeNavigateToPoseServer()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.fake_server.shutdown()
+        finally:
+            try:
+                cls.node.destroy_timer(cls._cmd_vel_timer)
+                cls.node.destroy_timer(cls._tf_timer)
+                cls.node.destroy_node()
+            finally:
+                rclpy.shutdown()
+
+    @classmethod
+    def _tf_publish_callback(cls):
+        x, y = cls._robot_xy
+        t = TransformStamped()
+        t.header.stamp = cls.node.get_clock().now().to_msg()
+        t.header.frame_id = 'map'
+        t.child_frame_id = 'base_link'
+        t.transform.translation.x = x
+        t.transform.translation.y = y
+        t.transform.rotation.w = 1.0
+        cls.tf_broadcaster.sendTransform(t)
+
+    @classmethod
+    def _cmd_vel_publish_callback(cls):
+        # mapoi モードの advance は TF 由来 (tolerance.xy 進入) なので cmd_vel は
+        # 「動いている」状態を保ち、pause POI の auto-pause 判定にだけ関わる。
+        cls.cmd_vel_pub.publish(Twist())  # 0 速度 (= 停止扱い、pause dwell を成立させる)
+
+    @classmethod
+    def _nav_status_callback(cls, msg):
+        cls.received_nav_status.append(msg.data)
+
+    @classmethod
+    def _event_callback(cls, msg):
+        cls.received_events.append(msg)
+
+    def setUp(self):
+        self._set_robot_pose(*self.FAR_AWAY_XY)
+        self._publish_cancel()
+        self._spin_for(0.3)
+        self.received_nav_status.clear()
+        self.received_events.clear()
+        self.fake_server.reset()
+        self.assertTrue(self._wait_for_subscriber('mapoi/nav/route'),
+                        'mapoi_nav2_bridge が mapoi/nav/route を subscribe していない')
+
+    def tearDown(self):
+        self._publish_cancel()
+        self._spin_for(0.4)
+        self._set_robot_pose(*self.FAR_AWAY_XY)
+        self.received_nav_status.clear()
+        self.received_events.clear()
+        self.fake_server.reset()
+
+    # --- helpers ---
+
+    def _set_robot_pose(self, x, y):
+        type(self)._robot_xy = (x, y)
+
+    def _spin_for(self, duration_sec):
+        end = time.monotonic() + duration_sec
+        while time.monotonic() < end:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+
+    def _wait_for_subscriber(self, topic_name, timeout_sec=5.0):
+        end = time.monotonic() + timeout_sec
+        while time.monotonic() < end:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+            if self.node.count_subscribers(topic_name) > 0:
+                return True
+        return False
+
+    def _wait_for_nav_status(self, status, timeout_sec=None):
+        if timeout_sec is None:
+            timeout_sec = self.NAV_STATUS_WAIT_TIMEOUT
+        end = time.monotonic() + timeout_sec
+        while time.monotonic() < end:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if any(s == status or s.startswith(status + ':')
+                   for s in self.received_nav_status):
+                return True
+        return False
+
+    def _wait_for_goal_count(self, n, timeout_sec=None):
+        if timeout_sec is None:
+            timeout_sec = self.GOAL_WAIT_TIMEOUT
+        end = time.monotonic() + timeout_sec
+        while time.monotonic() < end:
+            rclpy.spin_once(self.node, timeout_sec=0.05)
+            if len(self.fake_server.goals_xy()) >= n:
+                return True
+        return False
+
+    def _publish_route(self, route_name):
+        msg = String()
+        msg.data = route_name
+        self.route_pub.publish(msg)
+
+    def _publish_cancel(self):
+        msg = String()
+        msg.data = ''
+        self.cancel_pub.publish(msg)
+
+    def _publish_resume(self):
+        msg = String()
+        msg.data = ''
+        self.resume_pub.publish(msg)
+
+    def _activate_route(self, route_name):
+        """Route を投入し、最初の NavigateToPose goal が mock に届くまで待つ。
+
+        action server discovery 未完了のタイミングで route を投入すると bridge は
+        backend_unavailable で route を放棄する。初回 test の discovery race を吸収する
+        ため、goal が届くまで route 投入を数回リトライする。
+        """
+        for _ in range(5):
+            self._publish_route(route_name)
+            if self._wait_for_goal_count(1, timeout_sec=2.0):
+                return
+        self.fail(f"route '{route_name}' で最初の waypoint goal が mock に届かなかった")
+
+    def _assert_xy_close(self, actual, expected, tol=0.05):
+        self.assertAlmostEqual(actual[0], expected[0], delta=tol)
+        self.assertAlmostEqual(actual[1], expected[1], delta=tol)
+
+    # --- tests ---
+
+    def test_first_waypoint_goal_sent_on_route_start(self):
+        """route 開始で先頭 waypoint への NavigateToPose goal が送られる。"""
+        self._activate_route('route_a')
+        goals = self.fake_server.goals_xy()
+        self.assertGreaterEqual(len(goals), 1)
+        self._assert_xy_close(goals[0], self.WP0)
+
+    def test_advance_on_radius_entry(self):
+        """OR トリガ a: 現 waypoint の tolerance.xy 進入で次 waypoint へ goal を送り直す。"""
+        self._activate_route('route_a')  # goal[0] = WP0 (poi_goal_only)
+        self._set_robot_pose(*self.WP0)  # WP0 radius に進入
+        self.assertTrue(
+            self._wait_for_goal_count(2),
+            'WP0 tolerance.xy 進入後に WP1 への goal が送られるはず')
+        goals = self.fake_server.goals_xy()
+        self._assert_xy_close(goals[1], self.WP1)  # poi_with_pause
+
+    def test_advance_on_nav2_succeeded_without_radius_entry(self):
+        """OR トリガ b: robot が radius に入らずとも Nav2 SUCCEEDED で次へ進む (スタック防止)。"""
+        self._activate_route('route_a')  # goal[0] = WP0
+        # robot は FAR_AWAY のまま (WP0 radius に入らない)。mock が WP0 を SUCCEEDED に。
+        self.fake_server.succeed_current_goal()
+        self.assertTrue(
+            self._wait_for_goal_count(2),
+            'Nav2 SUCCEEDED 後に次 waypoint への goal が送られるはず')
+        goals = self.fake_server.goals_xy()
+        self._assert_xy_close(goals[1], self.WP1)
+
+    def test_pause_waypoint_stops_and_resume_advances(self):
+        """pause waypoint 到達で停止 (進めない) → resume で次 waypoint へ進む。"""
+        self._activate_route('route_a')          # goal[0] = WP0
+        self._set_robot_pose(*self.WP0)           # → WP1 へ advance
+        self.assertTrue(self._wait_for_goal_count(2), '前提: WP1 への advance')
+        self._set_robot_pose(*self.WP1)           # WP1 (pause) radius に進入
+        # pause POI 到達で "paused" status が出る。
+        self.assertTrue(
+            self._wait_for_nav_status('paused'),
+            'pause waypoint 到達で "paused" status が出るはず')
+        # pause 中は次 goal を送らない (advance しない)。
+        self._spin_for(0.6)
+        self.assertEqual(
+            len(self.fake_server.goals_xy()), 2,
+            f'pause 中は次 waypoint goal を送らないはず (実際: {self.fake_server.goals_xy()})')
+        # resume すると次 waypoint (WP2) へ進む。
+        self._publish_resume()
+        self.assertTrue(
+            self._wait_for_goal_count(3),
+            'resume 後に次 waypoint への goal が送られるはず')
+        self._assert_xy_close(self.fake_server.goals_xy()[2], self.WP2)
+
+    def test_final_goal_waits_for_nav2_succeeded(self):
+        """最終 goal は tolerance.xy 進入では route 完了せず、Nav2 SUCCEEDED を待つ (#243 yaw 厳密)。
+
+        route_landmark は waypoints=[poi_goal_only] の単一 waypoint route。先頭 = 最終 goal
+        なので、radius 進入では succeeded にならず、mock が SUCCEEDED にして初めて route 完了する。
+        """
+        self._activate_route('route_landmark')   # goal[0] = poi_goal_only (= 最終 goal)
+        self._set_robot_pose(*self.WP0)           # 最終 goal radius に進入
+        self._spin_for(0.6)
+        self.assertFalse(
+            self._wait_for_nav_status('succeeded', timeout_sec=0.5),
+            '最終 goal は radius 進入だけでは succeeded にならないはず (Nav2 完走待ち)')
+        # mock が最終 goal を SUCCEEDED にすると route 完了。
+        self.fake_server.succeed_current_goal()
+        self.assertTrue(
+            self._wait_for_nav_status('succeeded'),
+            '最終 goal の Nav2 SUCCEEDED で route が succeeded になるはず')


### PR DESCRIPTION
## Summary

#243 (POI を小さくしたい) の方針として「mapoi が waypoint 到達判定の主導権を握る」提案本体を実装。Phase 1 (機構 + テスト)。`waypoint_arrival_mode` param で挙動を切り替える:

- **`nav2` (既定)**: 従来どおり Nav2 FollowWaypoints が waypoint 進行、mapoi は radius observer。**完全に無傷** (dormant な opt-in)。
- **`mapoi`**: route を一括投入せず、mapoi が 1 waypoint ずつ NavigateToPose を送り、**到達 = OR(現 waypoint の `tolerance.xy` 進入 ∨ Nav2 SUCCEEDED)** で次へ進める。`tolerance.xy < xy_goal_tolerance` が可能になる。

### 設計上の判断

- **OR 到達 (スタック防止)**: `tolerance.xy` を Nav2 の `xy_goal_tolerance` より小さくすると、AND 判定では「Nav2 が自分の半径で停止 → mapoi の tighter 半径に入れず永遠に未到達」でデッドロックする。OR にして Nav2 SUCCEEDED を保険にすることで route が止まらない。実効到達半径は緩い方になる (真に小さくするには Phase 3 で Nav2 `xy_goal_tolerance` も下げる)。
- **最終 goal の yaw**: 最終 goal だけは `tolerance.xy` 進入で進めず Nav2 NavigateToPose 完走 (yaw 厳密着地) を待つ → route 終端の二重判定と yaw 問題を同時に解消。
- **pause waypoint**: 到達で auto-pause (進めない)、`mapoi/nav/resume` で index++ して次 waypoint へ。

### テスト (NavigateToPose mock)

新規 `test_poi_event_route_mapoi_arrival.py` で 5 shape を pin:
- 先頭 waypoint goal 送信 / radius 進入 advance (トリガ a) / Nav2 SUCCEEDED advance (トリガ b, radius 未進入) / pause 停止+resume 再開 / 最終 goal は radius だけでは succeeded にならず Nav2 SUCCEEDED を待つ。

## 既知の limitation / 残り

- mapoi tolerance.xy < Nav2 停止半径の pause POI では、robot が mapoi 半径外で止まり ENTER 不発 → `EVENT_PAUSED` が出ない場合がある (auto-pause 自体は OR で発火)。Phase 3 で Nav2 tolerance を下げて整合させる。
- **Phase 3 (別 PR)**: yaml の `tolerance.xy > xy_goal_tolerance` 制約コメント反転、Nav2 `xy_goal_tolerance` 引き下げ、demo POI 縮小、README、sim 実走確認。

## Test plan

- [x] `ROS_DISTRO=jazzy`: `colcon test --packages-select mapoi_server` → 全 81 tests, 0 failures (mapoi_arrival 5 / route_integration 7 含む)
- [x] `ROS_DISTRO=humble`: 同上 81 tests, 0 failures
- [x] nav2 モード (既定) の既存 launch_test 全 pass を確認 (機構は dormant)