### PR TITLE
test(webui): POI 操作の純粋ロジックを切り出してテスト (refs #273)

### DIFF
--- a/mapoi_webui/tests/web/poi-interactions.test.js
+++ b/mapoi_webui/tests/web/poi-interactions.test.js
@@ -1,0 +1,207 @@
+// vitest unit tests for the pure POI 直接操作 helpers in
+// mapoi_webui/web/js/poi-interactions.js (#273)。
+//
+// 対象 (map-viewer.js から切り出した純粋ロジック・幾何):
+// - classifyPoiClick   : シングル/ダブルクリック判別コア (#240)
+// - wedgeVertexCount    : 扇形 polygon の頂点数 (#275)
+// - wedgePointsWorld    : 扇形 polygon の頂点列 (world) (#275)
+// - worldToLatLng / latLngToWorld : 等方スケール座標変換 (#273)
+// - yawFromDelta        : yaw 回転ハンドルの角度算出 + 等方性不変条件 (#275 / PR #276)
+//
+// テスト方針:
+// - map-viewer.js の _handlePoiClick / _wedgePoints / _addYawHandle / worldToLatLng が
+//   これらに委譲するので、ここで純粋ロジックを固めれば DOM/Leaflet 配線を起こさずに
+//   回帰検知できる (各 PR の Cursor review でテスト不足 medium を繰り返し指摘された箇所)。
+// - Leaflet / DOM / window への依存はゼロで pure JS のみ。
+
+import { describe, it, expect } from 'vitest';
+import * as poi from '../../web/js/poi-interactions.js';
+
+const {
+  classifyPoiClick,
+  wedgeVertexCount,
+  wedgePointsWorld,
+  worldToLatLng,
+  latLngToWorld,
+  yawFromDelta,
+} = poi;
+
+function nearly(a, b, tol = 1e-9) {
+  return Math.abs(a - b) < tol;
+}
+
+describe('classifyPoiClick (#240)', () => {
+  const TH = 300; // map-viewer の _poiDblClickMs
+
+  it('単発 (prev 無し) はシングルで今回の (index, now) を保持する', () => {
+    const r = classifyPoiClick(-1, 0, 2, 1000, TH);
+    expect(r.isDouble).toBe(false);
+    expect(r.nextIndex).toBe(2);
+    expect(r.nextTime).toBe(1000);
+  });
+
+  it('同一 index への閾値内 2 連クリックはダブルで追跡 state を reset する', () => {
+    const r = classifyPoiClick(2, 1000, 2, 1100, TH);
+    expect(r.isDouble).toBe(true);
+    expect(r.nextIndex).toBe(-1);
+    expect(r.nextTime).toBe(0);
+  });
+
+  it('別 index は閾値内でもシングル', () => {
+    const r = classifyPoiClick(2, 1000, 3, 1100, TH);
+    expect(r.isDouble).toBe(false);
+    expect(r.nextIndex).toBe(3);
+    expect(r.nextTime).toBe(1100);
+  });
+
+  it('閾値境界: 299ms=ダブル / 300ms=シングル / 301ms=シングル (strict <)', () => {
+    expect(classifyPoiClick(2, 1000, 2, 1299, TH).isDouble).toBe(true);
+    expect(classifyPoiClick(2, 1000, 2, 1300, TH).isDouble).toBe(false);
+    expect(classifyPoiClick(2, 1000, 2, 1301, TH).isDouble).toBe(false);
+  });
+
+  it('3 連クリック: ダブル後の reset state (-1,0) からの再クリックはシングル', () => {
+    const dbl = classifyPoiClick(2, 1000, 2, 1100, TH);
+    expect(dbl.isDouble).toBe(true);
+    // dbl 後に保持される (-1, 0) を prev として渡す
+    const third = classifyPoiClick(dbl.nextIndex, dbl.nextTime, 2, 1150, TH);
+    expect(third.isDouble).toBe(false);
+    expect(third.nextIndex).toBe(2);
+    expect(third.nextTime).toBe(1150);
+  });
+
+  it('判定は渡された prev だけで決まる (capture-before-callback の保証)', () => {
+    // map-viewer は prev をコールバック前に capture して渡す。コールバック (highlightPoi) が
+    // 追跡 state を reset しても、capture 済みの prev で判定するのでダブルは保たれる。
+    // 一方、reset 後の prev (-1,0) を渡すと別物としてシングルになる — 渡し方の重要性を固定する。
+    expect(classifyPoiClick(2, 1000, 2, 1100, TH).isDouble).toBe(true);
+    expect(classifyPoiClick(-1, 0, 2, 1100, TH).isDouble).toBe(false);
+  });
+});
+
+describe('wedgeVertexCount (#275)', () => {
+  it('狭い扇形でも最低 8 分割を保証する', () => {
+    expect(wedgeVertexCount(0.001)).toBe(8);
+    expect(wedgeVertexCount(0.05)).toBe(8); // 2*0.05/0.1 = 1 → max(8,1)
+    expect(wedgeVertexCount(0.4)).toBe(8); // 2*0.4/0.1 = 8 → max(8,8)
+  });
+
+  it('0.1 rad 刻みで ceil した分割数を返す', () => {
+    expect(wedgeVertexCount(Math.PI / 4)).toBe(16); // 2*0.7854/0.1 = 15.7 → 16
+    expect(wedgeVertexCount(Math.PI / 2)).toBe(32); // 2*1.5708/0.1 = 31.4 → 32
+  });
+
+  it('yawTol に対し単調非減少', () => {
+    let prev = 0;
+    for (let t = 0.05; t < Math.PI; t += 0.05) {
+      const n = wedgeVertexCount(t);
+      expect(n).toBeGreaterThanOrEqual(prev);
+      prev = n;
+    }
+  });
+});
+
+describe('wedgePointsWorld (#275)', () => {
+  const cx = 5;
+  const cy = -3;
+  const r = 2;
+  const yawCenter = 0.7;
+  const yawTol = Math.PI / 6; // 30°
+
+  it('先頭は中心点で、長さは N+2 (中心 + 弧 N+1 点)', () => {
+    const pts = wedgePointsWorld(cx, cy, r, yawCenter, yawTol);
+    const N = wedgeVertexCount(yawTol);
+    expect(pts.length).toBe(N + 2);
+    expect(pts[0]).toEqual({ x: cx, y: cy });
+  });
+
+  it('弧の始端 (i=0) は yawCenter - yawTol、終端 (i=N) は yawCenter + yawTol', () => {
+    const pts = wedgePointsWorld(cx, cy, r, yawCenter, yawTol);
+    const start = pts[1];
+    const end = pts[pts.length - 1];
+    const aStart = yawCenter - yawTol;
+    const aEnd = yawCenter + yawTol;
+    expect(nearly(start.x, cx + r * Math.cos(aStart))).toBe(true);
+    expect(nearly(start.y, cy + r * Math.sin(aStart))).toBe(true);
+    expect(nearly(end.x, cx + r * Math.cos(aEnd))).toBe(true);
+    expect(nearly(end.y, cy + r * Math.sin(aEnd))).toBe(true);
+  });
+
+  it('弧上の全頂点は中心から半径 r', () => {
+    const pts = wedgePointsWorld(cx, cy, r, yawCenter, yawTol);
+    pts.slice(1).forEach((p) => {
+      const d = Math.hypot(p.x - cx, p.y - cy);
+      expect(nearly(d, r, 1e-9)).toBe(true);
+    });
+  });
+
+  it('弧は yawCenter について対称に張られる', () => {
+    const pts = wedgePointsWorld(cx, cy, r, yawCenter, yawTol);
+    const start = pts[1];
+    const end = pts[pts.length - 1];
+    const angStart = Math.atan2(start.y - cy, start.x - cx);
+    const angEnd = Math.atan2(end.y - cy, end.x - cx);
+    // start/end の角度が yawCenter から ±yawTol
+    expect(nearly(angEnd - yawCenter, yawTol, 1e-9)).toBe(true);
+    expect(nearly(yawCenter - angStart, yawTol, 1e-9)).toBe(true);
+  });
+});
+
+describe('worldToLatLng / latLngToWorld (#273)', () => {
+  const origin = [-10, 20];
+  const resolution = 0.05;
+
+  it('world → latlng → world で round-trip する', () => {
+    const cases = [[0, 0], [3.2, -7.5], [-10, 20], [100, -100]];
+    cases.forEach(([x, y]) => {
+      const ll = worldToLatLng(x, y, origin, resolution);
+      const back = latLngToWorld(ll.lat, ll.lng, origin, resolution);
+      expect(nearly(back.x, x, 1e-9)).toBe(true);
+      expect(nearly(back.y, y, 1e-9)).toBe(true);
+    });
+  });
+
+  it('x,y を同一 resolution で割る等方スケール (同距離の world 変位は同距離の latlng 変位)', () => {
+    const base = worldToLatLng(0, 0, origin, resolution);
+    const dx = worldToLatLng(1, 0, origin, resolution);
+    const dy = worldToLatLng(0, 1, origin, resolution);
+    const lngStep = dx.lng - base.lng;
+    const latStep = dy.lat - base.lat;
+    expect(nearly(lngStep, latStep, 1e-12)).toBe(true);
+    expect(nearly(lngStep, 1 / resolution, 1e-9)).toBe(true);
+  });
+});
+
+describe('yawFromDelta + 等方性不変条件 (#275 / PR #276 false-positive 根拠)', () => {
+  it('latlng 差分から atan2 で yaw を返す', () => {
+    expect(nearly(yawFromDelta(0, 1), 0)).toBe(true); // +lng → 0
+    expect(nearly(yawFromDelta(1, 0), Math.PI / 2)).toBe(true); // +lat → π/2
+    expect(nearly(yawFromDelta(0, -1), Math.PI)).toBe(true); // -lng → π
+  });
+
+  it('worldToLatLng が等方スケールなので、handle の latlng yaw は world yaw と厳密一致する', () => {
+    // wedgePointsWorld → worldToLatLng → yawFromDelta の round-trip を、複数の
+    // origin / resolution / world yaw で確認する。resolution が約分されて yaw が保たれる
+    // (= PR #276 review の「yaw 座標系」high が false-positive である根拠)。
+    const center = { cx: 4, cy: -6 };
+    const r = 1.5;
+    const configs = [
+      { origin: [0, 0], resolution: 0.05 },
+      { origin: [-12.3, 7.8], resolution: 0.1 },
+      { origin: [100, -50], resolution: 0.25 },
+    ];
+    const yaws = [0, 0.3, 1.0, Math.PI / 2, 2.5, -0.7, -2.9];
+    configs.forEach(({ origin, resolution }) => {
+      const cLL = worldToLatLng(center.cx, center.cy, origin, resolution);
+      yaws.forEach((theta) => {
+        const tip = {
+          x: center.cx + r * Math.cos(theta),
+          y: center.cy + r * Math.sin(theta),
+        };
+        const tipLL = worldToLatLng(tip.x, tip.y, origin, resolution);
+        const yaw = yawFromDelta(tipLL.lat - cLL.lat, tipLL.lng - cLL.lng);
+        expect(nearly(yaw, theta, 1e-9)).toBe(true);
+      });
+    });
+  });
+});

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -230,6 +230,9 @@
   <!-- poi-filter.js は MapoiPoiFilter を window に attach する pure helper 群 (#85)。
        app.js より前に読み込む。 -->
   <script src="/js/poi-filter.js"></script>
+  <!-- poi-interactions.js は MapoiPoiInteractions を window に attach する pure helper 群 (#273)。
+       map-viewer.js より前に読み込む (クリック判別 / wedge 幾何 / 座標変換で参照される)。 -->
+  <script src="/js/poi-interactions.js"></script>
   <script src="/js/map-viewer.js"></script>
   <script src="/js/poi-editor.js"></script>
   <script src="/js/route-editor.js"></script>

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -318,10 +318,12 @@ class MapViewer {
       this._lastPoiClickIndex, this._lastPoiClickTime, index, Date.now(), this._poiDblClickMs,
     );
     if (this.onPoiClick) this.onPoiClick(index);
-    if (r.isDouble && this.onPoiDblClick) this.onPoiDblClick(index);
-    // 追跡 state はコールバックの後に書き、reset を上書きして次クリックの判定基準に残す。
+    // 追跡 state は onPoiClick の後・onPoiDblClick の前に書く。onPoiClick (→ highlightPoi)
+    // が走らせる reset を上書きしつつ、旧実装と同じく onPoiDblClick より前に確定させる
+    // (ダブル時は (-1,0) に reset 済みとなり、dblClick ハンドラが例外を投げても state は残らない)。
     this._lastPoiClickIndex = r.nextIndex;
     this._lastPoiClickTime = r.nextTime;
+    if (r.isDouble && this.onPoiDblClick) this.onPoiDblClick(index);
   }
 
   /**

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -121,9 +121,9 @@ class MapViewer {
    */
   worldToLatLng(x, y) {
     const m = this.metadata;
-    const lng = (x - m.origin[0]) / m.resolution;
-    const lat = (y - m.origin[1]) / m.resolution;
-    return L.latLng(lat, lng);
+    // 等方スケールの座標変換は pure helper に委譲し単体テスト対象にする (#273)。
+    const ll = MapoiPoiInteractions.worldToLatLng(x, y, m.origin, m.resolution);
+    return L.latLng(ll.lat, ll.lng);
   }
 
   /**
@@ -131,10 +131,7 @@ class MapViewer {
    */
   latLngToWorld(latlng) {
     const m = this.metadata;
-    return {
-      x: latlng.lng * m.resolution + m.origin[0],
-      y: latlng.lat * m.resolution + m.origin[1],
-    };
+    return MapoiPoiInteractions.latLngToWorld(latlng.lat, latlng.lng, m.origin, m.resolution);
   }
 
   /**
@@ -315,18 +312,16 @@ class MapViewer {
    * @private
    */
   _handlePoiClick(index) {
-    const prevIndex = this._lastPoiClickIndex;
-    const prevTime = this._lastPoiClickTime;
-    const now = Date.now();
-    const isDouble = prevIndex === index && (now - prevTime) < this._poiDblClickMs;
+    // 判別コアは pure helper (#273)。prev はコールバック前に capture して渡すので、
+    // onPoiClick → highlightPoi 経由で追跡 state が reset されても判定は保たれる。
+    const r = MapoiPoiInteractions.classifyPoiClick(
+      this._lastPoiClickIndex, this._lastPoiClickTime, index, Date.now(), this._poiDblClickMs,
+    );
     if (this.onPoiClick) this.onPoiClick(index);
-    if (isDouble) {
-      this._resetPoiClickTracking();
-      if (this.onPoiDblClick) this.onPoiDblClick(index);
-    } else {
-      this._lastPoiClickIndex = index;
-      this._lastPoiClickTime = now;
-    }
+    if (r.isDouble && this.onPoiDblClick) this.onPoiDblClick(index);
+    // 追跡 state はコールバックの後に書き、reset を上書きして次クリックの判定基準に残す。
+    this._lastPoiClickIndex = r.nextIndex;
+    this._lastPoiClickTime = r.nextTime;
   }
 
   /**
@@ -428,7 +423,9 @@ class MapViewer {
       className: 'poi-yaw-handle', html: svg, iconSize: [18, 18], iconAnchor: [9, 9],
     });
     const handle = L.marker(tipLL, { icon, draggable: true, zIndexOffset: 1500 }).addTo(this.map);
-    const yawFrom = (ll) => Math.atan2(ll.lat - centerLL.lat, ll.lng - centerLL.lng);
+    const yawFrom = (ll) => MapoiPoiInteractions.yawFromDelta(
+      ll.lat - centerLL.lat, ll.lng - centerLL.lng,
+    );
     handle.on('drag', () => {
       const newYaw = yawFrom(handle.getLatLng());
       this.updatePoiMarkerYaw(index, newYaw);
@@ -640,20 +637,15 @@ class MapViewer {
   }
 
   /**
-   * 扇形 (wedge) の polygon 頂点列を計算する (#275)。中心 → 弧 (yawCenter±yawTol) → 中心。
-   * 初期描画 (_drawSectorForPoi) と回転ハンドルドラッグ中の setLatLngs 追従の両方で使う。
+   * 扇形 (wedge) の polygon 頂点列 (latlng) を計算する (#275)。中心 → 弧 (yawCenter±yawTol) → 中心。
+   * 幾何 (頂点数 / 角度範囲) は pure helper に切り出し単体テスト対象とし (#273)、ここでは
+   * world 座標を worldToLatLng で latlng へ変換するだけ。初期描画 (_drawSectorForPoi) と
+   * 回転ハンドルドラッグ中の setLatLngs 追従の両方で使う。
    * @private
    */
   _wedgePoints(cx, cy, r, yawCenter, yawTol) {
-    const totalAngle = 2 * yawTol;
-    const N = Math.max(8, Math.ceil(totalAngle / 0.1));
-    const startAngle = yawCenter - yawTol;
-    const pts = [this.worldToLatLng(cx, cy)];  // 中心点 → 弧 → 中心 (polygon で自動閉じる)
-    for (let i = 0; i <= N; i += 1) {
-      const a = startAngle + (totalAngle * i) / N;
-      pts.push(this.worldToLatLng(cx + r * Math.cos(a), cy + r * Math.sin(a)));
-    }
-    return pts;
+    return MapoiPoiInteractions.wedgePointsWorld(cx, cy, r, yawCenter, yawTol)
+      .map((p) => this.worldToLatLng(p.x, p.y));
   }
 
   /**

--- a/mapoi_webui/web/js/poi-interactions.js
+++ b/mapoi_webui/web/js/poi-interactions.js
@@ -1,0 +1,152 @@
+/**
+ * Pure helpers for map 上の POI 直接操作 (#240 クリック判別 / #239 ドラッグ / #275 yaw 回転)。
+ *
+ * map-viewer.js の Leaflet / DOM 配線から「純粋なロジック・幾何」だけを切り出し、
+ * 単体テスト (mapoi_webui/tests/web/poi-interactions.test.js) で回帰検知できるようにする。
+ * 各 PR で繰り返しテスト不足を指摘された判別コア・wedge 幾何・座標変換を対象とする (#273)。
+ *
+ * Browser からは `MapoiPoiInteractions.*` のグローバルとして使い、
+ * Node (vitest) からは `module.exports` 経由で import する dual export 形式
+ * (geometry.js / poi-filter.js と同じ #129 パターン)。Leaflet / DOM / window 非依存。
+ */
+(function () {
+  'use strict';
+
+  /**
+   * POI marker クリックのシングル/ダブル判別コア (#240)。
+   *
+   * 同一 index への 2 連クリックが `thresholdMs` 未満ならダブル (= 編集パネル)、
+   * それ以外はシングル (= 選択のみ)。判定は「前回クリックの index / 時刻」と「今回の
+   * index / 時刻」だけで決まる純関数なので、map-viewer.js の `_handlePoiClick` が
+   * 呼び出し前に prev を capture して渡す。これにより onPoiClick → highlightPoi 経由で
+   * クリック追跡 state が reset されても、ここで掴んだ prev で判定が保たれる。
+   *
+   * 次に保持すべき追跡 state も返す:
+   * - ダブル時は `(-1, 0)` にリセット (3 連クリックを 2 回目のダブルにしない)
+   * - シングル時は今回の `(index, now)` を保持 (次クリックの判定基準にする)
+   *
+   * @param {number} prevIndex 前回クリックした POI index (未クリックは -1)
+   * @param {number} prevTime 前回クリック時刻 (ms, Date.now() 値)
+   * @param {number} index 今回クリックした POI index
+   * @param {number} now 今回クリック時刻 (ms)
+   * @param {number} thresholdMs ダブルクリック判定の上限間隔 (ms)
+   * @returns {{ isDouble: boolean, nextIndex: number, nextTime: number }}
+   */
+  function classifyPoiClick(prevIndex, prevTime, index, now, thresholdMs) {
+    const isDouble = prevIndex === index && (now - prevTime) < thresholdMs;
+    if (isDouble) {
+      return { isDouble: true, nextIndex: -1, nextTime: 0 };
+    }
+    return { isDouble: false, nextIndex: index, nextTime: now };
+  }
+
+  /**
+   * 扇形 (wedge) polygon の頂点数 (#275)。中心角 `2*yawTol` を 0.1 rad 刻みで割り、
+   * 最低 8 分割を保証する (狭い扇形でもカクつかない最低限の滑らかさ)。
+   *
+   * @param {number} yawTol 片側 tolerance (rad, > 0)
+   * @returns {number} 弧の分割数 N (弧の頂点は N+1 個)
+   */
+  function wedgeVertexCount(yawTol) {
+    return Math.max(8, Math.ceil((2 * yawTol) / 0.1));
+  }
+
+  /**
+   * 扇形 (wedge) polygon の頂点列を world 座標で計算する (#275)。
+   * 中心点 → 弧 (`yawCenter - yawTol` から `yawCenter + yawTol`) の順に並べ、polygon の
+   * 自然な閉じ (最後の頂点 → 先頭 = 中心) で扇形になる。map-viewer.js の `_wedgePoints`
+   * がこれを `worldToLatLng` で latlng に変換して描画 / ドラッグ追従に使う。
+   *
+   * 戻り値配列の構造: `[center, arc(i=0), arc(i=1), ..., arc(i=N)]` (長さ N+2)。
+   * - `arc(i=0)` は始端角 `yawCenter - yawTol`
+   * - `arc(i=N)` は終端角 `yawCenter + yawTol`
+   *
+   * @param {number} cx 中心 x (world)
+   * @param {number} cy 中心 y (world)
+   * @param {number} r 半径 (tolerance.xy)
+   * @param {number} yawCenter 扇形中心角 (rad)
+   * @param {number} yawTol 片側 tolerance (rad)
+   * @returns {Array<{x: number, y: number}>}
+   */
+  function wedgePointsWorld(cx, cy, r, yawCenter, yawTol) {
+    const totalAngle = 2 * yawTol;
+    const N = wedgeVertexCount(yawTol);
+    const startAngle = yawCenter - yawTol;
+    const pts = [{ x: cx, y: cy }];
+    for (let i = 0; i <= N; i += 1) {
+      const a = startAngle + (totalAngle * i) / N;
+      pts.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) });
+    }
+    return pts;
+  }
+
+  /**
+   * World 座標 → Leaflet CRS.Simple の (lat, lng) (pixel 空間) への変換 (純粋版)。
+   * map-viewer.js の `worldToLatLng` がこれに委譲する。x,y を同一 `resolution` で
+   * 割る等方スケールなので、ワールド空間の角度が latlng 空間でも保たれる
+   * (yaw 回転ハンドルの不変条件、`yawFromDelta` 参照)。
+   *
+   * @param {number} x world x
+   * @param {number} y world y
+   * @param {Array<number>} origin map origin `[originX, originY]`
+   * @param {number} resolution m/pixel
+   * @returns {{ lat: number, lng: number }}
+   */
+  function worldToLatLng(x, y, origin, resolution) {
+    return {
+      lat: (y - origin[1]) / resolution,
+      lng: (x - origin[0]) / resolution,
+    };
+  }
+
+  /**
+   * Leaflet CRS.Simple の (lat, lng) → world 座標への逆変換 (純粋版)。
+   * map-viewer.js の `latLngToWorld` がこれに委譲する。
+   *
+   * @param {number} lat
+   * @param {number} lng
+   * @param {Array<number>} origin map origin `[originX, originY]`
+   * @param {number} resolution m/pixel
+   * @returns {{ x: number, y: number }}
+   */
+  function latLngToWorld(lat, lng, origin, resolution) {
+    return {
+      x: lng * resolution + origin[0],
+      y: lat * resolution + origin[1],
+    };
+  }
+
+  /**
+   * yaw 回転ハンドルのドラッグ位置 (中心からの latlng 差分) から新 yaw を求める (#275)。
+   *
+   * `worldToLatLng` が x,y を同一 resolution で割る等方スケールのため、latlng 空間で
+   * `atan2(latDelta, lngDelta)` を取った値はワールド yaw と厳密一致する (resolution が
+   * 約分される)。これが PR #276 review で yaw 座標系 high と指摘された点の false-positive
+   * 根拠 — テストで `wedgePointsWorld` → `worldToLatLng` → `yawFromDelta` の round-trip を
+   * 任意の origin / resolution で確認することで不変条件を守る。
+   *
+   * @param {number} latDelta ハンドル lat - 中心 lat
+   * @param {number} lngDelta ハンドル lng - 中心 lng
+   * @returns {number} yaw (rad)
+   */
+  function yawFromDelta(latDelta, lngDelta) {
+    return Math.atan2(latDelta, lngDelta);
+  }
+
+  const api = {
+    classifyPoiClick,
+    wedgeVertexCount,
+    wedgePointsWorld,
+    worldToLatLng,
+    latLngToWorld,
+    yawFromDelta,
+  };
+
+  if (typeof window !== 'undefined') {
+    window.MapoiPoiInteractions = window.MapoiPoiInteractions || {};
+    Object.assign(window.MapoiPoiInteractions, api);
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+}());


