### PR TITLE
test(webui): navigation API の自動テスト追加

### DIFF
--- a/mapoi_webui/CMakeLists.txt
+++ b/mapoi_webui/CMakeLists.txt
@@ -43,6 +43,19 @@ if(BUILD_TESTING)
     test/test_api_save_pois_version_conflict.py
     TIMEOUT 10
   )
+  # `get_navigation_capabilities` の subscriber 数→availability 統合契約 (#199)。
+  # resolver 単体 (test_resolve_backend_status_for_ui) と endpoint test の中間にある
+  # 「legacy fallback vs backend_status 上書き / localization 独立」を pin。
+  ament_add_pytest_test(test_get_navigation_capabilities
+    test/test_get_navigation_capabilities.py
+    TIMEOUT 10
+  )
+  # navigation API endpoint 契約 (#199): /api/nav/switch-map validation (400/404)、
+  # /api/mode・/api/nav/status の payload shape を Flask test_client で固定。
+  ament_add_pytest_test(test_api_nav_endpoints
+    test/test_api_nav_endpoints.py
+    TIMEOUT 10
+  )
 endif()
 
 ament_package()

--- a/mapoi_webui/test/test_api_nav_endpoints.py
+++ b/mapoi_webui/test/test_api_nav_endpoints.py
@@ -1,0 +1,173 @@
+"""Flask endpoint level test for navigation API (#199).
+
+`/api/nav/switch-map` の validation 契約と、`/api/mode` / `/api/nav/status` が
+navigation capabilities を正しく包んで返すことを Flask `test_client` で固定する:
+
+- `/api/nav/switch-map`
+    * body が dict でない / `map_name` 不在 / 空白のみ → 400 `map_name required`
+    * `get_maps_list()` に存在しない map → 404 `unknown map: ...`
+    * maps list が空 (maps_path 未設定等) → membership check skip して 200
+    * 正常時は `mapoi/nav/switch_map` に strip 済 map_name を publish して 200
+    * publish helper の warning を payload に透過
+- `/api/mode`        → `{'navigation': <capabilities>}`
+- `/api/nav/status`  → status / target / robot_pose / robot_radius / navigation を同梱
+
+`test_api_save_pois_version_conflict.py` と同じく `create_flask_app` を duck-typed
+`_FakeNode` に bind する。各 endpoint closure は request 時にしか評価されないため、
+本 test が叩く経路で参照される attr / method だけを `_FakeNode` に持たせれば足りる。
+`get_navigation_capabilities` 自体のロジックは `test_get_navigation_capabilities.py`
+で別途 pin しているので、ここでは sentinel dict の透過だけを確認する。
+"""
+import unittest
+
+from mapoi_webui.mapoi_webui_node import MapoiWebNode
+
+
+class _NullLogger:
+    def info(self, *_a, **_k):
+        pass
+
+    def warn(self, *_a, **_k):
+        pass
+
+    def error(self, *_a, **_k):
+        pass
+
+
+class _FakeNode:
+    """nav endpoint 経路で参照される最小限の attr / method を持つ duck-typed node."""
+
+    def __init__(self, *, maps=None, warning=None, nav_caps=None,
+                 nav_status='idle', nav_target=None, robot_pose=None,
+                 robot_radius=0.3):
+        self._maps = [] if maps is None else list(maps)
+        self._warning = warning
+        self._nav_caps = nav_caps if nav_caps is not None else {
+            'navigation_available': False}
+        self.nav_status_ = nav_status
+        self.nav_status_target_ = nav_target
+        self.robot_pose_ = robot_pose
+        self.robot_radius_ = robot_radius
+        # publish_with_subscriber_check に渡されるだけで中身は使わない
+        self.switch_map_pub_ = object()
+        # publish された (topic, data) を記録して assert する
+        self.published = []
+
+    def get_maps_list(self):
+        return list(self._maps)
+
+    def publish_with_subscriber_check(self, pub, msg, topic_name):
+        self.published.append((topic_name, getattr(msg, 'data', None)))
+        return (True, self._warning)
+
+    def get_navigation_capabilities(self):
+        return self._nav_caps
+
+    def get_logger(self):
+        return _NullLogger()
+
+
+def _client(node):
+    app = MapoiWebNode.create_flask_app(node)
+    return app.test_client()
+
+
+class TestApiNavSwitchMap(unittest.TestCase):
+
+    def test_non_dict_body_returns_400(self):
+        node = _FakeNode(maps=['mapA'])
+        resp = _client(node).post('/api/nav/switch-map', json=[1, 2])
+        self.assertEqual(resp.status_code, 400, resp.get_data(as_text=True))
+        self.assertIn('map_name', resp.get_json().get('error', ''))
+        self.assertEqual(node.published, [])  # publish されていない
+
+    def test_missing_map_name_returns_400(self):
+        node = _FakeNode(maps=['mapA'])
+        resp = _client(node).post('/api/nav/switch-map', json={})
+        self.assertEqual(resp.status_code, 400, resp.get_data(as_text=True))
+        self.assertIn('map_name', resp.get_json().get('error', ''))
+        self.assertEqual(node.published, [])
+
+    def test_whitespace_map_name_returns_400(self):
+        node = _FakeNode(maps=['mapA'])
+        resp = _client(node).post('/api/nav/switch-map', json={'map_name': '   '})
+        self.assertEqual(resp.status_code, 400, resp.get_data(as_text=True))
+        self.assertEqual(node.published, [])
+
+    def test_unknown_map_returns_404(self):
+        node = _FakeNode(maps=['mapA', 'mapB'])
+        resp = _client(node).post('/api/nav/switch-map', json={'map_name': 'mapX'})
+        self.assertEqual(resp.status_code, 404, resp.get_data(as_text=True))
+        self.assertIn('mapX', resp.get_json().get('error', ''))
+        self.assertEqual(node.published, [])
+
+    def test_valid_map_publishes_and_returns_200(self):
+        node = _FakeNode(maps=['mapA'])
+        resp = _client(node).post('/api/nav/switch-map', json={'map_name': 'mapA'})
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertTrue(body.get('success'))
+        self.assertEqual(body.get('map_name'), 'mapA')
+        self.assertNotIn('warning', body)  # warning なし時は key を出さない
+        self.assertEqual(node.published, [('mapoi/nav/switch_map', 'mapA')])
+
+    def test_valid_map_name_is_stripped_before_publish(self):
+        node = _FakeNode(maps=['mapA'])
+        resp = _client(node).post('/api/nav/switch-map', json={'map_name': '  mapA  '})
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        self.assertEqual(resp.get_json().get('map_name'), 'mapA')
+        # publish される data も strip 済
+        self.assertEqual(node.published, [('mapoi/nav/switch_map', 'mapA')])
+
+    def test_empty_maps_list_skips_membership_check(self):
+        """`get_maps_list()` が空 (maps_path 未設定等) なら存在チェックを skip して publish。
+
+        実装の `if maps and map_name not in maps` は maps 空で short-circuit する。
+        """
+        node = _FakeNode(maps=[])
+        resp = _client(node).post('/api/nav/switch-map', json={'map_name': 'anything'})
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        self.assertEqual(node.published, [('mapoi/nav/switch_map', 'anything')])
+
+    def test_warning_is_passed_through(self):
+        node = _FakeNode(maps=['mapA'], warning='no subscribers on mapoi/nav/switch_map')
+        resp = _client(node).post('/api/nav/switch-map', json={'map_name': 'mapA'})
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        self.assertEqual(
+            resp.get_json().get('warning'), 'no subscribers on mapoi/nav/switch_map')
+
+
+class TestApiMode(unittest.TestCase):
+
+    def test_mode_wraps_navigation_capabilities(self):
+        sentinel = {'navigation_available': True, 'command_available': False, 'topics': {}}
+        node = _FakeNode(nav_caps=sentinel)
+        resp = _client(node).get('/api/mode')
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        self.assertEqual(resp.get_json(), {'navigation': sentinel})
+
+
+class TestApiNavStatus(unittest.TestCase):
+
+    def test_nav_status_payload_shape(self):
+        sentinel = {'navigation_available': True}
+        node = _FakeNode(
+            nav_caps=sentinel,
+            nav_status='navigating',
+            nav_target='poi_kitchen',
+            robot_pose={'x': 1.0, 'y': 2.0, 'yaw': 0.5},
+            robot_radius=0.35,
+        )
+        resp = _client(node).get('/api/nav/status')
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertEqual(body.get('status'), 'navigating')
+        self.assertEqual(body.get('target'), 'poi_kitchen')
+        self.assertEqual(body.get('robot_pose'), {'x': 1.0, 'y': 2.0, 'yaw': 0.5})
+        self.assertEqual(body.get('robot_radius'), 0.35)
+        # navigation capabilities が同梱されている
+        self.assertEqual(body.get('navigation'), sentinel)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mapoi_webui/test/test_get_navigation_capabilities.py
+++ b/mapoi_webui/test/test_get_navigation_capabilities.py
@@ -1,0 +1,176 @@
+"""Unit test for `MapoiWebNode.get_navigation_capabilities` (#199, #198 / #205 / #212).
+
+`_resolve_backend_status_for_ui` 単体 (`test_resolve_backend_status_for_ui.py`) は
+状態遷移ロジックしか pin しない。本 test はその resolver と各 publisher の
+`get_subscription_count()` を組み合わせた `get_navigation_capabilities` の **統合契約**
+を固定する:
+
+- backend_status 未受信 (None) → subscriber 数による legacy fallback
+- command topic (goal/route/cancel/pause/resume) の subscriber が availability の根拠。
+  `switch_map` / `initialpose` は command 扱いしない (#... initialpose は localization
+  bridge が残すため除外)
+- backend_status 受信済み → backend_ready が legacy fallback を上書き
+  (#212 codex review high: command subscriber が残っても false-enable しない)
+- backend_status 受信済み + lost (alive=False) → 明示 unready
+- localization_status は navigation とは独立した payload
+
+ROS 2 Node を本物で起動せず、`get_navigation_capabilities` を duck-typed node に
+unbound 呼び出しする。`_resolve_backend_status_for_ui` は `@staticmethod` なので
+実物をそのまま class 属性に貼り、本物の resolver で統合経路を検証する。
+"""
+import unittest
+
+from mapoi_webui.mapoi_webui_node import MapoiWebNode
+
+
+class _FakePub:
+    """`get_subscription_count()` だけを持つ最小 publisher stub。"""
+
+    def __init__(self, count=0):
+        self._count = count
+
+    def get_subscription_count(self):
+        return self._count
+
+
+class _NavCapNode:
+    """`get_navigation_capabilities` が参照する attr / staticmethod だけを持つ duck-typed node.
+
+    7 publisher の subscriber 数と 4 つの backend_status 系 attr を constructor で差し込む。
+    `_resolve_backend_status_for_ui` は実物 (staticmethod) をそのまま使う。
+    """
+
+    _resolve_backend_status_for_ui = staticmethod(
+        MapoiWebNode._resolve_backend_status_for_ui)
+
+    def __init__(self, *, counts=None, backend_status=None, nav_alive=True,
+                 localization_status=None, localization_alive=True):
+        counts = counts or {}
+        self.switch_map_pub_ = _FakePub(counts.get('switch_map', 0))
+        self.goal_poi_pub_ = _FakePub(counts.get('goal', 0))
+        self.route_pub_ = _FakePub(counts.get('route', 0))
+        self.cancel_pub_ = _FakePub(counts.get('cancel', 0))
+        self.pause_pub_ = _FakePub(counts.get('pause', 0))
+        self.resume_pub_ = _FakePub(counts.get('resume', 0))
+        self.initialpose_poi_pub_ = _FakePub(counts.get('initialpose', 0))
+        self.backend_status_ = backend_status
+        self.nav_backend_alive_ = nav_alive
+        self.localization_status_ = localization_status
+        self.localization_backend_alive_ = localization_alive
+
+
+def _caps(**kwargs):
+    node = _NavCapNode(**kwargs)
+    return MapoiWebNode.get_navigation_capabilities(node)
+
+
+class TestGetNavigationCapabilities(unittest.TestCase):
+
+    # ---- legacy fallback (backend_status 未受信) -------------------------------
+
+    def test_no_backend_status_no_subscribers_all_unavailable(self):
+        """backend_status 未受信 + subscriber ゼロ → 全 unavailable, backend_status None."""
+        caps = _caps()
+        self.assertFalse(caps['navigation_available'])
+        self.assertFalse(caps['switch_map_available'])
+        self.assertFalse(caps['command_available'])
+        self.assertIsNone(caps['backend_status'])
+        # topics は 7 key 全て available False で揃う
+        self.assertEqual(set(caps['topics']), {
+            'switch_map', 'goal', 'route', 'cancel', 'pause', 'resume',
+            'initialpose'})
+        self.assertFalse(any(t['available'] for t in caps['topics'].values()))
+
+    def test_legacy_command_subscriber_enables_navigation(self):
+        """command topic に subscriber → legacy で navigation_available True。
+
+        switch_map に subscriber がいなければ switch_map_available は False のまま
+        (両者は独立、#205 round 3)。
+        """
+        caps = _caps(counts={'goal': 1})
+        self.assertTrue(caps['command_available'])
+        self.assertTrue(caps['navigation_available'])
+        self.assertFalse(caps['switch_map_available'])
+        self.assertTrue(caps['topics']['goal']['available'])
+        self.assertEqual(caps['topics']['goal']['subscribers'], 1)
+
+    def test_legacy_switch_map_subscriber_only(self):
+        """switch_map のみ subscriber → switch_map 由来で legacy navigation_available True。"""
+        caps = _caps(counts={'switch_map': 2})
+        self.assertFalse(caps['command_available'])
+        self.assertTrue(caps['switch_map_available'])
+        self.assertTrue(caps['navigation_available'])  # legacy = switch_map or command
+        self.assertEqual(caps['topics']['switch_map']['subscribers'], 2)
+
+    def test_initialpose_subscriber_is_not_command_evidence(self):
+        """initialpose の subscriber は command 扱いしない (localization bridge が残す等)。
+
+        backend_status 未受信下で initialpose だけ subscriber がいても
+        command_available / navigation_available は False のまま。
+        """
+        caps = _caps(counts={'initialpose': 3})
+        self.assertTrue(caps['topics']['initialpose']['available'])
+        self.assertFalse(caps['command_available'])
+        self.assertFalse(caps['navigation_available'])
+        self.assertFalse(caps['switch_map_available'])
+
+    # ---- backend_status 受信済み (legacy を上書き) -----------------------------
+
+    def test_backend_ready_overrides_legacy_true(self):
+        """backend_status ready (alive) → subscriber ゼロでも navigation_available True。
+
+        switch_map_available は backend_ready の alias になる (#205 round 3 high #2)。
+        """
+        status = {'backend_type': 'nav2', 'backend_ready': True, 'reason': ''}
+        caps = _caps(backend_status=status, nav_alive=True)
+        self.assertTrue(caps['navigation_available'])
+        self.assertTrue(caps['switch_map_available'])
+        self.assertEqual(caps['backend_status'], status)
+
+    def test_backend_not_ready_overrides_legacy_command_subscriber(self):
+        """backend_status not-ready (alive) は command subscriber が残っていても勝つ。
+
+        #212 codex review high: backend_status path に乗ったら legacy false-enable を
+        起こさず navigation_available False。
+        """
+        status = {'backend_type': 'nav2', 'backend_ready': False, 'reason': 'Nav2 missing'}
+        caps = _caps(counts={'goal': 1, 'route': 1}, backend_status=status, nav_alive=True)
+        self.assertTrue(caps['command_available'])  # subscriber は存在する
+        self.assertFalse(caps['navigation_available'])  # が backend_ready=False が勝つ
+        self.assertFalse(caps['switch_map_available'])
+
+    def test_backend_seen_but_lost_is_explicit_unready(self):
+        """backend_status 受信済みだが lost (alive=False) → 明示 unready。
+
+        cache は ready=True を保持していても liveliness lost で False に倒れ、
+        command subscriber が残っていても navigation_available False (#212)。
+        """
+        status = {'backend_type': 'nav2', 'backend_ready': True, 'reason': ''}
+        caps = _caps(counts={'goal': 1}, backend_status=status, nav_alive=False)
+        self.assertFalse(caps['navigation_available'])
+        self.assertFalse(caps['switch_map_available'])
+        # 返却 backend_status は backend_ready False に上書きされている
+        self.assertFalse(caps['backend_status']['backend_ready'])
+        self.assertIn('liveliness', caps['backend_status']['reason'].lower())
+
+    # ---- localization は navigation と独立 -------------------------------------
+
+    def test_localization_status_is_independent(self):
+        """localization_status は navigation 判定に影響せず、独立 payload として出る。"""
+        loc = {'backend_type': 'amcl', 'backend_ready': True, 'reason': ''}
+        caps = _caps(counts={'goal': 1}, localization_status=loc, localization_alive=True)
+        # navigation は backend_status 未受信なので legacy (goal subscriber) のまま
+        self.assertTrue(caps['navigation_available'])
+        # localization は別 key で resolver を通った値
+        self.assertEqual(caps['localization_status'], loc)
+
+    def test_localization_lost_does_not_disable_navigation(self):
+        """localization が lost でも navigation 側は独立に評価される。"""
+        loc = {'backend_type': 'amcl', 'backend_ready': True, 'reason': ''}
+        caps = _caps(counts={'goal': 1}, localization_status=loc, localization_alive=False)
+        self.assertTrue(caps['navigation_available'])  # navigation は legacy のまま生きている
+        self.assertFalse(caps['localization_status']['backend_ready'])  # localization は unready
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 概要
`#199`（navigation endpoint / UI helper の自動テスト追加）のうち、**backend (endpoint + capabilities) 部分**を実装。Node を本物で起動せず、duck-typed node + Flask `test_client` で契約を pin する（既存 `test_api_save_pois_version_conflict.py` の方式を踏襲）。

