### PR TITLE
feat(webui): tolerance.yaw を度数で綺麗に表示し yaw 不問の扇形を消さない (refs #267)

### DIFF
--- a/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
+++ b/mapoi_turtlebot3_example/maps/turtlebot3_world/mapoi_config.yaml
@@ -15,10 +15,10 @@
 #   radius に掛かる程度の広さを保てばよく、audio_landmark は 0.35 のまま (狭めない)。
 # - tolerance.yaw >= 0.001 (msg spec #138)。統一仕様 (#265) で yaw は中間 waypoint / 最終 goal /
 #   単発 Go すべての到達判定に効く。到達判定の角度差は [0, π] (最大 π ≈ 180°)。yaw を問わない
-#   純通過点は π 直下の 3.14 にする (fly-through、basic_waypoint)。3.14 だと真後ろ ±0.09° のごく
-#   狭い帯だけ radius 未到達になるが Nav2 SUCCEEDED が保険になるので実害なし。π 以上 (3.15 等) に
-#   すると RViz/WebUI の扇形が全周になり描画されなくなるため 3.14 に留める。向きが要る POI は
-#   小値 (goal は 0.1、pause は撮影向きを緩く問う 1.5708)。
+#   純通過点は π (= 180°、yaml では 3.1416) にする (fly-through、basic_waypoint)。WebUI は
+#   yaw 不問を塗りつぶし円 (disc) で描画 (#267)。向きが要る POI は小値 (goal は 0.1、pause は
+#   撮影向きを緩く問う 1.5708 = 90°)。値は区切りの良い度数の rad 等価に揃え、WebUI の度数表示
+#   (#267) で 180/90/120/45° と綺麗に round-trip する (start=2.0944=120°, audio_landmark=0.7854=45°)。
 # - tag 排他: landmark × pause / landmark × waypoint は #143 validation で reject。
 custom_tags:
 - {name: audio_info, description: Audio guide trigger (POI 進入で音声再生 mock)}
@@ -49,7 +49,7 @@ poi:
   name: basic_waypoint
   pose: {x: -0.6, y: -0.89, yaw: 0.06}
   tags: [waypoint]
-  tolerance: {xy: 0.3, yaw: 3.14}
+  tolerance: {xy: 0.3, yaw: 3.1416}
 - description: tutorial_03 / tour_full の pause POI (停止中に camera 撮影 mock を発火)
   name: pause_waypoint
   pose: {x: 0.01, y: -0.27, yaw: -0.08}
@@ -65,4 +65,4 @@ poi:
   name: audio_landmark
   pose: {x: -1.09, y: -0.5, yaw: -0.03}
   tags: [landmark, audio_info]
-  tolerance: {xy: 0.35, yaw: 0.785}
+  tolerance: {xy: 0.35, yaw: 0.7854}

--- a/mapoi_webui/tests/web/poi-filter.test.js
+++ b/mapoi_webui/tests/web/poi-filter.test.js
@@ -22,6 +22,7 @@ const {
   parseTolerance,
   degToRad,
   radToDeg,
+  formatToleranceYawDeg,
   roundTo,
   TOLERANCE_MIN,
   POSE_XY_DIGITS,
@@ -155,6 +156,41 @@ describe('degToRad / radToDeg', () => {
     [0.1, 1, 45, 90, 180, 359].forEach((deg) => {
       expect(radToDeg(degToRad(deg))).toBeCloseTo(deg, 6);
     });
+  });
+});
+
+describe('formatToleranceYawDeg (#267)', () => {
+  // editor は rad を保存し度数で表示する。保存値は roundTo(degToRad(deg), 4) なので、
+  // 区切りの良い度数は綺麗に表示され編集なし save でも churn しないことを pin する。
+  it('displays round degrees cleanly (integer, no trailing zeros)', () => {
+    [30, 45, 90, 120, 180].forEach((deg) => {
+      const storedRad = roundTo(degToRad(deg), TOLERANCE_YAW_DIGITS);
+      expect(formatToleranceYawDeg(storedRad)).toBe(deg);
+    });
+  });
+
+  it('treats yaw 不問 (π / 3.1416) as 180', () => {
+    expect(formatToleranceYawDeg(3.1416)).toBe(180);
+    expect(formatToleranceYawDeg(Math.PI)).toBe(180);
+  });
+
+  it('keeps two-decimal precision for non-round values', () => {
+    // goal の strict yaw 0.1 rad ≈ 5.73°
+    expect(formatToleranceYawDeg(0.1)).toBe(5.73);
+  });
+
+  it('round-trips round degrees without drift (deg → rad(4桁) → deg)', () => {
+    [30, 45, 90, 120, 180].forEach((deg) => {
+      const storedRad = roundTo(degToRad(deg), TOLERANCE_YAW_DIGITS);
+      const shownDeg = formatToleranceYawDeg(storedRad);
+      const resavedRad = roundTo(degToRad(shownDeg), TOLERANCE_YAW_DIGITS);
+      expect(resavedRad).toBe(storedRad);
+    });
+  });
+
+  it('returns NaN for non-numeric input', () => {
+    expect(Number.isNaN(formatToleranceYawDeg('abc'))).toBe(true);
+    expect(Number.isNaN(formatToleranceYawDeg(NaN))).toBe(true);
   });
 });
 

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -435,7 +435,10 @@ class MapViewer {
     const r = poi.tolerance.xy;
     const yawCenter = poi.pose.yaw || 0;
     const yawTol = (typeof poi.tolerance.yaw === 'number') ? poi.tolerance.yaw : 0;
+    // 到達判定の角度差は [0, π] なので yawTol >= π は「yaw 不問 (全方位)」。0 < yawTol < π は
+    // 扇形 (wedge)、>= π は塗りつぶし円 (disc) で表す (#267)。
     const hasYawConstraint = yawTol > 0 && yawTol < Math.PI;
+    const isYawUnconstrained = yawTol >= Math.PI;
 
     const color = this.getPoiColor(poi);
 
@@ -459,8 +462,8 @@ class MapViewer {
     circle.bringToBack();
     this.sectorLayers.push(circle);
 
-    // 扇形 (yaw 制約): 0 < yaw < π の時のみ重ね描き (#179)。
-    // 完全円 (yaw 不問) なら扇形 = 円で情報冗長になるため省略。
+    // 扇形 (yaw 制約): 0 < yaw < π の時に重ね描き (#179)。
+    const fillOpacity = isWaypoint ? 0.25 : 0.10;  // waypoint=塗り、landmark=薄塗り (#179 ユーザー確認 2)
     if (hasYawConstraint) {
       const totalAngle = 2 * yawTol;
       const N = Math.max(8, Math.ceil(totalAngle / 0.1));
@@ -478,11 +481,25 @@ class MapViewer {
         weight: 1,
         opacity: 0.7,
         fillColor: color,
-        fillOpacity: isWaypoint ? 0.25 : 0.10,  // waypoint=塗り、landmark=薄塗り (#179 ユーザー確認 2)
+        fillOpacity,
         interactive: false,
       }).addTo(this.map);
       sector.bringToBack();
       this.sectorLayers.push(sector);
+    } else if (isYawUnconstrained) {
+      // yaw 不問 (yawTol >= π = 全方位): 扇形を省略すると xy 円の outline だけになり「描画され
+      // ていない?」と誤認されるため、xy 円を塗りつぶした disc で「全方位 OK」を明示する (#267)。
+      // 扇形 (wedge) が広がりきって円になったもの、という連続的な見た目になる。
+      const disc = L.polygon(circlePoints, {
+        color,
+        weight: 1,
+        opacity: 0.7,
+        fillColor: color,
+        fillOpacity,
+        interactive: false,
+      }).addTo(this.map);
+      disc.bringToBack();
+      this.sectorLayers.push(disc);
     }
 
     // pause overlay: xy 円沿いに dot pattern を重ね描き (#179)。

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -338,16 +338,18 @@ class PoiEditor {
     this.inputYaw.value = Number.isFinite(yawRounded) ? yawRounded : 0;
     // tolerance: xy は m そのまま、yaw は rad → deg 変換して UI に表示 (#138)。
     // `||` だと意図的な小さい値も default で上書きされるので Number.isFinite ベースで判定。
-    // toFixed(4) で round-trip 精度を 0.0001° (≒ 0.00000175 rad) 以内に抑える
-    // (Codex review #139 low 対応: toFixed(2) だと未編集 save で yaml 値が微小に変化する懸念)。
+    // yaw は formatToleranceYawDeg で 2 桁丸め + 末尾ゼロ除去し、30/45/90/180 等の区切りの
+    // 良い度数を綺麗に表示する (#267)。区切りの良い度数は rad 4 桁保存と完全に round-trip し
+    // 未編集 save で churn しない (旧 toFixed(4) は #139 で churn 回避のため採用したが
+    // "180.0002" 等と汚かった)。非 round 値はごく稀に ≤0.0001 rad ≒ 0.006° drift しうるが
+    // yaml 4 桁粒度内で実害なし。
     const xyVal = poi.tolerance && poi.tolerance.xy;
     this.inputToleranceXy.value = Number.isFinite(xyVal)
       ? MapoiPoiFilter.roundTo(xyVal, MapoiPoiFilter.TOLERANCE_XY_DIGITS)
       : 0.5;
     const yawValRad = poi.tolerance && poi.tolerance.yaw;
-    this.inputToleranceYaw.value = Number.isFinite(yawValRad)
-      ? MapoiPoiFilter.radToDeg(yawValRad).toFixed(4)
-      : 45;
+    const yawDeg = MapoiPoiFilter.formatToleranceYawDeg(yawValRad);
+    this.inputToleranceYaw.value = Number.isFinite(yawDeg) ? yawDeg : 45;
     this.inputTags.value = (poi.tags || []).join(', ');
     this.inputDescription.value = poi.description || '';
     this.renderTagChips();

--- a/mapoi_webui/web/js/poi-filter.js
+++ b/mapoi_webui/web/js/poi-filter.js
@@ -83,6 +83,26 @@
     return Number.isFinite(v) ? v * 180.0 / Math.PI : NaN;
   }
 
+  // POI editor の tolerance.yaw 入力欄の度数表示桁数 (#267)。内部 / yaml は rad だが editor は
+  // 度数で入出力する (#138)。2 桁丸め + 末尾ゼロ除去で 30/45/90/180 等の区切りの良い度数を
+  // 綺麗に表示する (rad 4 桁保存 → 度数 0.01° 解像度で round-trip も安定)。
+  const TOLERANCE_YAW_DISPLAY_DIGITS = 2;
+
+  /**
+   * tolerance.yaw (rad) を editor 表示用の度数値に変換する純関数 (#267)。
+   * radToDeg 後に 2 桁で丸め、parseFloat で末尾ゼロを落とす (例: 45.00 → 45、180.00 → 180)。
+   * 区切りの良い度数 (30/45/90/180 等) が綺麗に表示され、入力 → 保存 → 再表示の round-trip も
+   * 安定する。旧実装は toFixed(4) で 3.14 rad → "179.9088"、180° 入力 → "180.0002" と汚かった。
+   *
+   * @param {string|number} rad
+   * @returns {number} 度数 (非数値入力時は NaN)
+   */
+  function formatToleranceYawDeg(rad) {
+    const deg = radToDeg(rad);
+    if (!Number.isFinite(deg)) return NaN;
+    return parseFloat(deg.toFixed(TOLERANCE_YAW_DISPLAY_DIGITS));
+  }
+
   /**
    * POI form の tolerance round-trip を保つ純関数 (#87 / #138)。
    * `||` だと意図的な小さい値も default で上書きされるので Number.isFinite で判定。
@@ -139,12 +159,14 @@
     parseTolerance,
     degToRad,
     radToDeg,
+    formatToleranceYawDeg,
     roundTo,
     TOLERANCE_MIN,
     POSE_XY_DIGITS,
     POSE_YAW_DIGITS,
     TOLERANCE_XY_DIGITS,
     TOLERANCE_YAW_DIGITS,
+    TOLERANCE_YAW_DISPLAY_DIGITS,
   };
 
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## 概要

#265 で `tolerance.yaw` が mapoi モードの到達判定に効くようになり、「yaw 不問の通過点」運用が日常化した。その動作確認で見つかった WebUI の 2 課題 (#267) に対応する。

1. **度数表示が汚い**: editor は度数で入出力する (#138) が `toFixed(4)` 表示のため、`3.14 rad → "179.9088"`、`180°` 入力 → `"180.0002"` と汚く、区切りの良い度数 (30/45/90/180) が綺麗に出なかった。
2. **yaw 不問で扇形が消える**: `tolerance.yaw >= π` (全方位) のとき扇形描画を「円と冗長」として省略していたため、xy 円の outline だけになり「描画バグ?」とユーザーが誤認した。

## 変更

- **`poi-filter.js` `formatToleranceYawDeg(rad)`** (純関数, テスト付き): `radToDeg` 後に 2 桁丸め + `parseFloat` で末尾ゼロ除去。`45.00 → 45`、`180.00 → 180`。区切りの良い度数は rad 4 桁保存と**完全に round-trip し未編集 save で churn しない** (旧 `toFixed(4)` は #139 で churn 回避のため採用したが表示が汚かった。本実装は round 度数の churn を保ちつつ表示を改善)。
- **`poi-editor.js`**: tolerance.yaw 表示を新ヘルパに差し替え。
- **`map-viewer.js`**: `tolerance.yaw >= π` を扇形省略ではなく**塗りつぶし円 (disc)** で描画。扇形 (wedge) が広がりきって円になる連続的な見た目で「全方位 OK」を明示。
- **demo config**: `basic_waypoint` を π (180°, `3.1416`) に戻し disc 表示、`audio_landmark` を `0.7854` (45°) に揃え、全 POI を区切りの良い度数の rad 等価に統一 (start=120°, pause=90°, goal=5.73° strict)。

## テスト

- vitest `poi-filter.test.js`: 50/50 PASS。新規 `formatToleranceYawDeg` 5 ケース (round 度数の clean 表示 / yaw 不問=180 / 非 round 値の 2 桁精度 / round 度数の drift なし round-trip / NaN) を追加。
- JS 構文チェック (`node --check`) 3 ファイル OK。
- demo config: yaml 妥当性 + 整合性条件 (全 yaw>=0.001, goal==0.1) 確認、全 POI が clean な度数 (180/120/90/45/5.73°)。
- **未確認**: 扇形 disc の実描画は Leaflet (ブラウザ DOM) のため本環境でビジュアル確認できていません。WebUI 実機での扇形/disc 表示の目視確認をお願いします。

## スコープ外 (follow-up)

- RViz POI editor の度数表示 (現状「yaw rad」) と RViz 扇形 publisher の yaw 不問描画は本 PR 対象外。#267 に残課題として残す。

refs #267