### PR TITLE
test(webui): Leaflet 直結部と全 js 200 配信を Playwright smoke 化 (#284)

### DIFF
--- a/.github/workflows/consistency-check.yml
+++ b/.github/workflows/consistency-check.yml
@@ -49,3 +49,40 @@ jobs:
       - name: Run vitest
         run: npm test
         working-directory: mapoi_webui/tests/web
+
+  webui_e2e:
+    # jsdom 不可の Leaflet 直結部 + 全 js 200 配信を headless chromium で smoke (#284)。
+    # 配信は ROS 非依存の Python モックサーバ (e2e/server/mock_server.py)。GL/GPU 不要。
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: mapoi_webui/tests/web/package-lock.json
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: mapoi_webui/tests/web
+
+      - name: Install Playwright browser (chromium)
+        run: npx playwright install --with-deps chromium
+        working-directory: mapoi_webui/tests/web
+
+      - name: Run Playwright e2e smoke
+        run: npm run test:e2e
+        working-directory: mapoi_webui/tests/web
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: mapoi_webui/tests/web/playwright-report/
+          retention-days: 7

--- a/.github/workflows/consistency-check.yml
+++ b/.github/workflows/consistency-check.yml
@@ -54,6 +54,7 @@ jobs:
     # jsdom 不可の Leaflet 直結部 + 全 js 200 配信を headless chromium で smoke (#284)。
     # 配信は ROS 非依存の Python モックサーバ (e2e/server/mock_server.py)。GL/GPU 不要。
     runs-on: ubuntu-latest
+    timeout-minutes: 15  # SSE 常時接続 / install のハング保険
     steps:
       - uses: actions/checkout@v4
 
@@ -80,7 +81,7 @@ jobs:
         working-directory: mapoi_webui/tests/web
 
       - name: Upload Playwright report
-        if: ${{ !cancelled() }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report

--- a/mapoi_webui/tests/web/.gitignore
+++ b/mapoi_webui/tests/web/.gitignore
@@ -1,1 +1,7 @@
 node_modules/
+
+# Playwright e2e (#284) の生成物
+test-results/
+playwright-report/
+blob-report/
+.last-run.json

--- a/mapoi_webui/tests/web/e2e/README.md
+++ b/mapoi_webui/tests/web/e2e/README.md
@@ -1,0 +1,47 @@
+# mapoi_webui Playwright e2e (browser smoke)
+
+jsdom (vitest) では原理的に検証できない **Leaflet 直結部**と「**全 js 200 配信**」を、
+headless chromium で smoke する層 (#284, #273 follow-up)。既存の vitest unit
+(`../*.test.js`) とは別レイヤーで、テストファイルは `*.e2e.js`。
+
+## 何を検証するか
+
+- `all-js-200.e2e.js` — A: HTML の `<script>` 列挙 ⇔ `web/js/` 実ファイルの双方向整合、
+  実ロードでの js/css 404 ゼロ、全 helper の global 定義 (「200 だが未定義」検知)。
+- `poi-drag.e2e.js` — B: 選択中 POI marker だけ draggable (`leaflet-marker-draggable`)、
+  ドラッグで dirty 化、route 編集中はドラッグ不可・Cancel で復帰。
+- `yaw-handle.e2e.js` — C: 選択中 wedge POI に yaw ハンドル 1 個 / disc では無し、
+  ハンドル drag で矢印 rotation が追従し dirty 化。
+- `section-collapse.e2e.js` — D: 編集フォーム開で nav/tag/route と poi-list が畳まれ、
+  閉じると「元の開閉状態」へ復元 (全開ではない)。
+
+## サーバ構成 (ROS 非依存)
+
+`server/mock_server.py` (Python 標準ライブラリのみ) が実 `web/` を静的配信し、`/api/*` を
+`fixtures/state.json` 由来の決定論的 JSON で返す。実 Flask backend (`mapoi_webui_node.py`) は
+import 時に rclpy / mapoi_interfaces を要し CI が重く、フィクスチャも制御できないため再利用しない。
+map 画像は zlib で動的生成し、バイナリを git に置かない。Playwright の `webServer` が自動起動する。
+
+> 配信元は source `web/`。CMakeLists が `install(DIRECTORY web)` で web/ を丸ごと配信するため
+> per-file packaging drift は原理上起きず、source を試すのが正 (#284)。
+
+## ローカル実行
+
+`mapoi_webui/tests/web/` で:
+
+```bash
+npm ci                                    # 依存導入 (@playwright/test 含む)
+npx playwright install --with-deps chromium  # 初回のみ: ブラウザバイナリ
+npm run test:e2e                          # = playwright test (webServer 自動起動)
+```
+
+前提: Node 20 系、`python3` が PATH 上にあること (ROS source は不要)。
+leaflet は本番同様 unpkg CDN から読むため実行に外部ネット接続が要る。
+
+デバッグ: `npx playwright test --headed` / `--debug` / `--ui`。
+ポート衝突時は `MOCK_PORT=8801 npm run test:e2e`。
+
+## CI
+
+`.github/workflows/consistency-check.yml` の `webui_e2e` ジョブ (vitest の `webui_js_tests` と並走)。
+headless chromium のため GL/GPU 不要 (#229 の GL 問題とは別レイヤー)。

--- a/mapoi_webui/tests/web/e2e/all-js-200.e2e.js
+++ b/mapoi_webui/tests/web/e2e/all-js-200.e2e.js
@@ -1,0 +1,76 @@
+// A. 全 js 200 smoke (#284, #273 follow-up)。
+// 配信欠落・読み込み順崩れ・実行時 404 の即時検知。回帰防止の本丸。
+//
+// 検知対象: (i) HTML の <script> 列挙 ⇔ web/js/ 実ファイルの双方向整合、
+//           (ii) ブラウザ実ロードでの js/css 404 / JS 実行エラー、(iii) 全 helper の global 定義。
+// 配信元は source web/ (CMakeLists が install(DIRECTORY web) で web/ 丸ごと配信するため
+// per-file packaging drift は原理上起きない → source を試すのが正)。
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+// e2e/ から repo の web/js/ へ: e2e -> tests/web -> tests -> mapoi_webui -> web/js
+const WEB_JS_DIR = path.resolve(__dirname, '../../../web/js');
+
+// 各 helper が window もしくは lexical global として load 後に定義されているか。
+// 注: const/class の top-level 宣言は window プロパティにならないため bare 名 + typeof で見る。
+const EXPECTED_GLOBALS = [
+  'MapoiApi', 'MapoiGeometry', 'MapoiPoiFilter', 'MapoiPoiInteractions',
+  'MapoiNavControls', 'MapViewer', 'PoiEditor', 'RouteEditor',
+];
+
+test.describe('A. 全 js 200 smoke', () => {
+  test('全 /js・/css が 200 で配信され、HTML⇔実ファイルが整合し、JS 実行エラーが無い', async ({ page }) => {
+    const badResponses = [];
+    page.on('response', (res) => {
+      const p = new URL(res.url()).pathname;
+      if ((p.startsWith('/js/') || p.startsWith('/css/')) && res.status() >= 400) {
+        badResponses.push(`${res.status()} ${p}`);
+      }
+    });
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+      // SSE の onerror は console.warn なので error のみ拾う。
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    const pageErrors = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    const indexResp = await page.goto('/');
+    expect(indexResp.status()).toBe(200);
+    // 初期化 (loadMaps→…→showPois) 完了の合図として POI marker 描画を待つ。
+    await expect(page.locator('.poi-arrow-icon')).toHaveCount(4);
+
+    // --- HTML が列挙する /js/*.js を抽出し各々 200 ---
+    const htmlJs = await page.$$eval('script[src^="/js/"]', (els) =>
+      els.map((e) => new URL(e.src).pathname));
+    expect(htmlJs.length).toBeGreaterThan(0);
+    for (const p of htmlJs) {
+      const r = await page.request.get(p);
+      expect(r.status(), `${p} は 200 であるべき`).toBe(200);
+    }
+    expect((await page.request.get('/css/style.css')).status()).toBe(200);
+    expect((await page.request.get('/')).status()).toBe(200);
+
+    // --- HTML 集合 ⇔ web/js/ 実ファイル集合 の双方向整合 ---
+    const htmlSet = new Set(htmlJs.map((p) => p.replace(/^\/js\//, '')));
+    const diskSet = new Set(fs.readdirSync(WEB_JS_DIR).filter((f) => f.endsWith('.js')));
+    const missingFromHtml = [...diskSet].filter((f) => !htmlSet.has(f)); // disk にあるが HTML 未参照
+    const missingFromDisk = [...htmlSet].filter((f) => !diskSet.has(f)); // HTML 参照だが disk になし
+    expect(missingFromHtml, 'web/js/ にあるが index.html が読み込んでいない js').toEqual([]);
+    expect(missingFromDisk, 'index.html が読むが web/js/ に存在しない js').toEqual([]);
+
+    // --- 全 helper が load 後に global 定義済み (200 だが未定義 を間接検知) ---
+    const undefinedGlobals = await page.evaluate((names) =>
+      names.filter((n) => {
+        // bare 名で typeof を見る (window 非依存)。
+        try { return eval(`typeof ${n}`) === 'undefined'; } catch (_e) { return true; }
+      }), EXPECTED_GLOBALS);
+    expect(undefinedGlobals, 'load 後に未定義の helper global').toEqual([]);
+
+    // --- 実ロードで js/css の 4xx/5xx ゼロ・JS 実行エラーゼロ ---
+    expect(badResponses, 'js/css の 4xx/5xx 応答').toEqual([]);
+    expect(pageErrors, 'pageerror (未捕捉例外)').toEqual([]);
+    expect(consoleErrors, 'console.error').toEqual([]);
+  });
+});

--- a/mapoi_webui/tests/web/e2e/fixtures/state.json
+++ b/mapoi_webui/tests/web/e2e/fixtures/state.json
@@ -1,0 +1,76 @@
+{
+  "_comment": "mapoi_webui e2e モックサーバが返す決定論的フィクスチャ (#284)。形状は実 backend (mapoi_webui_node.py) / フロント (api.js, app.js, map-viewer.js) 由来。",
+  "maps": ["test_map"],
+  "current_map": "test_map",
+  "metadata": {
+    "resolution": 0.05,
+    "origin": [-5.0, -5.0, 0.0],
+    "width": 200,
+    "height": 200
+  },
+  "config_version": "fixture-v1",
+  "pois": [
+    {
+      "name": "poi_wedge",
+      "pose": { "x": -2.0, "y": -1.0, "yaw": 0.0 },
+      "tolerance": { "xy": 0.3, "yaw": 0.7854 },
+      "tags": ["waypoint"],
+      "description": "Wedge POI (yaw tol 45deg, 0<yaw<pi -> 扇形 + 回転ハンドル)"
+    },
+    {
+      "name": "poi_wedge2",
+      "pose": { "x": -1.0, "y": -1.0, "yaw": 1.5708 },
+      "tolerance": { "xy": 0.3, "yaw": 1.0472 },
+      "tags": ["waypoint"],
+      "description": "Wedge POI 2"
+    },
+    {
+      "name": "poi_disc",
+      "pose": { "x": 0.0, "y": 0.0, "yaw": 0.0 },
+      "tolerance": { "xy": 0.25, "yaw": 3.15 },
+      "tags": ["waypoint"],
+      "description": "Disc POI (yaw tol >= pi -> 塗り円, yaw 不問, ハンドルなし)"
+    },
+    {
+      "name": "poi_pause",
+      "pose": { "x": 1.0, "y": 1.0, "yaw": 0.1 },
+      "tolerance": { "xy": 0.4, "yaw": 1.5708 },
+      "tags": ["waypoint", "pause"],
+      "description": "Pause POI (dot pattern overlay)"
+    }
+  ],
+  "tags": [
+    { "name": "waypoint", "description": "Navigation waypoint", "is_system": true },
+    { "name": "landmark", "description": "Reference POI (not a navigation target)", "is_system": true },
+    { "name": "pause", "description": "Robot pauses at this POI", "is_system": true }
+  ],
+  "routes": [
+    {
+      "name": "test_route",
+      "waypoints": ["poi_wedge", "poi_disc", "poi_pause"],
+      "landmarks": []
+    }
+  ],
+  "nav_status": {
+    "status": "idle",
+    "target": "",
+    "robot_pose": { "x": -2.0, "y": -1.0, "yaw": 0.0 },
+    "robot_radius": 0.15,
+    "navigation": {
+      "navigation_available": true,
+      "switch_map_available": true,
+      "command_available": true,
+      "topics": {
+        "goal": { "topic": "mapoi/nav/goal_pose_poi", "subscribers": 1, "available": true },
+        "route": { "topic": "mapoi/nav/route", "subscribers": 1, "available": true },
+        "cancel": { "topic": "mapoi/nav/cancel", "subscribers": 1, "available": true },
+        "pause": { "topic": "mapoi/nav/pause", "subscribers": 1, "available": true },
+        "resume": { "topic": "mapoi/nav/resume", "subscribers": 1, "available": true },
+        "switch_map": { "topic": "mapoi/nav/switch_map", "subscribers": 1, "available": true },
+        "initialpose": { "topic": "mapoi/initialpose_poi", "subscribers": 1, "available": true }
+      },
+      "backend_status": { "backend_type": "Nav2", "backend_ready": true, "reason": "healthy" },
+      "localization_status": null
+    }
+  }
+}

--- a/mapoi_webui/tests/web/e2e/helpers.js
+++ b/mapoi_webui/tests/web/e2e/helpers.js
@@ -1,0 +1,39 @@
+// mapoi_webui e2e 共有ヘルパ (#284)。*.e2e.js ではないので Playwright のテスト対象にならない。
+const { expect } = require('@playwright/test');
+
+// app 起動を明示待ちする。SSE (/api/events) が開きっぱなしで 'networkidle' は来ないため、
+// 代わりに「全 POI marker が描画される」= loadMaps→switchMap→loadPois→showPois 完了 を待つ。
+async function loadApp(page) {
+  const resp = await page.goto('/');
+  expect(resp.status()).toBe(200);
+  await expect(page.locator('.poi-arrow-icon')).toHaveCount(4);
+}
+
+// POI 名の完全一致で card を返す。'poi_wedge' が 'poi_wedge2' に部分一致しないよう anchored regex。
+function poiCard(page, name) {
+  return page.locator('.poi-card').filter({
+    has: page.locator('.poi-card-name', { hasText: new RegExp(`^${name}$`) }),
+  });
+}
+
+// card 本体クリックで selectPoi → onSelectionChange → highlightPoi (marker 強調 + draggable + yaw ハンドル)。
+// Edit/Copy/Del/checkbox は stopPropagation するので、name 要素をクリックして card の click に委ねる。
+async function selectPoi(page, name) {
+  await poiCard(page, name).locator('.poi-card-name').click();
+  await expect(poiCard(page, name)).toHaveClass(/(^|\s)selected(\s|$)/);
+}
+
+// computed display を返す ('' ではなく実値 block/flex/none)。
+function displayOf(page, selector) {
+  return page.locator(selector).evaluate((el) => getComputedStyle(el).display);
+}
+
+// 指定 section を望む開閉状態にする (toggle ボタンを必要時だけ押す)。
+async function setSectionOpen(page, toggleId, bodyId, wantOpen) {
+  const isClosed = (await displayOf(page, bodyId)) === 'none';
+  if (wantOpen === isClosed) {
+    await page.locator(toggleId).click();
+  }
+}
+
+module.exports = { loadApp, poiCard, selectPoi, displayOf, setSectionOpen };

--- a/mapoi_webui/tests/web/e2e/helpers.js
+++ b/mapoi_webui/tests/web/e2e/helpers.js
@@ -10,9 +10,11 @@ async function loadApp(page) {
 }
 
 // POI 名の完全一致で card を返す。'poi_wedge' が 'poi_wedge2' に部分一致しないよう anchored regex。
+// 名前に regex メタ文字が来ても壊れないようエスケープする。
 function poiCard(page, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return page.locator('.poi-card').filter({
-    has: page.locator('.poi-card-name', { hasText: new RegExp(`^${name}$`) }),
+    has: page.locator('.poi-card-name', { hasText: new RegExp(`^${escaped}$`) }),
   });
 }
 

--- a/mapoi_webui/tests/web/e2e/poi-drag.e2e.js
+++ b/mapoi_webui/tests/web/e2e/poi-drag.e2e.js
@@ -1,0 +1,51 @@
+// B. POI ドラッグ enable/disable の実適用 (#284, 優先度 高)。
+// pure helper shouldEnablePoiDrag の bool を実際に L.marker.dragging.enable()/disable() へ
+// 流した結果を実ブラウザで検証する。Leaflet は draggable な marker の icon に
+// 'leaflet-marker-draggable' class を付けるので、これで「掴める/掴めない」を観測する。
+const { test, expect } = require('@playwright/test');
+const { loadApp, selectPoi } = require('./helpers');
+
+// 選択中 (highlighted) の POI arrow marker = draggable。yaw ハンドル (.poi-yaw-handle) も
+// draggable だが class が異なるので、.poi-arrow-icon に限定すれば arrow だけ数えられる。
+const DRAGGABLE_ARROW = '.poi-arrow-icon.leaflet-marker-draggable';
+
+test.describe('B. POI ドラッグ enable/disable の実適用', () => {
+  test('選択中 POI marker だけ draggable になり、ドラッグで dirty 化する', async ({ page }) => {
+    await loadApp(page);
+    // 初期は draggable な arrow marker 無し・未 dirty。
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(0);
+    await expect(page.locator('#btn-save')).toBeDisabled();
+
+    await selectPoi(page, 'poi_wedge');
+    // 選択中 1 個だけ draggable。
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
+
+    // その marker を実ドラッグ → dragend → onPoiDragEnd → working copy 更新 + dirty。
+    const marker = page.locator(DRAGGABLE_ARROW);
+    const box = await marker.boundingBox();
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 45, cy + 30, { steps: 10 });
+    await page.mouse.move(cx + 75, cy + 55, { steps: 10 });
+    await page.mouse.up();
+
+    await expect(page.locator('#btn-save')).toBeEnabled();
+    await expect(page.locator('#dirty-indicator')).not.toBeEmpty();
+  });
+
+  test('route 編集中は選択中 POI でもドラッグ不可になり、Cancel で戻る', async ({ page }) => {
+    await loadApp(page);
+    await selectPoi(page, 'poi_wedge');
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
+
+    // route 編集開始 → routeEditor.onEditingChange → setPoiDraggingAllowed(false)。
+    await page.locator('#btn-add-route').click();
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(0);
+
+    // Cancel → setPoiDraggingAllowed(true) で再び draggable。
+    await page.locator('#btn-route-form-cancel').click();
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
+  });
+});

--- a/mapoi_webui/tests/web/e2e/section-collapse.e2e.js
+++ b/mapoi_webui/tests/web/e2e/section-collapse.e2e.js
@@ -1,0 +1,43 @@
+// D. section 折りたたみの app.js 実適用 (#284, #273 で明示の重点)。
+// POI 編集フォームを開くと PoiEditor.showForm → onEditFormVisibilityChange(true) →
+// app.js collapseSectionsForEditing が nav/tag/route を畳み poi-list を隠す。閉じると
+// 開く前の開閉状態へ復元する (全開ではなく「元の状態」)。IIFE の app.js は単体 export を
+// 持たず jsdom では new MapViewer で落ちるため、この配線は実ブラウザでのみ通せる。
+const { test, expect } = require('@playwright/test');
+const { loadApp, poiCard, displayOf, setSectionOpen } = require('./helpers');
+
+test.describe('D. section 折りたたみの app.js 実適用', () => {
+  test('編集フォーム開で他 section と poi-list が畳まれ、閉じると元の開閉に戻る', async ({ page }) => {
+    await loadApp(page);
+
+    // 初期状態を既知に固定: nav 開・route 開・tag 閉 (= 1280px 既定だが防御的に設定)。
+    // tag を「閉」にしておくことで、復元が全開ではなく「元の状態」であることを検証できる。
+    await setSectionOpen(page, '#btn-nav-toggle', '#nav-body', true);
+    await setSectionOpen(page, '#btn-route-toggle', '#route-body', true);
+    await setSectionOpen(page, '#btn-tag-toggle', '#tag-body', false);
+
+    const navBefore = await displayOf(page, '#nav-body');
+    const routeBefore = await displayOf(page, '#route-body');
+    expect(navBefore).not.toBe('none'); // 開いている前提 (collapse を意味あるものにする)
+    expect(routeBefore).not.toBe('none');
+    expect(await displayOf(page, '#tag-body')).toBe('none'); // 元から閉
+
+    // POI の Edit を開く。
+    await poiCard(page, 'poi_wedge').locator('.btn-edit').click();
+    await expect(page.locator('#poi-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+
+    // 編集中は nav/tag/route と poi-list が全て非表示。
+    expect(await displayOf(page, '#nav-body')).toBe('none');
+    expect(await displayOf(page, '#tag-body')).toBe('none');
+    expect(await displayOf(page, '#route-body')).toBe('none');
+    expect(await displayOf(page, '#poi-list')).toBe('none');
+
+    // Cancel で閉じる → 元の開閉状態へ復元。
+    await page.locator('#btn-form-cancel').click();
+    await expect(page.locator('#poi-edit-form')).toHaveClass(/(^|\s)hidden(\s|$)/);
+    expect(await displayOf(page, '#nav-body')).toBe(navBefore);     // 元の開へ
+    expect(await displayOf(page, '#route-body')).toBe(routeBefore); // 元の開へ
+    expect(await displayOf(page, '#tag-body')).toBe('none');        // 元の閉のまま (全開ではない)
+    expect(await displayOf(page, '#poi-list')).not.toBe('none');    // 一覧復活
+  });
+});

--- a/mapoi_webui/tests/web/e2e/server/mock_server.py
+++ b/mapoi_webui/tests/web/e2e/server/mock_server.py
@@ -126,6 +126,8 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-cache")
         self.send_header("Connection", "keep-alive")
         self.end_headers()
+        if self.command == "HEAD":
+            return  # HEAD は header のみ。stream loop に入らない (無限ループ回避)。
         try:
             self.wfile.write(b": connected\n\n")
             self.wfile.flush()

--- a/mapoi_webui/tests/web/e2e/server/mock_server.py
+++ b/mapoi_webui/tests/web/e2e/server/mock_server.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""ROS 非依存のモック webui サーバ (mapoi_webui Playwright e2e 用, #284)。
+
+実 `mapoi_webui/web/` を静的配信し、`/api/*` を `e2e/fixtures/state.json` 由来の
+決定論的 JSON で返す。実 Flask backend (mapoi_webui_node.py) は import 時に
+rclpy / mapoi_interfaces を要し CI が重く、フィクスチャも制御できないため再利用しない。
+本サーバは Python 標準ライブラリのみ (CI に Python があれば追加依存ゼロ) で動く。
+
+- 静的: `/` -> web/index.html, `/css/<f>` -> web/css/<f>, `/js/<f>` -> web/js/<f>
+- API GET: /api/maps, /api/maps/<n>/metadata, /api/maps/<n>/image (動的生成 PNG),
+           /api/pois, /api/routes, /api/tag_definitions, /api/nav/status, /api/mode
+- API POST: /api/pois ほか -> {"success": true, ...} (テストは save を踏まないが契約上用意)
+- SSE: /api/events -> text/event-stream を張りっぱなしにし keepalive (フロントの
+       EventSource が onerror で再接続を繰り返さないように 200 を返し続ける)
+"""
+import argparse
+import json
+import re
+import struct
+import sys
+import time
+import zlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+FIXTURE_PATH = SCRIPT_DIR.parent / "fixtures" / "state.json"
+
+
+def find_web_dir():
+    """`__file__` から上方向に web/js/app.js を持つディレクトリを探し web/ を返す。"""
+    for parent in SCRIPT_DIR.parents:
+        candidate = parent / "web"
+        if (candidate / "js" / "app.js").is_file():
+            return candidate
+    raise RuntimeError("web/ (web/js/app.js) が見つからない: layout を確認")
+
+
+WEB_DIR = find_web_dir()
+with FIXTURE_PATH.open(encoding="utf-8") as f:
+    STATE = json.load(f)
+
+CONTENT_TYPES = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "application/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".json": "application/json; charset=utf-8",
+    ".ico": "image/x-icon",
+}
+
+
+def make_png(width, height):
+    """zlib だけで 8bit グレースケール PNG を生成 (バイナリを git に置かないため動的生成)。
+
+    Leaflet の imageOverlay は metadata の bounds に合わせて伸縮するので、画素内容は
+    smoke の本質に無関係。視認用に薄いチェッカーを描く。"""
+    def chunk(typ, data):
+        return (
+            struct.pack(">I", len(data))
+            + typ
+            + data
+            + struct.pack(">I", zlib.crc32(typ + data) & 0xFFFFFFFF)
+        )
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 0, 0, 0, 0)  # 8bit grayscale
+    raw = bytearray()
+    for y in range(height):
+        raw.append(0)  # filter type 0 (None)
+        for x in range(width):
+            raw.append(210 if ((x // 20) + (y // 20)) % 2 == 0 else 170)
+    idat = zlib.compress(bytes(raw), 6)
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", idat)
+        + chunk(b"IEND", b"")
+    )
+
+
+_meta = STATE["metadata"]
+MAP_PNG = make_png(int(_meta["width"]), int(_meta["height"]))
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args):  # ノイズ抑制 (Playwright webServer 出力を汚さない)
+        pass
+
+    # ---- helpers ----
+    def _send_bytes(self, status, body, content_type, extra_headers=None):
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        if extra_headers:
+            for k, v in extra_headers.items():
+                self.send_header(k, v)
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _send_json(self, obj, status=200):
+        self._send_bytes(status, json.dumps(obj).encode("utf-8"),
+                         CONTENT_TYPES[".json"])
+
+    def _send_static(self, rel_path):
+        target = (WEB_DIR / rel_path).resolve()
+        # ディレクトリトラバーサル防止
+        if WEB_DIR not in target.parents and target != WEB_DIR:
+            self._send_json({"error": "forbidden"}, 403)
+            return
+        if not target.is_file():
+            self._send_json({"error": "not found", "path": rel_path}, 404)
+            return
+        ctype = CONTENT_TYPES.get(target.suffix, "application/octet-stream")
+        self._send_bytes(200, target.read_bytes(), ctype)
+
+    def _send_sse(self):
+        # フロントの EventSource('/api/events') 用。200 + text/event-stream を張りっぱなしに
+        # して onerror による再接続ループ・404 を避ける。daemon thread なので process 終了で死ぬ。
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        self.end_headers()
+        try:
+            self.wfile.write(b": connected\n\n")
+            self.wfile.flush()
+            while True:
+                time.sleep(1.0)
+                self.wfile.write(b": keepalive\n\n")
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            return
+
+    # ---- routing ----
+    def do_GET(self):
+        path = unquote(urlparse(self.path).path)
+
+        if path == "/" or path == "/index.html":
+            self._send_static("index.html")
+            return
+        if path == "/favicon.ico":
+            self._send_bytes(204, b"", CONTENT_TYPES[".ico"])
+            return
+        if path.startswith("/css/"):
+            self._send_static("css/" + path[len("/css/"):])
+            return
+        if path.startswith("/js/"):
+            self._send_static("js/" + path[len("/js/"):])
+            return
+
+        if path == "/api/events":
+            self._send_sse()
+            return
+        if path == "/api/maps":
+            self._send_json({"maps": STATE["maps"], "current_map": STATE["current_map"]})
+            return
+        m = re.match(r"^/api/maps/([^/]+)/metadata$", path)
+        if m:
+            self._send_json(STATE["metadata"])
+            return
+        m = re.match(r"^/api/maps/([^/]+)/image$", path)
+        if m:
+            self._send_bytes(200, MAP_PNG, CONTENT_TYPES[".png"])
+            return
+        if path == "/api/pois":
+            self._send_json({
+                "pois": STATE["pois"],
+                "map_name": STATE["current_map"],
+                "config_version": STATE["config_version"],
+            })
+            return
+        if path == "/api/routes":
+            self._send_json({"routes": STATE["routes"], "map_name": STATE["current_map"]})
+            return
+        if path == "/api/tag_definitions":
+            self._send_json({"tags": STATE["tags"]})
+            return
+        if path == "/api/nav/status":
+            self._send_json(STATE["nav_status"])
+            return
+        if path == "/api/mode":
+            self._send_json({"navigation": STATE["nav_status"]["navigation"]})
+            return
+
+        self._send_json({"error": "not found", "path": path}, 404)
+
+    def do_HEAD(self):
+        self.do_GET()
+
+    def do_POST(self):
+        path = unquote(urlparse(self.path).path)
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        if length:
+            self.rfile.read(length)  # body は破棄 (テストは結果を踏まない)
+        if path == "/api/pois":
+            self._send_json({"success": True, "config_version": STATE["config_version"]})
+            return
+        # routes / custom_tags / maps/select / nav/* など一律 success
+        self._send_json({"success": True})
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=8799)
+    parser.add_argument("--host", default="127.0.0.1")
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    server.daemon_threads = True
+    print(f"[mock_server] serving {WEB_DIR} on http://{args.host}:{args.port}",
+          file=sys.stderr, flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/mapoi_webui/tests/web/e2e/yaw-handle.e2e.js
+++ b/mapoi_webui/tests/web/e2e/yaw-handle.e2e.js
@@ -1,0 +1,46 @@
+// C. yaw 回転ハンドルの DOM 生成と drag 追従 (#284, 優先度 高)。
+// 選択中 wedge POI のときだけ弧先端に .poi-yaw-handle marker が 1 個生成され、disc POI や
+// 未選択では出ない。ハンドルを掴んで回すと矢印が追従し dragend で yaw が dirty 化する。
+const { test, expect } = require('@playwright/test');
+const { loadApp, selectPoi } = require('./helpers');
+
+const DRAGGABLE_ARROW = '.poi-arrow-icon.leaflet-marker-draggable';
+
+test.describe('C. yaw 回転ハンドルの DOM 生成と drag 追従', () => {
+  test('wedge 選択でハンドル 1 個、disc 選択ではハンドル無し', async ({ page }) => {
+    await loadApp(page);
+    await expect(page.locator('.poi-yaw-handle')).toHaveCount(0);
+
+    await selectPoi(page, 'poi_wedge'); // 0 < yawTol < pi → wedge
+    await expect(page.locator('.poi-yaw-handle')).toHaveCount(1);
+
+    await selectPoi(page, 'poi_disc'); // yawTol >= pi → disc (yaw 不問)
+    await expect(page.locator('.poi-yaw-handle')).toHaveCount(0);
+  });
+
+  test('yaw ハンドルをドラッグすると矢印 rotation が変化し dirty 化する', async ({ page }) => {
+    await loadApp(page);
+    await selectPoi(page, 'poi_wedge');
+
+    const handle = page.locator('.poi-yaw-handle');
+    await expect(handle).toHaveCount(1);
+
+    // 選択中 arrow の SVG 初期 transform (rotate) を記録。
+    const arrowSvg = page.locator(`${DRAGGABLE_ARROW} svg`);
+    const before = await arrowSvg.getAttribute('style');
+
+    const box = await handle.boundingBox();
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx - 45, cy + 45, { steps: 10 });
+    await page.mouse.move(cx - 70, cy + 15, { steps: 10 });
+    await page.mouse.up();
+
+    // drag 追従で arrow rotation が変わり、dragend で onPoiYawDragEnd → dirty。
+    await expect(page.locator('#btn-save')).toBeEnabled();
+    const after = await page.locator(`${DRAGGABLE_ARROW} svg`).getAttribute('style');
+    expect(after).not.toBe(before);
+  });
+});

--- a/mapoi_webui/tests/web/package-lock.json
+++ b/mapoi_webui/tests/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.49.1",
         "jsdom": "^29.1.1",
         "vitest": "^2.1.8"
       }
@@ -632,6 +633,22 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -1474,6 +1491,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.12",

--- a/mapoi_webui/tests/web/package.json
+++ b/mapoi_webui/tests/web/package.json
@@ -6,9 +6,11 @@
   "license": "MIT",
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
     "jsdom": "^29.1.1",
     "vitest": "^2.1.8"
   }

--- a/mapoi_webui/tests/web/playwright.config.js
+++ b/mapoi_webui/tests/web/playwright.config.js
@@ -1,0 +1,41 @@
+// Playwright e2e (browser smoke) config for mapoi_webui frontend (#284).
+//
+// 既存の vitest unit (jsdom, *.test.js) とは別レイヤー。jsdom では原理的に
+// 動かない Leaflet 直結部 (marker drag / yaw ハンドル DOM / section 折りたたみの
+// app.js 実適用) と「全 js 200 配信」を、実ブラウザ (headless chromium) で smoke する。
+//
+// テストファイルは *.e2e.js とし、vitest の既定 include (*.test.js / *.spec.js) と
+// 衝突させない (vitest config は変更不要のまま据え置く)。
+//
+// 配信は ROS 非依存の Python モックサーバ (e2e/server/mock_server.js は無く .py)。
+// 実 web/ を静的配信し /api/* を fixture JSON で返すため、rclpy / ROS 環境なしで
+// CI/ローカルとも動く。実 Flask backend (rclpy 依存) は再利用しない (#284 配信方針)。
+const { defineConfig, devices } = require('@playwright/test');
+
+const PORT = process.env.MOCK_PORT || '8799';
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.e2e.js',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: BASE_URL,
+    viewport: { width: 1280, height: 800 },
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: `python3 e2e/server/mock_server.py --port ${PORT}`,
+    url: `${BASE_URL}/`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});


### PR DESCRIPTION
## 概要

#273 で「jsdom では原理的に動かない」として残し、Playwright smoke へ切り出すとした **Leaflet 直結部**と**配線 (wiring) 検証**、および「**全 js 200 配信**」を、headless chromium の e2e smoke として新設します (#273 follow-up)。

refs #284

## 検証対象

| spec | 領域 | 内容 |
|---|---|---|
| `all-js-200.e2e.js` | **A** 全 js 200 | HTML の `<script>` 列挙 ⇔ `web/js/` 実ファイルの双方向整合、実ロードでの js/css 404 ゼロ、全 helper の global 定義 (「200 だが未定義」検知) |
| `poi-drag.e2e.js` | **B** POI ドラッグ | 選択中 marker だけ `leaflet-marker-draggable`、ドラッグで dirty 化、route 編集中は不可・Cancel で復帰 |
| `yaw-handle.e2e.js` | **C** yaw ハンドル | 選択中 wedge POI にハンドル 1 個 / disc では 0、ハンドル drag で矢印 rotation 追従 + dirty |
| `section-collapse.e2e.js` | **D** section 折りたたみ | 編集フォーム開で nav/tag/route + poi-list 畳み、閉で「元の開閉状態」へ復元 (全開ではない) |

#284 の達成ライン (受入の必須ライン) **A + B/C/D** をカバーします。E〜H (優先度 中〜低) は段階追加の余地として #284 に残します (本 PR では close しません)。

## 構成 / 設計判断

- **配信は ROS 非依存の Python モックサーバ** (`e2e/server/mock_server.py`, 標準ライブラリのみ)。実 `web/` を静的配信し `/api/*` を `e2e/fixtures/state.json` 由来の決定論的 JSON で返す。
  - 実 Flask backend (`mapoi_webui_node.py`) は import 時に rclpy / mapoi_interfaces を要し CI が重く、フィクスチャも制御できないため**再利用しない** (#284 の未決事項「配信方針」をこの形で確定)。
  - 配信元は **source `web/`**。CMakeLists が `install(DIRECTORY web)` で `web/` を丸ごと配信するため per-file packaging drift は原理上起きず、source を試すのが正。
  - map 画像は zlib で**動的生成**し、バイナリを git に置かない。
- テストファイルは `*.e2e.js`。vitest の既定 include (`*.test.js` / `*.spec.js`) と衝突しないため **vitest 設定は無変更**。既存 unit 132 テストは引き続き全 pass。
- SSE (`/api/events`) を 200 で張りっぱなしにし、`networkidle` ではなく POI marker 描画完了を明示待ちする。

## CI

`.github/workflows/consistency-check.yml` に `webui_e2e` ジョブを追加 (既存 `webui_js_tests` と並走)。`npm ci` → `playwright install --with-deps chromium` → `npm run test:e2e`。headless chromium のため GL/GPU 不要 (#229 の GL 問題とは別レイヤー)。失敗時は HTML レポートを artifact 化。

## ローカル確認結果

- e2e: **6 passed** / vitest unit: **132 passed (回帰なし)**。
- 回帰検知の実証: 孤児 js を置くと `missingFromHtml` で fail、存在しない `<script>` を足すと 404 で fail することを確認。

ローカル再現手順は `mapoi_webui/tests/web/e2e/README.md` 参照。

## 関連

- #273 (派生元。残スコープを本 PR で実体化)
- #193 (test 構成棚卸しの親傘。本件はその webui カバレッジ穴埋めの一つ)
- #267 (`_drawSectorForPoi` 扇形描画の pin 接点。本 PR は扇形描画自体は未 assert、F として #284 に残置)
