### PR TITLE
feat(turtlebot3_example): demo を mapoi 到達モード既定に + POI tolerance 調整 (Close #243)

### DIFF
--- a/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
+++ b/mapoi_turtlebot3_example/launch/turtlebot3_navigation.launch.yaml
@@ -29,12 +29,15 @@ launch:
 
 - arg:
     name: waypoint_arrival_mode
-    default: "nav2"
+    default: "mapoi"
     description: >
-      waypoint 到達モード (#243)。nav2 (default) = 従来の Nav2 FollowWaypoints 主導。
-      mapoi = mapoi が tolerance.xy 到達判定で 1 waypoint ずつ進める (POI を小さくできる)。
-      mapoi モードで小さい POI を活かすには param/<distro>/burger.yaml の goal_checker
-      xy_goal_tolerance (既定 0.25) も下げること。詳細は mapoi_server/README.md 参照。
+      waypoint 到達モード (#243)。mapoi (本 demo の既定) = mapoi が tolerance.xy 到達判定で
+      1 waypoint ずつ進める。nav2 = 従来の Nav2 FollowWaypoints 主導。本 demo の config は
+      mapoi モード前提で調整済 (waypoint tolerance.xy 一律 0.3)。さらに POI を小さくするには
+      param/<distro>/burger.yaml の goal_checker xy_goal_tolerance も下げる。詳細は
+      mapoi_server/README.md「waypoint 到達モード」節。
+      ※ mapoi_nav2_bridge param 自体の既定は nav2 のまま (downstream 影響回避)。本 arg は
+        demo launch だけ mapoi を既定にする。
 
 
 # Gazebo launch (distro 別の headless-aware wrapper を使い分け)

--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -1,27 +1,21 @@
-# シナリオ: 機能カタログ demo (#230)。各機能 (waypoint / landmark / pause) を 1 route ずつ
-# 確認できる tutorial 系と、全機能を 1 route で踏む tour_full の集合。自前 robot への
-# 流用を意識し、地名・部屋名ではなく機能を示す抽象名で命名する。
+# シナリオ: 機能カタログ demo (#230)。waypoint / landmark / pause を 1 route ずつ確認できる
+# tutorial 系 + 全機能を踏む tour_full。自前 robot 流用を意識し機能ベースの抽象名で命名。
 #
-# demo subscriber (audio_guide_node / camera_node) の起動は本 launch から分離する方針
-# (#230 follow-up #238)。subscriber を立ち上げない場合は ros2 topic echo /mapoi/events で
-# 動作確認、立ち上げる場合は audio 発話 / camera 撮影 mock が走る。
+# demo subscriber (audio_guide_node / camera_node) は本 launch から分離 (#238)。立ち上げない
+# 場合は ros2 topic echo /mapoi/events で確認、立ち上げると audio 発話 / camera 撮影 mock が走る。
 #
-# POI 座標調整時の制約 (本 demo は既定の waypoint_arrival_mode=nav2 を前提に調整済):
-# - waypoint の tolerance.xy は Nav2 controller の xy_goal_tolerance (0.25) より大きく取る。
-#   Nav2 が POI tolerance.xy 内に入る前にゴール判定で停止し radius event が発火しないため、
-#   最小 0.30 (5cm 余裕)。
-#   ※ waypoint_arrival_mode=mapoi (#243) では mapoi が tolerance.xy 到達で進行を主導するため
-#     この制約は逆転し、tolerance.xy < xy_goal_tolerance が可能 (POI を小さくできる)。その際は
-#     Nav2 を tight 半径まで寄せるため param/<distro>/burger.yaml の goal_checker
-#     xy_goal_tolerance も併せて下げる (詳細は mapoi_server/README.md「waypoint 到達モード」節)。
-# - landmark の tolerance.xy は waypoint ではなく「ENTER (音声等) トリガ半径」なので、上記の
-#   waypoint 縮小とは独立。経路 (waypoint 直線) が radius に掛かる程度の広さを保てばよく、mapoi
-#   モードでも狭める必要はない (audio_landmark は広いまま)。
-# - tolerance.yaw は >= 0.001 (rad) を指定 (msg spec #138 で 0 / 負値は禁止)。yaw を問わない
-#   通過点は π (≒ 180°) 近辺。yaw 厳密化したい POI は小さい値 (例: goal は 0.10)。なお mapoi
-#   モードでも最終 goal の yaw は Nav2 完走で決まるため、厳密 yaw を効かせるには Nav2 の
-#   yaw_goal_tolerance も下げる必要がある。
-# - tag 排他: landmark × pause / landmark × waypoint は #143 validation で reject される。
+# 本 demo は waypoint_arrival_mode=mapoi 既定 (#243)。POI 座標調整時の制約:
+# - waypoint tolerance.xy は Nav2 controller の xy_goal_tolerance (0.25) 以上に取る。mapoi
+#   モードの到達は OR(tolerance.xy 進入 ∨ Nav2 SUCCEEDED) なので進行自体は保証されるが、
+#   ENTER / pause の EVENT_PAUSED は robot が tolerance.xy 内に入って初めて発火するため、Nav2 が
+#   止まる ~0.25 より小さいと取りこぼす。本 demo は安全側に waypoint 一律 0.3。さらに小さく
+#   するには burger.yaml の goal_checker.xy_goal_tolerance も下げて robot を tight 半径まで寄せる
+#   (詳細は mapoi_server/README.md「waypoint 到達モード」節)。
+# - landmark tolerance.xy は ENTER トリガ半径で waypoint 進行とは独立。経路 (waypoint 直線) が
+#   radius に掛かる程度の広さを保てばよく、audio_landmark は 0.35 のまま (狭めない)。
+# - tolerance.yaw >= 0.001 (msg spec #138)。yaw を問わない通過点は π 近辺、厳密化する POI は
+#   小値 (goal は 0.1)。mapoi モードでも最終 goal の yaw は Nav2 完走で決まる。
+# - tag 排他: landmark × pause / landmark × waypoint は #143 validation で reject。
 custom_tags:
 - {name: audio_info, description: Audio guide trigger (POI 進入で音声再生 mock)}
 - {name: capture_trigger, description: Camera capture trigger (pause POI で停止中に撮影 mock)}
@@ -44,27 +38,27 @@ gazebo:
 poi:
 - description: 全 route 起点 (POI list 先頭 = default initial pose, Gazebo spawn 位置)
   name: start
-  pose: {x: -2, y: -0.5, yaw: 0}
+  pose: {x: -2.0, y: -0.5, yaw: 0.0}
   tags: [waypoint]
-  tolerance: {xy: 0.5, yaw: 0.785}
+  tolerance: {xy: 0.3, yaw: 2.0944}
 - description: tutorial_01 / 02 / tour_full の南側中継点 (pure waypoint)
   name: basic_waypoint
   pose: {x: -0.6, y: -0.89, yaw: 0.06}
   tags: [waypoint]
-  tolerance: {xy: 0.35, yaw: 0.7850002283279937}
+  tolerance: {xy: 0.3, yaw: 0.785}
 - description: tutorial_03 / tour_full の pause POI (停止中に camera 撮影 mock を発火)
   name: pause_waypoint
   pose: {x: 0.01, y: -0.27, yaw: -0.08}
   tags: [waypoint, pause, capture_trigger]
-  tolerance: {xy: 0.3, yaw: 3.1399991679827224}
+  tolerance: {xy: 0.3, yaw: 1.5708}
 - description: tutorial_01 / 02 / tour_full の終点 (北、yaw 厳密)
   name: goal
   pose: {x: 0.66, y: -0.65, yaw: 0.01}
   tags: [waypoint]
-  tolerance: {xy: 0.4, yaw: 0.10000038482226709}
+  tolerance: {xy: 0.3, yaw: 0.1}
 - description: tutorial_02 / tour_full の route.landmarks 列挙対象 (audio_info で audio_guide_node
     発火対象)
   name: audio_landmark
   pose: {x: -1.09, y: -0.5, yaw: -0.03}
   tags: [landmark, audio_info]
-  tolerance: {xy: 0.35, yaw: 0.7850002283279937}
+  tolerance: {xy: 0.35, yaw: 0.785}

--- a/mapoi_turtlebot3_example/test/test_demo_config_integrity.py
+++ b/mapoi_turtlebot3_example/test/test_demo_config_integrity.py
@@ -28,9 +28,10 @@ CONFIG_PATH = (
     Path(__file__).resolve().parents[1] / "maps" / "turtlebot3_world" / "mapoi_config.yaml"
 )
 
-# Nav2 controller の xy_goal_tolerance 既定値。POI tolerance.xy がこれ以下だと Nav2 が
-# POI 半径内に入る前に goal 到達判定で停止し、radius event (ENTER 等) が発火しない。
-# config 冒頭コメントの「tolerance.xy は最小 0.30 (5cm 余裕)」に対応する下限。
+# waypoint tolerance.xy の下限。本 demo は waypoint_arrival_mode=mapoi 既定 (#243) だが、
+# Nav2 の xy_goal_tolerance (0.25) より小さいと robot が radius 内に入る前に Nav2 が停止し、
+# ENTER / pause の EVENT_PAUSED を取りこぼす。安全側に Nav2 tol + 余裕の 0.30 を下限とする
+# (mapoi モードでも進行自体は OR で保証されるが、event 発火には radius 進入が必要)。
 XY_TOLERANCE_FLOOR = 0.30
 
 # msg spec (#138): tolerance.yaw は 0 / 負値禁止、最小 0.001 rad。
@@ -82,7 +83,11 @@ def test_config_file_exists():
 
 
 def test_all_poi_xy_tolerance_above_floor():
-    """全 POI の tolerance.xy が Nav2 xy_goal_tolerance + 余裕の下限 (0.30) 以上 (#230)。"""
+    """全 POI の tolerance.xy が下限 (0.30) 以上 (#230 / #243)。
+
+    mapoi モード既定でも ENTER / EVENT_PAUSED 発火には robot が radius 内に入る必要があり、
+    Nav2 が停止する ~0.25 より小さいと取りこぼすため、Nav2 tol + 余裕の 0.30 を下限に保つ。
+    """
     cfg = _load_config()
     for poi in cfg["poi"]:
         xy = poi["tolerance"]["xy"]


### PR DESCRIPTION
## Summary

#243 (POI を小さくしたい) の仕上げ (Phase 3b)。**sim 実走確認を経て** demo を mapoi 主導 waypoint 到達モード既定に切り替え、POI tolerance を調整する。Phase 1 (#259 機構) / Phase 3a (#260 launch arg + docs) に続く最終段。

- **`turtlebot3_navigation.launch.yaml`**: `waypoint_arrival_mode` arg 既定を `nav2`→`mapoi`。**`mapoi_nav2_bridge` の param 自体の既定は `nav2` のまま** (downstream への影響回避) で、demo launch だけ `mapoi` を既定にする。
- **`turtlebot3_world/mapoi_config.yaml`**: waypoint `tolerance.xy` を一律 **0.3** に調整 (start 0.5 / basic_waypoint 0.35 / goal 0.4 → 0.3、pause_waypoint は 0.3 維持)。`audio_landmark` は ENTER トリガ半径なので **0.35 のまま**。header コメントを mapoi モード前提に更新。
- **`test_demo_config_integrity`**: `tolerance.xy` 下限 0.30 の根拠を mapoi モード前提に更新 (値は据え置き、全 POI が満たす)。

## 設計判断 (option B: Nav2 tol 据え置き)

`tolerance.xy` を Nav2 `xy_goal_tolerance` (0.25) **以上** (0.3) に保つことで、mapoi モードでも robot が radius 内に入って **ENTER / `EVENT_PAUSED` が確実に発火**する (= pause/camera demo が壊れない)。sim で pause→撮影→resume の動作を確認済み。

`tolerance.xy < xy_goal_tolerance` まで攻める (真に小さい POI) には Nav2 `goal_checker.xy_goal_tolerance` も下げる必要があるが、event 取りこぼしリスクがあるため demo では安全側に倒した (手順は README「waypoint 到達モード」節)。

## 残り (別 issue、本 PR の scope 外)

- #261: mapoi モードで単発 Go (`goal_pose_poi`) も POI 個別 tolerance を使う
- #262: WebUI Robot Map のプルダウン選択を map 上の選択状態に同期
- `backend_status` の mode 対応 (mapoi 単独構成で `follow_waypoints` 無しでも ready)

## Test plan

- [x] `ROS_DISTRO=jazzy` / `humble` 両方で `test_demo_config_integrity` 7 tests pass (新 tolerance)
- [x] 両 distro で `turtlebot3_navigation.launch.yaml --show-args` の `waypoint_arrival_mode` 既定が `mapoi`
- [x] **(Phase 3b / ユーザ)** sim 実走で mapoi モードの advance / pause→撮影→resume / 最終 goal 着地・完走を確認済み