### PR DESCRIPTION
## 概要

map 上の POI 直接操作 (#240 クリック判別 / #239 ドラッグ移動 / #275 yaw 回転) の回帰が手動確認頼みで、各 PR の Cursor review でテスト不足を繰り返し指摘されていた (#273)。DOM/Leaflet 非依存の**純粋ロジック・幾何**を `poi-interactions.js` に切り出し、vitest で回帰検知できるようにする (geometry.js / poi-filter.js と同じ #129 dual-export パターン)。

## 変更

- **新規** `mapoi_webui/web/js/poi-interactions.js` (`MapoiPoiInteractions`)
  - `classifyPoiClick` — シングル/ダブル判別コア
  - `wedgeVertexCount` / `wedgePointsWorld` — 扇形 polygon の頂点数・頂点列
  - `worldToLatLng` / `latLngToWorld` — 等方スケール座標変換
  - `yawFromDelta` — yaw 回転ハンドルの角度算出
- **リファクタ** `map-viewer.js` (+22 −30) — `_handlePoiClick` / `_wedgePoints` / `_addYawHandle` の yawFrom / `worldToLatLng` / `latLngToWorld` を上記に委譲。**挙動は忠実に保持** (判別 state の最終値・wedge の latlng 列は従来と同一)。
- **テスト** `tests/web/poi-interactions.test.js` — 17 件追加、計 **67 件 green**
- `index.html` に script 読み込みを追加 (map-viewer.js より前)

## このPRがカバーする #273 のチェック項目

- [x] クリック判別コア: 300ms 境界 (299=double / 300・301=single) / 同一 index のみ / prev capture-before-callback の保証 / 3 連クリック
- [x] `_wedgePoints` の幾何: 頂点数 `max(8, ceil(2·yawTol/0.1))` / 角度範囲 (yawCenter±yawTol) / 起点・終点 / 半径不変 / 対称性
- [x] yaw 等方スケール不変条件 (PR #276 review high の false-positive 根拠を `wedgePointsWorld → worldToLatLng → yawFromDelta` の round-trip で test 化)

## #273 に残す follow-up (DOM/Leaflet インスタンス依存)

純関数スコープ外として #273 に残置:

- `PoiEditor.updateDraggedPosition` / `updateDraggedYaw` の dirty 化・編集フォーム同期・pose 欠損 early return (丸め自体は既存 `roundTo` テストで担保済)
- `setPoiDraggingAllowed` / `_applyPoiDraggable` / `_refreshYawHandle` の出し分け
- 編集モード UX (`exitEditMode` 連携・セクション折りたたみ)

これらは jsdom harness の導入が必要で、本 PR では純関数の最大カバーを優先した (#273 検討事項の方針に沿う)。

## テスト

`mapoi_webui/tests/web` で `npm test` → 67 passed。CI (consistency-check / webui_js_tests) で自動実行される。