## 追加テスト
### `test_get_navigation_capabilities.py`（9 ケース）
`get_navigation_capabilities` の **subscriber 数 → availability 統合契約**。`_resolve_backend_status_for_ui`（`@staticmethod`）を実物のまま使い、resolver 単体 test と endpoint test の中間ロジックを固定:
- backend_status 未受信 → command topic subscriber による legacy fallback
- `switch_map` / `initialpose` は command 扱いしない（initialpose は localization bridge が残すため除外）
- backend_status 受信済みは backend_ready が legacy を上書き（#212: command subscriber 残存でも false-enable しない）
- 受信済み + lost (alive=False) → 明示 unready
- localization_status は navigation と独立

### `test_api_nav_endpoints.py`（10 ケース）
- `/api/nav/switch-map`: body 非 dict / `map_name` 不在 / 空白 → 400、未知 map → 404、maps list 空 → membership check skip、正常時は strip 済 map_name を publish、publish helper の warning 透過
- `/api/mode`: `{'navigation': <capabilities>}` の透過
- `/api/nav/status`: status / target / robot_pose / robot_radius / navigation の同梱

## テスト
- pytest 直叩き: webui 全 6 ファイル 40 passed（既存 21 + 新規 19、既存無傷）
- `colcon test`（CMakeLists 登録経由）: jazzy / humble 両 distro で 0 failures

## 残タスク（別 PR）
`#199` の **frontend UI helper**（`updateNavControlsAvailability` / `requestNavigationMapSwitch` 等の DOM 依存テスト）は未着手。jsdom vs Playwright の方針が `#273` と共通で未決のため、本 PR では backend のみ。このため `Close` ではなく `refs #199`。
