### PR TITLE
fix(webui): switch-map の非文字列 map_name を 400 で弾く (refs #199)

### DIFF
--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -661,9 +661,13 @@ class MapoiWebNode(Node):
         @app.route('/api/nav/switch-map', methods=['POST'])
         def api_nav_switch_map():
             data = request.get_json()
-            if not isinstance(data, dict) or 'map_name' not in data:
+            # map_name は文字列必須。非文字列 (null / 数値 / list 等) を str() で
+            # coerce すると `null` が literal 'None' になり、maps_path 未設定時の
+            # membership skip 経路でそのまま publish される潜在バグになる。別 client
+            # からの POST 保険として、型不正は coerce せず 400 で弾く (#199 follow-up)。
+            if not isinstance(data, dict) or not isinstance(data.get('map_name'), str):
                 return jsonify({'error': 'map_name required'}), 400
-            map_name = str(data['map_name']).strip()
+            map_name = data['map_name'].strip()
             if not map_name:
                 return jsonify({'error': 'map_name required'}), 400
             maps = node.get_maps_list()

--- a/mapoi_webui/test/test_api_nav_endpoints.py
+++ b/mapoi_webui/test/test_api_nav_endpoints.py
@@ -102,7 +102,7 @@ class TestApiNavSwitchMap(unittest.TestCase):
         `null` が literal 'None'、数値が '123' になり、maps_path 未設定時の
         membership skip 経路でそのまま publish される潜在バグがあった。
         """
-        for bad in (None, 123, 1.5, True, ['mapA'], {'name': 'mapA'}):
+        for bad in (None, 123, 1.5, True, False, ['mapA'], {'name': 'mapA'}):
             node = _FakeNode(maps=[])  # membership skip 経路でも publish させない
             resp = _client(node).post('/api/nav/switch-map', json={'map_name': bad})
             self.assertEqual(

--- a/mapoi_webui/test/test_api_nav_endpoints.py
+++ b/mapoi_webui/test/test_api_nav_endpoints.py
@@ -92,7 +92,24 @@ class TestApiNavSwitchMap(unittest.TestCase):
         node = _FakeNode(maps=['mapA'])
         resp = _client(node).post('/api/nav/switch-map', json={'map_name': '   '})
         self.assertEqual(resp.status_code, 400, resp.get_data(as_text=True))
+        self.assertIn('map_name', resp.get_json().get('error', ''))
         self.assertEqual(node.published, [])
+
+    def test_non_string_map_name_returns_400(self):
+        """非文字列 map_name は coerce せず 400 で弾く (#199 follow-up)。
+
+        旧実装は `str(data['map_name']).strip()` で coerce していたため、
+        `null` が literal 'None'、数値が '123' になり、maps_path 未設定時の
+        membership skip 経路でそのまま publish される潜在バグがあった。
+        """
+        for bad in (None, 123, 1.5, True, ['mapA'], {'name': 'mapA'}):
+            node = _FakeNode(maps=[])  # membership skip 経路でも publish させない
+            resp = _client(node).post('/api/nav/switch-map', json={'map_name': bad})
+            self.assertEqual(
+                resp.status_code, 400,
+                f'map_name={bad!r}: {resp.get_data(as_text=True)}')
+            self.assertIn('map_name', resp.get_json().get('error', ''))
+            self.assertEqual(node.published, [], f'map_name={bad!r} を publish した')
 
     def test_unknown_map_returns_404(self):
         node = _FakeNode(maps=['mapA', 'mapB'])


### PR DESCRIPTION
## 概要

PR #280 の Cursor review follow-up。`/api/nav/switch-map` の validation を硬化する。

旧実装は `map_name = str(data['map_name']).strip()` で**非文字列を coerce** していたため、潜在バグがあった:

- `{"map_name": null}` → `str(None)` = `'None'` → 空でないので通過
- `{"map_name": 123}` → `'123'`

`maps_path` 未設定 (= `get_maps_list()` が空) の時は membership check が skip されるため、上記の coerce 済み文字列 (`'None'` 等) が **そのまま `mapoi/nav/switch_map` に publish** されてしまう。frontend は常に `select.value` (文字列) を送るので実害は限定的だが、エンドポイントは別 client からの POST も想定している (POI validation の同様コメント参照)。

## 変更

- **handler**: `map_name` を `isinstance(str)` で必須化。非文字列は coerce せず `400 map_name required` で reject。`null` / 数値 / bool / list / dict はすべて 400
- **test** (`test_api_nav_endpoints.py`):
  - `test_non_string_map_name_returns_400` — `None` / `123` / `1.5` / `True` / `list` / `dict` を網羅し、400 かつ publish していないことを確認
  - `test_whitespace_map_name_returns_400` — error メッセージに `map_name` を含む assert を追加 (他ケースと揃えて硬化)

## テスト

- webui backend pytest **41 passed** (humble)。Python のみの変更で C++ なしのため単一 distro で十分
- 旧コードでは新テスト (`None`→`'None'` publish 等) が fail することを確認済 (= fix を確実にガード)

## 挙動保存

既存ケース (非 dict body / map_name 不在 / whitespace / unknown map 404 / 正常 publish / strip / 空 maps skip / warning 透過) はすべて従来通り 9 件 green。