### PR TITLE
test(webui): navigation frontend helper を nav-controls.js に分離 (Close #199)

### DIFF
--- a/mapoi_webui/tests/web/api-nav.test.js
+++ b/mapoi_webui/tests/web/api-nav.test.js
@@ -1,0 +1,54 @@
+// MapoiApi の navigation 系 fetch 契約 (#199)。
+// navSwitchMap / mode が叩く endpoint・method・body・戻り値を、global fetch を
+// stub して固定する。DOM 非依存なので default (node) 環境で回す。
+// backend 側の validation は test_api_nav_endpoints.py (#279) が pin 済で、ここは
+// client が「正しい URL に正しい payload を投げ、JSON をそのまま返す」ことだけを見る。
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as MapoiApi from '../../web/js/api.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete globalThis.fetch;
+});
+
+function mockFetch(payload) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    json: vi.fn().mockResolvedValue(payload),
+  });
+  globalThis.fetch = fetchMock;
+  return fetchMock;
+}
+
+describe('MapoiApi.navSwitchMap', () => {
+  it('POST /api/nav/switch-map に map_name を JSON body で送る', async () => {
+    const fetchMock = mockFetch({ ok: true });
+    const res = await MapoiApi.navSwitchMap('floor1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/nav/switch-map');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(opts.body)).toEqual({ map_name: 'floor1' });
+    expect(res).toEqual({ ok: true });
+  });
+
+  it('backend の warning/error 応答をそのまま透過する', async () => {
+    mockFetch({ warning: 'no subscriber' });
+    expect(await MapoiApi.navSwitchMap('floor1')).toEqual({ warning: 'no subscriber' });
+  });
+});
+
+describe('MapoiApi.mode', () => {
+  it('GET /api/mode を叩き JSON をそのまま返す', async () => {
+    const fetchMock = mockFetch({ mode: 'navigation' });
+    const res = await MapoiApi.mode();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/mode');
+    expect(opts).toBeUndefined(); // GET は options なし
+    expect(res).toEqual({ mode: 'navigation' });
+  });
+});

