### PR TITLE
feat(webui): Navigation プルダウン選択で POI/route を地図ハイライト (Close #262)

### DIFF
--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -708,6 +708,48 @@
     navPollingTimer = setInterval(pollNavStatus, 1000);
   }
 
+  // Navigation プルダウン選択 → map 上で選択状態にする (#262)。
+  // プルダウンで POI / route を選んだら editor 選択経路 (selectPoi / selectRoute) に
+  // 流し込み、既存の onSelectionChange (→ highlightPoi/highlightRoute + syncNav*) に
+  // map ハイライトと dropdown 逆同期を委ねる。これで list / map / dropdown の選択 state を
+  // 単一ソース (poiEditor.selectedIndex / routeEditor.selectedIndex) で揃える。
+  // 空 ("-- Select --") は選択解除ではなく no-op とし現在の選択を維持する
+  // (Run/Go ボタンの `if (!name) return;` と同じく「未選択 = 操作しない」)。
+  function highlightPoiFromNav(name) {
+    if (!name) return;
+    const index = poiEditor.pois.findIndex((p) => p.name === name);
+    if (index < 0) return;
+    // 既に選択中なら再 render を避け、map ハイライトだけ確実に反映する。
+    if (index === poiEditor.selectedIndex) {
+      mapViewer.highlightPoi(index);
+      return;
+    }
+    poiEditor.selectPoi(index);
+  }
+
+  // goal POI / initial pose POI どちらの dropdown も同じ POI 選択経路を共有する
+  // (#111 の goal 欄 auto-fill もこの選択経由でそのまま効く)。
+  navGoalSelect.addEventListener('change', () => {
+    highlightPoiFromNav(navGoalSelect.value);
+  });
+  navInitialPoseSelect.addEventListener('change', () => {
+    highlightPoiFromNav(navInitialPoseSelect.value);
+  });
+
+  navRouteSelect.addEventListener('change', () => {
+    const name = navRouteSelect.value;
+    if (!name) return;
+    const index = routeEditor.routes.findIndex((r) => r.name === name);
+    if (index < 0) return;
+    // routeEditor.selectRoute は toggle (同 index 再選択で -1 解除)。dropdown 経由で
+    // 既選択 route を選び直した時に誤って解除しないよう、選択中なら highlight のみ。
+    if (index === routeEditor.selectedIndex) {
+      mapViewer.highlightRoute(index);
+      return;
+    }
+    routeEditor.selectRoute(index);
+  });
+
   document.getElementById('btn-nav-go').addEventListener('click', async () => {
     const name = navGoalSelect.value;
     if (!name) return;


### PR DESCRIPTION
## 概要

Close #262

Navigation > Robot Map のプルダウンで POI / route を選んでも地図上でハイライトされず、選んだ対象が視覚的に分からなかった。プルダウンの `change` を地図の選択状態に繋ぎ、選んだ POI / route がハイライトされるようにする。

## 変更内容

`mapoi_webui/web/js/app.js` に 3 つの nav プルダウンの `change` ハンドラを追加:

- `nav-goal-select` / `nav-initialpose-select` → `poiEditor.selectPoi(index)` 経由
- `nav-route-select` → `routeEditor.selectRoute(index)` 経由
- いずれも既存の `onSelectionChange` (→ `highlightPoi` / `highlightRoute` + `syncNav*`) に map ハイライトと dropdown 逆同期を委譲

## 設計判断

- `highlightPoi` / `highlightRoute` は単なる視覚強調でなく、選択 POI の drag 可 (#239)・yaw ハンドル (#275)・route の `_activeRouteIdx` / robot connector を伴う「選択状態」そのもの。地図だけハイライトして editor 選択とズレると不整合になるため、既存の editor 選択経路に流して選択 state を単一ソース (`poiEditor.selectedIndex` / `routeEditor.selectedIndex`) に揃えた。
- `routeEditor.selectRoute` は list クリック用の toggle 挙動 (同 index 再選択で解除)。dropdown で既選択 route を選び直した時に誤って解除しないよう、選択中は `highlightRoute` のみ呼ぶガードを追加。
- 空選択 (`-- Select --`) は選択解除ではなく no-op とし現在の選択を維持 (Run/Go ボタンの `if (!name) return;` と同じ「未選択 = 操作しない」)。

## 既知の限界 (本 PR では非対応)

- initial-pose プルダウンで POI を選ぶと、その POI が editor 選択になり `syncNavGoalSelect` 経由で goal 欄も auto-fill される (#111 の既存挙動の延長、その POI が goal 候補の場合)。
- 可視性 toggle で隠した POI / route を選んでも地図上に marker / line が無いためハイライトは出ない (選択 state は更新)。visibility 連動は scope 外。

## テスト

- `vitest run` 67 件 green (app.js は DOM glue で従来どおり unit テスト対象外、#273 の jsdom フェーズと同じ境界)。
- `node --check app.js` syntax OK。