### PR TITLE
feat(turtlebot3_example): demo に waypoint_arrival_mode launch arg を追加 + docs (refs #243)

### DIFF
--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -138,6 +138,7 @@ POI 名を指定した自律走行と、POI 半径イベント検知を行うノ
 | `auto_resume_timeout_sec` | `double` | `0.0` | `EVENT_PAUSED` 発火後の auto-resume timeout (秒、#231)。`0.0` で disabled (現行仕様、外部 `/mapoi/nav/resume` を無限待ち)。正値で「PAUSED から N 秒後に内部 resume を呼ぶ」demo / 自動運転シナリオ向け opt-in 動作を有効化。負値は起動時に `0.0` へ clamp。動的 reconfigure 非対応 |
 | `cmd_vel_topic` | `string` | `cmd_vel` | `EVENT_PAUSED` 判定用 `cmd_vel` の subscribe 先 topic 名。Nav2 と同じ topic を見る前提 (停止判定 source) |
 | `cmd_vel_msg_type` | `string` | `auto` | `cmd_vel` の message 型 (#249 / #251)。`twist` / `twist_stamped` / `auto` (default = `ROS_DISTRO` から自動選択)。詳細と override が必要なケースは下記サブセクション参照 |
+| `waypoint_arrival_mode` | `string` | `nav2` | route の waypoint 到達判定の主導権 (#243)。`nav2` / `mapoi`。詳細は下記「waypoint 到達モード」節参照。動的 reconfigure 非対応 (起動時に解決、未知値は `nav2` にフォールバック) |
 
 ##### `cmd_vel_msg_type` の値と override が必要な構成 (#249 / #251)
 
@@ -158,6 +159,32 @@ POI 名を指定した自律走行と、POI 半径イベント検知を行うノ
 | 最小 CI / 自作 container で `ROS_DISTRO` が unset、かつ humble を使う | `cmd_vel_msg_type: "twist"` を明示 (default fallback は `twist_stamped` のため) |
 
 未知値 (typo) は WARN を出した上で `ROS_DISTRO` ベースで安全側にフォールバックする。
+
+##### waypoint 到達モード (`waypoint_arrival_mode`、#243)
+
+route 走行中に「ある waypoint に到達したので次へ進む」判定を **どちらが主導するか** を切り替える。
+
+| 値 | 到達判定の主導 | tolerance.xy と xy_goal_tolerance の関係 |
+| --- | --- | --- |
+| `nav2` (default) | Nav2 `FollowWaypoints` が `xy_goal_tolerance` で waypoint を進行。mapoi は radius observer (`EVENT_ENTER` 等を出すだけ) | `tolerance.xy` は `xy_goal_tolerance` **より大きく** 取る必要がある (Nav2 が radius に入る前に goal 判定で止まると ENTER が出ないため) |
+| `mapoi` | mapoi が 1 waypoint ずつ `NavigateToPose` を送り、**到達 = OR(`tolerance.xy` 進入 ∨ Nav2 SUCCEEDED)** で次へ進める | `tolerance.xy < xy_goal_tolerance` が可能 (POI を小さくできる) |
+
+**`mapoi` モードの設計ポイント:**
+
+- **OR 到達 (スタック防止)**: `tolerance.xy` を `xy_goal_tolerance` より小さくすると、AND 判定では「Nav2 が自分の半径で停止 → robot が mapoi の tighter 半径に入れず未到達のまま」でデッドロックする。OR にし Nav2 SUCCEEDED を保険にすることで route が止まらない。
+- **実効到達半径を真に小さくするには Nav2 も寄せる**: OR の実効到達半径は「緩い方」になる。`tolerance.xy=0.15` でも Nav2 が `xy_goal_tolerance=0.25` で止まれば実効 0.25 のまま (ENTER も出ない)。POI を実際に小さくするには `param/<distro>/burger.yaml` の `goal_checker.xy_goal_tolerance` も `tolerance.xy` 以下まで下げる。
+- **最終 goal の yaw**: route 最終 waypoint だけは `tolerance.xy` 進入では進めず、Nav2 `NavigateToPose` の完走 (= goal_checker の yaw 判定込み) を待つ。厳密 yaw を効かせたいなら Nav2 の `yaw_goal_tolerance` も下げる。
+- **landmark は対象外**: `landmark` は waypoint ではなく ENTER (音声等) トリガ半径なので本モードの進行判定に関与せず、半径は経路に掛かる程度に広いままでよい。
+- **pause waypoint**: 到達で auto-pause し、`mapoi/nav/resume` で次 waypoint へ進む。
+
+**demo (turtlebot3_example) で試す:**
+
+```sh
+# mapoi モードで起動 (POI を小さくする実験には burger.yaml の goal_checker.xy_goal_tolerance も下げる)
+ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml waypoint_arrival_mode:=mapoi
+```
+
+demo の sample config (`turtlebot3_world/mapoi_config.yaml`) は既定の `nav2` モード前提で tolerance を調整済み。`mapoi` モードで POI を縮小する場合は yaml の tolerance と Nav2 param をセットで sim 確認しながら調整する。
 
 #### サブスクライバー
 

--- a/mapoi_server/launch/mapoi_bringup.launch.yaml
+++ b/mapoi_server/launch/mapoi_bringup.launch.yaml
@@ -102,6 +102,17 @@ launch:
       上書き必要時に override する。
 
 - arg:
+    name: waypoint_arrival_mode
+    default: "nav2"
+    description: >
+      mapoi_nav2_bridge の waypoint_arrival_mode parameter forward (#243)。
+      nav2 (default) = Nav2 FollowWaypoints が waypoint 進行を主導 (mapoi は radius observer)。
+      mapoi = mapoi が「tolerance.xy 進入 ∨ Nav2 SUCCEEDED」(OR) で 1 waypoint ずつ
+      NavigateToPose を送って進める。mapoi モードでは tolerance.xy < xy_goal_tolerance が可能で
+      POI を小さくできる。ただし実効到達半径を真に小さくするには Nav2 controller の
+      xy_goal_tolerance (param/<distro>/burger.yaml の goal_checker) も併せて下げる必要がある。
+
+- arg:
     name: with_amcl_localization_bridge
     default: "true"
     description: >
@@ -131,6 +142,7 @@ launch:
       - {name: auto_resume_timeout_sec, value: $(var auto_resume_timeout_sec)}
       - {name: cmd_vel_msg_type, value: "$(var cmd_vel_msg_type)"}
       - {name: cmd_vel_topic, value: "$(var cmd_vel_topic)"}
+      - {name: waypoint_arrival_mode, value: "$(var waypoint_arrival_mode)"}
     if: $(var with_nav2_bridge)
 
 - node:

--- a/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
@@ -27,6 +27,15 @@ launch:
     default: "true"
     description: "Launch シミュレータ GUI (Humble: gzclient / Jazzy: gz sim -g). false で headless. server は常時起動"
 
+- arg:
+    name: waypoint_arrival_mode
+    default: "nav2"
+    description: >
+      waypoint 到達モード (#243)。nav2 (default) = 従来の Nav2 FollowWaypoints 主導。
+      mapoi = mapoi が tolerance.xy 到達判定で 1 waypoint ずつ進める (POI を小さくできる)。
+      mapoi モードで小さい POI を活かすには param/<distro>/burger.yaml の goal_checker
+      xy_goal_tolerance (既定 0.25) も下げること。詳細は mapoi_server/README.md 参照。
+
 
 # Gazebo launch (distro 別の headless-aware wrapper を使い分け)
 # - Humble: Gazebo Classic 用 (gazebo_ros gzserver/gzclient を条件化)
@@ -78,6 +87,7 @@ launch:
       - {name: simulator, value: "$(eval \"'gazebo' if '$(env ROS_DISTRO)' == 'humble' else 'gz'\")"}
       - {name: robot_entity_name, value: "$(env TURTLEBOT3_MODEL)"}
       - {name: robot_sdf_path, value: "$(find-pkg-share turtlebot3_gazebo)/models/turtlebot3_$(env TURTLEBOT3_MODEL)/model.sdf"}
+      - {name: waypoint_arrival_mode, value: "$(var waypoint_arrival_mode)"}
 
 # Mapoi Web UI
 # robot_radius は Nav2 param (param/$(ROS_DISTRO)/burger.yaml の `robot_radius: 0.1`)

--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -6,12 +6,21 @@
 # (#230 follow-up #238)。subscriber を立ち上げない場合は ros2 topic echo /mapoi/events で
 # 動作確認、立ち上げる場合は audio 発話 / camera 撮影 mock が走る。
 #
-# POI 座標調整時の制約:
-# - tolerance.xy は Nav2 controller の xy_goal_tolerance (0.25) より大きく取る。Nav2 が POI
-#   tolerance.xy 内に入る前にゴール判定で停止し radius event が発火しないため、最小 0.30
-#   (5cm 余裕)。
+# POI 座標調整時の制約 (本 demo は既定の waypoint_arrival_mode=nav2 を前提に調整済):
+# - waypoint の tolerance.xy は Nav2 controller の xy_goal_tolerance (0.25) より大きく取る。
+#   Nav2 が POI tolerance.xy 内に入る前にゴール判定で停止し radius event が発火しないため、
+#   最小 0.30 (5cm 余裕)。
+#   ※ waypoint_arrival_mode=mapoi (#243) では mapoi が tolerance.xy 到達で進行を主導するため
+#     この制約は逆転し、tolerance.xy < xy_goal_tolerance が可能 (POI を小さくできる)。その際は
+#     Nav2 を tight 半径まで寄せるため param/<distro>/burger.yaml の goal_checker
+#     xy_goal_tolerance も併せて下げる (詳細は mapoi_server/README.md「waypoint 到達モード」節)。
+# - landmark の tolerance.xy は waypoint ではなく「ENTER (音声等) トリガ半径」なので、上記の
+#   waypoint 縮小とは独立。経路 (waypoint 直線) が radius に掛かる程度の広さを保てばよく、mapoi
+#   モードでも狭める必要はない (audio_landmark は広いまま)。
 # - tolerance.yaw は >= 0.001 (rad) を指定 (msg spec #138 で 0 / 負値は禁止)。yaw を問わない
-#   通過点は π (≒ 180°) 近辺。yaw 厳密化したい POI は小さい値 (例: goal は 0.10)。
+#   通過点は π (≒ 180°) 近辺。yaw 厳密化したい POI は小さい値 (例: goal は 0.10)。なお mapoi
+#   モードでも最終 goal の yaw は Nav2 完走で決まるため、厳密 yaw を効かせるには Nav2 の
+#   yaw_goal_tolerance も下げる必要がある。
 # - tag 排他: landmark × pause / landmark × waypoint は #143 validation で reject される。
 custom_tags:
 - {name: audio_info, description: Audio guide trigger (POI 進入で音声再生 mock)}


### PR DESCRIPTION
## Summary

#243 Phase 1 (PR #259, merged) で入れた mapoi 主導 waypoint 到達モードを、demo で sim 評価できるよう **launch arg として公開**する Phase 3a。**既定 `nav2`**（従来挙動）なので demo の既定動作は変わらない。

- **`mapoi_bringup.launch.yaml`**: `waypoint_arrival_mode` arg (既定 `nav2`) を `mapoi_nav2_bridge` の param に forward (`cmd_vel_msg_type` 等と同じパターン)。
- **`turtlebot3_navigation.launch.yaml`**: 同 arg を bringup include に通す。`ros2 launch ... waypoint_arrival_mode:=mapoi` で切替可能に。
- **`mapoi_server/README.md`**: 「waypoint 到達モード」節を追加。OR 到達 (スタック防止)、実効半径を小さくするには Nav2 `xy_goal_tolerance` も下げる、最終 goal の yaw は Nav2 完走依存、**landmark は対象外で半径は広いまま**、demo での試し方を明記。
- **`turtlebot3_world/mapoi_config.yaml`**: header コメントを両モード前提に更新 (mapoi モードでは `tolerance.xy < xy_goal_tolerance` 可、landmark は独立)。

## スコープと残り

- **shipped tolerance は未変更** (demo 既定は `nav2` のまま)。整合テスト (`test_demo_config_integrity`) も不変で pass。
- **Phase 3b (ユーザ確認)**: 実際に demo を mapoi モードへ flip し、waypoint tolerance 縮小 + Nav2 `xy_goal_tolerance`/`yaw_goal_tolerance` 引き下げを **sim 実走で観察しながら**調整 → ここがユーザのハンズオン確認・最終 tuning。確定後に #243 を Close。

## Test plan

- [x] `ROS_DISTRO=jazzy` / `humble` 両方で `ros2 launch ... turtlebot3_navigation.launch.yaml --show-args` に `waypoint_arrival_mode` (default `nav2`) が出ることを確認
- [x] `mapoi_bringup.launch.yaml --show-args` でも arg 公開を確認
- [x] `test_demo_config_integrity` 7 tests pass (shipped config 不変)
- [ ] **(Phase 3b / ユーザ)** sim で `waypoint_arrival_mode:=mapoi` を実走し advance / pause / 最終 goal yaw を観察