--- a/mapoi_webui/tests/web/nav-controls.test.js
+++ b/mapoi_webui/tests/web/nav-controls.test.js
@@ -1,0 +1,257 @@
+// @vitest-environment jsdom
+//
+// nav-controls.js (#199) の unit test。
+// - 純粋ヘルパ (resolveCapabilities / deriveNavControlsState / decideMapSwitchOutcome /
+//   initialSectionOpenStates) は DOM 非依存だが、applyNavControlsState を同じ file で
+//   検証するため jsdom 環境で回す。
+// - backend 側契約は #279 (test_get_navigation_capabilities.py) が pin 済。ここはその
+//   frontend 投影: backend_status 優先 / legacy subscriber fallback / localization 独立 3-state /
+//   navigation availability 表示 / map switch 分岐 / compact 初期 section を固める。
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as nav from '../../web/js/nav-controls.js';
+
+const {
+  resolveCapabilities,
+  deriveNavControlsState,
+  applyNavControlsState,
+  decideMapSwitchOutcome,
+  initialSectionOpenStates,
+} = nav;
+
+describe('resolveCapabilities (navigation payload の前回値保持)', () => {
+  it('incoming があればそれを採用する', () => {
+    const incoming = { navigation_available: true };
+    expect(resolveCapabilities(incoming, { navigation_available: false })).toBe(incoming);
+  });
+
+  it('incoming が無ければ previous を維持する (poll で navigation 欠落しても UI を保つ)', () => {
+    const previous = { navigation_available: true };
+    expect(resolveCapabilities(null, previous)).toBe(previous);
+    expect(resolveCapabilities(undefined, previous)).toBe(previous);
+  });
+
+  it('両方無ければ null', () => {
+    expect(resolveCapabilities(null, null)).toBeNull();
+    expect(resolveCapabilities(undefined, undefined)).toBeNull();
+  });
+});
+
+describe('deriveNavControlsState — navigation 操作 gate', () => {
+  it('backend_status があれば backend_ready をそのまま使う (subscriber 数より優先)', () => {
+    const ready = deriveNavControlsState({
+      backend_status: { backend_ready: true },
+      command_available: false, // subscriber は 0 でも backend_ready 優先
+    });
+    expect(ready.navOperationsEnabled).toBe(true);
+
+    const notReady = deriveNavControlsState({
+      backend_status: { backend_ready: false },
+      command_available: true, // subscriber がいても backend_ready=false が優先
+    });
+    expect(notReady.navOperationsEnabled).toBe(false);
+  });
+
+  it('backend_status 不在は command_available (subscriber 数) で代用する (後方互換)', () => {
+    expect(deriveNavControlsState({ command_available: true }).navOperationsEnabled).toBe(true);
+    expect(deriveNavControlsState({ command_available: false }).navOperationsEnabled).toBe(false);
+  });
+});
+
+describe('deriveNavControlsState — navigation availability 表示', () => {
+  it('navigation_available=true は connected 表示', () => {
+    const s = deriveNavControlsState({ navigation_available: true });
+    expect(s.navigationAvailable).toBe(true);
+    expect(s.navClass).toContain('navigation-available');
+    expect(s.navClass).not.toContain('navigation-unavailable');
+    expect(s.navLabel).toBe('Navigation connected');
+  });
+
+  it('navigation_available=false は unavailable 表示', () => {
+    const s = deriveNavControlsState({ navigation_available: false });
+    expect(s.navigationAvailable).toBe(false);
+    expect(s.navClass).toContain('navigation-unavailable');
+    expect(s.navLabel).toBe('Navigation unavailable');
+  });
+
+  it('backend_status からツールチップを組む (backend_type / backend_ready / reason)', () => {
+    const s = deriveNavControlsState({
+      backend_status: { backend_type: 'nav2', backend_ready: false, reason: 'lifecycle inactive' },
+    });
+    expect(s.navTooltip).toBe('backend_type: nav2\nbackend_ready: false\nreason: lifecycle inactive');
+  });
+
+  it('reason が無ければツールチップに reason 行を出さない', () => {
+    const s = deriveNavControlsState({ backend_status: { backend_type: 'nav2', backend_ready: true } });
+    expect(s.navTooltip).toBe('backend_type: nav2\nbackend_ready: true');
+  });
+
+  it('backend_status 不在時は topics の subscriber 数からツールチップを組む', () => {
+    const s = deriveNavControlsState({
+      topics: {
+        goal: { topic: 'mapoi/nav/goal', subscribers: 1 },
+        cancel: { topic: 'mapoi/nav/cancel', subscribers: 0 },
+      },
+    });
+    expect(s.navTooltip).toBe('mapoi/nav/goal: 1\nmapoi/nav/cancel: 0');
+  });
+});
+
+describe('deriveNavControlsState — localization は navigation と独立 (#209 3-state)', () => {
+  it('localization_status.backend_ready=true は connected', () => {
+    const s = deriveNavControlsState({ localization_status: { backend_ready: true, backend_type: 'amcl' } });
+    expect(s.localizationReady).toBe(true);
+    expect(s.locClass).toContain('navigation-available');
+    expect(s.locLabel).toBe('Localization connected');
+    expect(s.locTooltip).toBe('backend_type: amcl\nbackend_ready: true');
+  });
+
+  it('localization_status.backend_ready=false は unavailable', () => {
+    const s = deriveNavControlsState({ localization_status: { backend_ready: false } });
+    expect(s.localizationReady).toBe(false);
+    expect(s.locClass).toContain('navigation-unavailable');
+    expect(s.locLabel).toBe('Localization unavailable');
+  });
+
+  it('localization_status 不在は unknown (安全側で disable / topic 未受信メッセージ)', () => {
+    const s = deriveNavControlsState({ navigation_available: true });
+    expect(s.localizationReady).toBe(false);
+    expect(s.locClass).toContain('navigation-unknown');
+    expect(s.locLabel).toBe('Localization unknown');
+    expect(s.locTooltip).toBe('mapoi/localization/backend_status not received yet');
+  });
+
+  it('navigation ready でも localization は独立 (片方が他方を上書きしない)', () => {
+    const s = deriveNavControlsState({ backend_status: { backend_ready: true } });
+    expect(s.navOperationsEnabled).toBe(true);
+    expect(s.localizationReady).toBe(false); // localization_status 不在
+  });
+});
+
+describe('deriveNavControlsState — capabilities 不在', () => {
+  it('null/undefined でも安全な default を返す', () => {
+    for (const caps of [null, undefined, {}]) {
+      const s = deriveNavControlsState(caps);
+      expect(s.navOperationsEnabled).toBe(false);
+      expect(s.navigationAvailable).toBe(false);
+      expect(s.localizationReady).toBe(false);
+      expect(s.navLabel).toBe('Navigation unavailable');
+      expect(s.locLabel).toBe('Localization unknown');
+    }
+  });
+});
+
+describe('applyNavControlsState — DOM への適用 (jsdom)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="nav-body"></div>
+      <div id="navigation-availability"><span id="navigation-availability-text"></span></div>
+      <div id="localization-availability"><span id="localization-availability-text"></span></div>
+      <button id="btn-nav-go"></button>
+      <button id="btn-nav-run"></button>
+      <button id="btn-nav-pause"></button>
+      <button id="btn-nav-resume"></button>
+      <button id="btn-nav-stop"></button>
+      <button id="btn-nav-setpose"></button>
+      <select id="nav-initialpose-select"></select>
+      <select id="navigation-map-select"></select>
+    `;
+  });
+
+  const operationButtonIds = [
+    'btn-nav-go', 'btn-nav-run', 'btn-nav-pause', 'btn-nav-resume', 'btn-nav-stop',
+  ];
+
+  it('available + ready 状態は操作 UI を enable し connected 表示にする', () => {
+    const state = deriveNavControlsState({
+      backend_status: { backend_ready: true, backend_type: 'nav2' },
+      navigation_available: true,
+      localization_status: { backend_ready: true, backend_type: 'amcl' },
+    });
+    applyNavControlsState(state, document);
+
+    operationButtonIds.forEach((id) => {
+      expect(document.getElementById(id).disabled).toBe(false);
+    });
+    expect(document.getElementById('navigation-map-select').disabled).toBe(false);
+    expect(document.getElementById('btn-nav-setpose').disabled).toBe(false);
+    expect(document.getElementById('nav-initialpose-select').disabled).toBe(false);
+    expect(document.getElementById('nav-body').classList.contains('navigation-unavailable-state')).toBe(false);
+    expect(document.getElementById('navigation-availability').className).toContain('navigation-available');
+    expect(document.getElementById('navigation-availability-text').textContent).toBe('Navigation connected');
+    expect(document.getElementById('navigation-availability').title)
+      .toBe('backend_type: nav2\nbackend_ready: true');
+  });
+
+  it('backend not ready は navigation 操作 UI を disable する', () => {
+    const state = deriveNavControlsState({
+      backend_status: { backend_ready: false },
+      navigation_available: false,
+    });
+    applyNavControlsState(state, document);
+
+    operationButtonIds.forEach((id) => {
+      expect(document.getElementById(id).disabled).toBe(true);
+    });
+    expect(document.getElementById('navigation-map-select').disabled).toBe(true);
+    expect(document.getElementById('nav-body').classList.contains('navigation-unavailable-state')).toBe(true);
+    expect(document.getElementById('navigation-availability-text').textContent).toBe('Navigation unavailable');
+  });
+
+  it('legacy fallback (command_available) でも操作 UI を enable する', () => {
+    const state = deriveNavControlsState({ command_available: true });
+    applyNavControlsState(state, document);
+    operationButtonIds.forEach((id) => {
+      expect(document.getElementById(id).disabled).toBe(false);
+    });
+  });
+
+  it('Set Initial Pose 系は localization 側で独立に gate する', () => {
+    // navigation ready だが localization 不在 → 操作ボタンは enable、setpose 系は disable。
+    const state = deriveNavControlsState({ backend_status: { backend_ready: true } });
+    applyNavControlsState(state, document);
+    expect(document.getElementById('btn-nav-go').disabled).toBe(false);
+    expect(document.getElementById('btn-nav-setpose').disabled).toBe(true);
+    expect(document.getElementById('nav-initialpose-select').disabled).toBe(true);
+    expect(document.getElementById('localization-availability-text').textContent).toBe('Localization unknown');
+    expect(document.getElementById('localization-availability').className).toContain('navigation-unknown');
+  });
+
+  it('一部 DOM が欠けていても例外を投げない', () => {
+    document.body.innerHTML = '<div id="nav-body"></div>'; // 他要素なし
+    const state = deriveNavControlsState({ navigation_available: true });
+    expect(() => applyNavControlsState(state, document)).not.toThrow();
+    expect(document.getElementById('nav-body').classList.contains('navigation-unavailable-state')).toBe(false);
+  });
+});
+
+describe('decideMapSwitchOutcome — map switch 応答の後続アクション', () => {
+  it('error は両 select を巻き戻し "Map switch failed:" を前置する', () => {
+    expect(decideMapSwitchOutcome({ error: 'map not found' }))
+      .toEqual({ kind: 'error', message: 'Map switch failed: map not found', revert: 'both' });
+  });
+
+  it('warning は navigation 側 select のみ巻き戻す', () => {
+    expect(decideMapSwitchOutcome({ warning: 'no subscriber' }))
+      .toEqual({ kind: 'warning', message: 'no subscriber', revert: 'nav' });
+  });
+
+  it('error は warning より優先する', () => {
+    expect(decideMapSwitchOutcome({ error: 'boom', warning: 'w' }).kind).toBe('error');
+  });
+
+  it('error/warning が無ければ switching として受理し巻き戻さない', () => {
+    expect(decideMapSwitchOutcome({})).toEqual({ kind: 'switching', message: '', revert: 'none' });
+    expect(decideMapSwitchOutcome(null)).toEqual({ kind: 'switching', message: '', revert: 'none' });
+  });
+});
+
+describe('initialSectionOpenStates — compact 初期表示', () => {
+  it('desktop は Navigation/Routes/POIs を開き Tags を閉じる', () => {
+    expect(initialSectionOpenStates(false)).toEqual({ nav: true, route: true, poi: true, tag: false });
+  });
+
+  it('compact は Navigation のみ開き Routes/POIs/Tags を閉じる', () => {
+    expect(initialSectionOpenStates(true)).toEqual({ nav: true, route: false, poi: false, tag: false });
+  });
+});

--- a/mapoi_webui/tests/web/package-lock.json
+++ b/mapoi_webui/tests/web/package-lock.json
@@ -9,7 +9,212 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
+        "jsdom": "^29.1.1",
         "vitest": "^2.1.8"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -401,6 +606,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -890,6 +1113,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -927,6 +1160,34 @@
         "node": ">= 16"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -945,6 +1206,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -953,6 +1221,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1036,12 +1317,83 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1052,6 +1404,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1077,6 +1436,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -1132,6 +1504,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -1177,6 +1569,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1205,6 +1610,13 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1250,6 +1662,62 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/vite": {
@@ -1401,6 +1869,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1417,6 +1933,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/mapoi_webui/tests/web/package.json
+++ b/mapoi_webui/tests/web/package.json
@@ -9,6 +9,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "jsdom": "^29.1.1",
     "vitest": "^2.1.8"
   }
 }

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -237,6 +237,9 @@
   <script src="/js/poi-editor.js"></script>
   <script src="/js/route-editor.js"></script>
   <script src="/js/sidebar-resizer.js"></script>
+  <!-- nav-controls.js は MapoiNavControls を window に attach する pure/DOM helper 群 (#199)。
+       app.js より前に読み込む (updateNavControlsAvailability / map switch / 初期 section で参照)。 -->
+  <script src="/js/nav-controls.js"></script>
   <script src="/js/app.js"></script>
 </body>
 </html>

--- a/mapoi_webui/web/js/api.js
+++ b/mapoi_webui/web/js/api.js
@@ -143,3 +143,10 @@ const MapoiApi = {
     return res.json();
   },
 };
+
+// Browser は <script> の global として `MapoiApi` を参照する。
+// Node (vitest) からは `module.exports` 経由で require し、fetch 契約を検証する
+// (#199 / geometry.js・poi-interactions.js と同じ #129 dual export パターン)。
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = MapoiApi;
+}

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -14,10 +14,7 @@
   const navInitialPoseSelect = document.getElementById('nav-initialpose-select');
   const navStatusDot = document.getElementById('nav-status-dot');
   const navStatusText = document.getElementById('nav-status-text');
-  const navigationAvailability = document.getElementById('navigation-availability');
-  const navigationAvailabilityText = document.getElementById('navigation-availability-text');
-  const localizationAvailability = document.getElementById('localization-availability');
-  const localizationAvailabilityText = document.getElementById('localization-availability-text');
+  // navigation/localization availability 表示は nav-controls.js が id 解決して適用する (#199)。
   const navigationWarning = document.getElementById('navigation-warning');
   const compactMediaQuery = window.matchMedia('(max-width: 768px)');
   let currentMap = '';
@@ -442,9 +439,11 @@
   }
 
   const compactInitial = compactMediaQuery.matches;
-  const routeToggle = setupSectionToggle('btn-route-toggle', document.getElementById('route-body'), !compactInitial);
-  setupSectionToggle('btn-poi-toggle', document.getElementById('poi-body'), !compactInitial);
-  const tagToggle = setupSectionToggle('btn-tag-toggle', document.getElementById('tag-body'), false);
+  // compact viewport 初期表示で開く section は nav-controls.js に集約 (#199)。
+  const initialSections = MapoiNavControls.initialSectionOpenStates(compactInitial);
+  const routeToggle = setupSectionToggle('btn-route-toggle', document.getElementById('route-body'), initialSections.route);
+  setupSectionToggle('btn-poi-toggle', document.getElementById('poi-body'), initialSections.poi);
+  const tagToggle = setupSectionToggle('btn-tag-toggle', document.getElementById('tag-body'), initialSections.tag);
   if (typeof compactMediaQuery.addEventListener === 'function') {
     compactMediaQuery.addEventListener('change', refreshResponsiveLayout);
   }
@@ -538,96 +537,14 @@
   }
 
   function updateNavControlsAvailability(navigation) {
-    currentNavigationCapabilities = navigation || currentNavigationCapabilities;
-    const capabilities = currentNavigationCapabilities || {};
-    const backendStatus = capabilities.backend_status || null;
-    const localizationStatus = capabilities.localization_status || null;
-    const commandAvailable = !!capabilities.command_available;
-    const navigationAvailable = !!capabilities.navigation_available;
-    // backend_status が届いている場合 (#198) は backend_ready をそのまま操作 enable に使う。
-    // Minimal contract (#205 review) なので per-capability gate は持たず、navigation 操作 UI 全体を
-    // 一括 gate する。後方互換: backend_status 不在は subscriber 数 (command_available) で代用。
-    const navOperationsEnabled = backendStatus
-      ? !!backendStatus.backend_ready
-      : commandAvailable;
-    // localization_status は #209 で追加された別契約。Set Initial Pose UI は localization
-    // bridge の backend_ready で gate する。topic 不在 (= bridge 未起動 / editor 構成) は
-    // 安全側に disable し、operator が「ready 表示なし」と判断できるようにする。
-    const localizationAvailable = !!(localizationStatus && localizationStatus.backend_ready);
-    const navBody = document.getElementById('nav-body');
-    if (navBody) {
-      navBody.classList.toggle('navigation-unavailable-state', !navigationAvailable);
-    }
-
-    if (navigationAvailability && navigationAvailabilityText) {
-      navigationAvailability.className = 'navigation-availability '
-        + (navigationAvailable ? 'navigation-available' : 'navigation-unavailable');
-      navigationAvailabilityText.textContent = navigationAvailable
-        ? 'Navigation connected'
-        : 'Navigation unavailable';
-      const tooltipLines = [];
-      if (backendStatus) {
-        tooltipLines.push(`backend_type: ${backendStatus.backend_type || 'unknown'}`);
-        tooltipLines.push(`backend_ready: ${backendStatus.backend_ready}`);
-        if (backendStatus.reason) {
-          tooltipLines.push(`reason: ${backendStatus.reason}`);
-        }
-      } else {
-        const topics = capabilities.topics || {};
-        Object.values(topics).forEach((topic) => {
-          tooltipLines.push(`${topic.topic}: ${topic.subscribers}`);
-        });
-      }
-      navigationAvailability.title = tooltipLines.join('\n');
-    }
-
-    if (localizationAvailability && localizationAvailabilityText) {
-      // navigation 用の class 名 (.navigation-available/.navigation-unavailable) をそのまま流用して
-      // dot color の CSS を共有する。状態としては「localization bridge ready / unavailable / unknown」。
-      let cls = 'navigation-availability ';
-      let label;
-      if (!localizationStatus) {
-        cls += 'navigation-unknown';
-        label = 'Localization unknown';
-      } else if (localizationStatus.backend_ready) {
-        cls += 'navigation-available';
-        label = 'Localization connected';
-      } else {
-        cls += 'navigation-unavailable';
-        label = 'Localization unavailable';
-      }
-      localizationAvailability.className = cls;
-      localizationAvailabilityText.textContent = label;
-      const tooltipLines = [];
-      if (localizationStatus) {
-        tooltipLines.push(`backend_type: ${localizationStatus.backend_type || 'unknown'}`);
-        tooltipLines.push(`backend_ready: ${localizationStatus.backend_ready}`);
-        if (localizationStatus.reason) {
-          tooltipLines.push(`reason: ${localizationStatus.reason}`);
-        }
-      } else {
-        tooltipLines.push('mapoi/localization/backend_status not received yet');
-      }
-      localizationAvailability.title = tooltipLines.join('\n');
-    }
-
-    [
-      document.getElementById('btn-nav-go'),
-      document.getElementById('btn-nav-run'),
-      document.getElementById('btn-nav-pause'),
-      document.getElementById('btn-nav-resume'),
-      document.getElementById('btn-nav-stop'),
-    ].forEach((btn) => {
-      if (btn) btn.disabled = !navOperationsEnabled;
-    });
-    // Set Initial Pose は localization 側 (#209)。Initial Pose POI 選択も同 gate。
-    const initialPoseBtn = document.getElementById('btn-nav-setpose');
-    if (initialPoseBtn) initialPoseBtn.disabled = !localizationAvailable;
-    if (navInitialPoseSelect) navInitialPoseSelect.disabled = !localizationAvailable;
-
-    // Operator map switch も bridge を経由するため backend_ready で gate する。
-    // Editor 側の map dropdown (header の Map:) は `/api/maps/select` で bridge 不問。
-    if (navigationMapSelect) navigationMapSelect.disabled = !navOperationsEnabled;
+    // 状態派生・DOM 適用は nav-controls.js に切り出し済 (#199)。ここは closure state
+    // (currentNavigationCapabilities) の維持と responsive 再計算だけを担う。
+    currentNavigationCapabilities = MapoiNavControls.resolveCapabilities(
+      navigation,
+      currentNavigationCapabilities,
+    );
+    const state = MapoiNavControls.deriveNavControlsState(currentNavigationCapabilities);
+    MapoiNavControls.applyNavControlsState(state, document);
     refreshResponsiveLayout();
   }
 
@@ -646,16 +563,19 @@
     try {
       setNavigationWarning('');
       const result = await MapoiApi.navSwitchMap(mapName);
-      if (result.error) {
-        throw new Error(result.error);
-      }
-      if (result.warning) {
-        setNavigationWarning(result.warning);
+      // error / warning / switching の分岐は nav-controls.js の純関数に集約 (#199)。
+      const outcome = MapoiNavControls.decideMapSwitchOutcome(result);
+      if (outcome.kind !== 'switching') {
+        setNavigationWarning(outcome.message);
         if (navigationMapSelect) navigationMapSelect.value = currentMap;
+        // error は header の Map: も巻き戻す (両 select)。warning は navigation 側のみ。
+        if (outcome.revert === 'both' && mapSelect) mapSelect.value = currentMap;
         return;
       }
       updateNavStatus('map_switching', mapName);
     } catch (e) {
+      // fetch 自体の失敗 (network 等)。result.error 由来のメッセージ整形は
+      // decideMapSwitchOutcome 側と揃えてある。
       setNavigationWarning('Map switch failed: ' + e.message);
       if (navigationMapSelect) navigationMapSelect.value = currentMap;
       if (mapSelect) mapSelect.value = currentMap;
@@ -785,7 +705,7 @@
     updateNavStatus('canceled', '');
   });
 
-  const navToggle = setupSectionToggle('btn-nav-toggle', document.getElementById('nav-body'));
+  const navToggle = setupSectionToggle('btn-nav-toggle', document.getElementById('nav-body'), initialSections.nav);
   startNavStatusPolling();
 
   // --- 編集モード時のセクション折りたたみ (#240) ---

--- a/mapoi_webui/web/js/nav-controls.js
+++ b/mapoi_webui/web/js/nav-controls.js
@@ -1,0 +1,235 @@
+/**
+ * Navigation 操作 UI の状態派生 / DOM 適用ヘルパ (#199 frontend)。
+ *
+ * app.js の `updateNavControlsAvailability` / `requestNavigationMapSwitch` /
+ * mobile initial state から「純粋な状態派生・分岐ロジック」と「DOM 適用」を切り出し、
+ * 単体テスト (mapoi_webui/tests/web/nav-controls.test.js) で回帰検知できるようにする。
+ * backend 側の契約は #279 (test_get_navigation_capabilities.py) で固めており、
+ * ここはその frontend 投影 (backend_status 優先 / legacy subscriber fallback /
+ * localization 独立 3-state) を対象とする。
+ *
+ * Browser からは `MapoiNavControls.*` のグローバルとして使い、
+ * Node (vitest) からは `module.exports` 経由で import する dual export 形式
+ * (api.js / poi-interactions.js と同じ #129 パターン)。
+ * 純粋ヘルパ (resolveCapabilities / deriveNavControlsState / decideMapSwitchOutcome /
+ * initialSectionOpenStates) は DOM / window 非依存。applyNavControlsState のみ document を取る。
+ */
+(function () {
+  'use strict';
+
+  /**
+   * navigation payload の「前回値保持」契約 (#199)。
+   * pollNavStatus が navigation を持たない応答を返した時、直前の capabilities を
+   * 維持して UI をちらつかせない。app.js の `navigation || currentCapabilities` 相当。
+   *
+   * @param {object|null} incoming  今回届いた navigation payload
+   * @param {object|null} previous  直前まで保持していた capabilities
+   * @returns {object|null} 採用する capabilities
+   */
+  function resolveCapabilities(incoming, previous) {
+    return incoming || previous || null;
+  }
+
+  function buildBackendTooltip(status, topics) {
+    const lines = [];
+    if (status) {
+      lines.push(`backend_type: ${status.backend_type || 'unknown'}`);
+      lines.push(`backend_ready: ${status.backend_ready}`);
+      if (status.reason) {
+        lines.push(`reason: ${status.reason}`);
+      }
+    } else {
+      const t = topics || {};
+      Object.values(t).forEach((topic) => {
+        lines.push(`${topic.topic}: ${topic.subscribers}`);
+      });
+    }
+    return lines.join('\n');
+  }
+
+  function buildLocalizationTooltip(status) {
+    const lines = [];
+    if (status) {
+      lines.push(`backend_type: ${status.backend_type || 'unknown'}`);
+      lines.push(`backend_ready: ${status.backend_ready}`);
+      if (status.reason) {
+        lines.push(`reason: ${status.reason}`);
+      }
+    } else {
+      lines.push('mapoi/localization/backend_status not received yet');
+    }
+    return lines.join('\n');
+  }
+
+  /**
+   * capabilities から navigation 操作 UI の表示状態を派生する純関数 (#199)。
+   *
+   * gate ルール (app.js の minimal contract / #205 review を踏襲):
+   * - navOperationsEnabled: backend_status があれば backend_ready、無ければ
+   *   command_available (subscriber 数) で代用 (後方互換)。navigation 操作 UI を一括 gate。
+   * - localizationReady: localization_status.backend_ready のみで判定 (#209, navigation と独立)。
+   * - navigationAvailable: capabilities.navigation_available をそのまま表示色に使う。
+   *
+   * @param {object|null} capabilities
+   * @returns {{
+   *   navOperationsEnabled: boolean, navigationAvailable: boolean, localizationReady: boolean,
+   *   navClass: string, navLabel: string, navTooltip: string,
+   *   locClass: string, locLabel: string, locTooltip: string,
+   * }}
+   */
+  function deriveNavControlsState(capabilities) {
+    const caps = capabilities || {};
+    const backendStatus = caps.backend_status || null;
+    const localizationStatus = caps.localization_status || null;
+    const commandAvailable = !!caps.command_available;
+    const navigationAvailable = !!caps.navigation_available;
+
+    const navOperationsEnabled = backendStatus
+      ? !!backendStatus.backend_ready
+      : commandAvailable;
+    const localizationReady = !!(localizationStatus && localizationStatus.backend_ready);
+
+    const navClass = 'navigation-availability '
+      + (navigationAvailable ? 'navigation-available' : 'navigation-unavailable');
+    const navLabel = navigationAvailable ? 'Navigation connected' : 'Navigation unavailable';
+    const navTooltip = buildBackendTooltip(backendStatus, caps.topics);
+
+    // localization は navigation の class 名を流用しつつ unknown を含む 3-state。
+    let locClass = 'navigation-availability ';
+    let locLabel;
+    if (!localizationStatus) {
+      locClass += 'navigation-unknown';
+      locLabel = 'Localization unknown';
+    } else if (localizationStatus.backend_ready) {
+      locClass += 'navigation-available';
+      locLabel = 'Localization connected';
+    } else {
+      locClass += 'navigation-unavailable';
+      locLabel = 'Localization unavailable';
+    }
+    const locTooltip = buildLocalizationTooltip(localizationStatus);
+
+    return {
+      navOperationsEnabled,
+      navigationAvailable,
+      localizationReady,
+      navClass,
+      navLabel,
+      navTooltip,
+      locClass,
+      locLabel,
+      locTooltip,
+    };
+  }
+
+  // navOperationsEnabled で一括 enable/disable する操作ボタン群。
+  const NAV_OPERATION_BUTTON_IDS = [
+    'btn-nav-go',
+    'btn-nav-run',
+    'btn-nav-pause',
+    'btn-nav-resume',
+    'btn-nav-stop',
+  ];
+
+  /**
+   * deriveNavControlsState の結果を DOM へ適用する (#199)。
+   * document を引数に取り、jsdom 上で最小 DOM を組んで検証できるようにする。
+   *
+   * @param {ReturnType<typeof deriveNavControlsState>} state
+   * @param {Document} doc
+   */
+  function applyNavControlsState(state, doc) {
+    const d = doc || (typeof document !== 'undefined' ? document : null);
+    if (!d) return;
+
+    const navBody = d.getElementById('nav-body');
+    if (navBody) {
+      navBody.classList.toggle('navigation-unavailable-state', !state.navigationAvailable);
+    }
+
+    const navAvail = d.getElementById('navigation-availability');
+    const navAvailText = d.getElementById('navigation-availability-text');
+    if (navAvail && navAvailText) {
+      navAvail.className = state.navClass;
+      navAvailText.textContent = state.navLabel;
+      navAvail.title = state.navTooltip;
+    }
+
+    const locAvail = d.getElementById('localization-availability');
+    const locAvailText = d.getElementById('localization-availability-text');
+    if (locAvail && locAvailText) {
+      locAvail.className = state.locClass;
+      locAvailText.textContent = state.locLabel;
+      locAvail.title = state.locTooltip;
+    }
+
+    NAV_OPERATION_BUTTON_IDS.forEach((id) => {
+      const btn = d.getElementById(id);
+      if (btn) btn.disabled = !state.navOperationsEnabled;
+    });
+
+    // Set Initial Pose 系は localization 側 (#209) で gate。
+    const initialPoseBtn = d.getElementById('btn-nav-setpose');
+    if (initialPoseBtn) initialPoseBtn.disabled = !state.localizationReady;
+    const initialPoseSelect = d.getElementById('nav-initialpose-select');
+    if (initialPoseSelect) initialPoseSelect.disabled = !state.localizationReady;
+
+    // Operator map switch も bridge 経由なので navigation 操作 gate に従う。
+    const navMapSelect = d.getElementById('navigation-map-select');
+    if (navMapSelect) navMapSelect.disabled = !state.navOperationsEnabled;
+  }
+
+  /**
+   * navSwitchMap の応答から後続アクションを決める純関数 (#199)。
+   * - error: warning 表示 + 両 select を current map に戻す
+   * - warning: warning 表示 + navigation 側 select のみ戻す (header の Map: は据え置き)
+   * - switching: 受理。status を map_switching に進める
+   *
+   * @param {{error?: string, warning?: string}|null} result
+   * @returns {{kind: 'error'|'warning'|'switching', message: string, revert: 'both'|'nav'|'none'}}
+   */
+  function decideMapSwitchOutcome(result) {
+    const r = result || {};
+    if (r.error) {
+      return { kind: 'error', message: 'Map switch failed: ' + r.error, revert: 'both' };
+    }
+    if (r.warning) {
+      return { kind: 'warning', message: r.warning, revert: 'nav' };
+    }
+    return { kind: 'switching', message: '', revert: 'none' };
+  }
+
+  /**
+   * compact viewport 初期表示でどの section を開くか (#199)。
+   * - Navigation: 常に open (操作系は最優先で見せる)
+   * - Routes / POIs: desktop は open、compact は閉じて地図領域を確保
+   * - Tags: 常に閉じる (編集時のみ開く副次 UI)
+   *
+   * @param {boolean} isCompact compactMediaQuery.matches
+   * @returns {{nav: boolean, route: boolean, poi: boolean, tag: boolean}}
+   */
+  function initialSectionOpenStates(isCompact) {
+    return {
+      nav: true,
+      route: !isCompact,
+      poi: !isCompact,
+      tag: false,
+    };
+  }
+
+  const api = {
+    resolveCapabilities,
+    deriveNavControlsState,
+    applyNavControlsState,
+    decideMapSwitchOutcome,
+    initialSectionOpenStates,
+  };
+
+  if (typeof window !== 'undefined') {
+    window.MapoiNavControls = window.MapoiNavControls || {};
+    Object.assign(window.MapoiNavControls, api);
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+}());


### PR DESCRIPTION
## 概要

#199 の frontend 分。`app.js` の navigation 操作 UI ロジックを純粋ヘルパ + DOM 適用に切り出し、jsdom で unit test 可能にする。backend 側 (`get_navigation_capabilities` / endpoint validation) は #279 で pin 済で、本 PR はその **frontend 投影** を固める。

これで #199 の完了条件 (backend validation/availability regression test + frontend helper の DOM state unit test + #197 review の test gap 解消) が揃うため **Close #199**。

## 変更

- **`web/js/nav-controls.js` (新規, dual export)** — `app.js` から抽出:
  - `resolveCapabilities` — poll で navigation 欠落時の前回値保持
  - `deriveNavControlsState` — backend_status 優先 / legacy subscriber fallback / localization 独立 3-state / availability 表示・tooltip 派生 (pure)
  - `applyNavControlsState` — 派生状態を id 解決で DOM へ適用 (jsdom 検証対象)
  - `decideMapSwitchOutcome` — map switch 応答の error/warning/switching 分岐 (pure)
  - `initialSectionOpenStates` — compact 初期 section (nav 常時 open / route・poi=`!compact` / tag closed)
- **`app.js`** — `updateNavControlsAvailability` / `requestNavigationMapSwitch` / mobile 初期 section を委譲化 (挙動保存)。未使用になった availability 系 ref を整理
- **`api.js`** — dual export 追加 (`navSwitchMap` / `mode` の fetch 契約テスト用)
- **`index.html`** — `nav-controls.js` を `app.js` の前に読込 (`install(DIRECTORY web)` で自動 install)
- **tests** — `nav-controls.test.js` (jsdom, 26) / `api-nav.test.js` (node, 3)
- **jsdom** を devDependency に追加 (vitest の per-file `@vitest-environment jsdom` で DOM テストのみ jsdom、純粋テストは node のまま)

## テスト

- `npm ci` → `npm test`: **vitest 96 passed** (新規 29 / 既存 67 維持)
- `node --check` 3 js OK

## 挙動保存メモ

- map switch の error メッセージ (`Map switch failed: ` + result.error) と revert 範囲 (error=両 select / warning=navigation 側のみ) は従来と一致。`catch` は network 失敗のみ担当
- availability 表示は closure ref を id 解決に置換 (同一 id) しただけで等価

Close #199