### PR TITLE
ci: launch_test を非PR retry gate 化 + テスト0件 silent green 防止 (#193)

### DIFF
--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   push:
     branches: [main]
+  # 週次 full run: PR gate 外の launch_test も含めて回し、integration regression と
+  # osrf/ros base image の drift を、コミットが無い週でも拾う (#193)。月曜 03:17 UTC。
+  schedule:
+    - cron: '17 3 * * 1'
   workflow_dispatch:
 
 permissions:
@@ -24,8 +28,9 @@ jobs:
       fail-fast: false  # 片 distro が落ちても他方の結果を残す (docker-build.yml に倣う)
       matrix:
         distro: [humble, jazzy]
-    # launch_test は除外する (下記) が、clean build + rosdep install のハング保険として確保。
-    timeout-minutes: 30
+    # PR では launch_test を除外 (下記 step) するが、main push / 週次 schedule / 手動 dispatch
+    # では同 job 内で launch_test 3 本 (各 120-180s) も実行するため余裕を持たせる。
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,7 +85,48 @@ jobs:
           set -eo pipefail
           source "/opt/ros/${{ matrix.distro }}/setup.bash"
           source install/setup.bash
-          colcon test --ctest-args -LE launch_test \
+          # critical-core の 4 package を明示。package rename / 消失で対象が静かに減るのを防ぐ。
+          colcon test --packages-select \
+              mapoi_server mapoi_rviz_plugins mapoi_turtlebot3_example mapoi_webui \
+            --ctest-args -LE launch_test \
+            --event-handlers console_direct+
+          colcon test-result --verbose
+
+          # 「テスト 0 件でも colcon が green」を塞ぐ hardening (#193)。
+          # gtest binary の build 漏れ / BUILD_TESTING off / ctest label 全除外などで test
+          # target が静かに消えても colcon test 自体は exit 0 になる。実際に結果を出した test
+          # target 数 (gtest 4 + pytest 5 = 9; humble/jazzy 両 distro で実測) を数え、下限を割れば
+          # fail。個々の case 数 (~130) ではなく target 数を不変量にして case 増減での誤検知を避ける。
+          # target を意図的に増減した時は EXPECTED_TARGETS も更新する (silent drop を強制的に可視化)。
+          EXPECTED_TARGETS=9
+          ran=$(find build -path '*test_results*' -name '*.xml' | wc -l)
+          echo "ran ${ran} test target result file(s); expected >= ${EXPECTED_TARGETS}"
+          if [ "${ran}" -lt "${EXPECTED_TARGETS}" ]; then
+            echo "::error::only ${ran} test target(s) produced results (expected >= ${EXPECTED_TARGETS}); possible silent test loss"
+            exit 1
+          fi
+
+      # 統合 launch_test (mapoi_server の Nav2 mock 駆動 3 本, 各 120-180s) は遅く、実プロセス +
+      # MultiThreadedExecutor のタイミング依存で CPU 逼迫時に flake する (特に
+      # test_poi_event_route_integration)。よって PR gate からは外す (上 step で -LE launch_test
+      # で除外済)。代わりに main push / 週次 schedule / 手動 dispatch でのみ、同一 build を再利用して
+      # ここで実行し、integration regression を PR を止めずに拾う。PR では skip されるため、required
+      # status check (build-test) の PR 判定には launch_test の結果は乗らない。
+      - name: colcon test (launch_test, non-PR のみ)
+        if: ${{ github.event_name != 'pull_request' }}
+        shell: bash
+        # setup.bash の nounset 非互換のため set -u は付けない (他 step と同様)。
+        run: |
+          set -eo pipefail
+          source "/opt/ros/${{ matrix.distro }}/setup.bash"
+          source install/setup.bash
+          # flake 対策: 落ちた test のみ最大 5 回まで再試行し、1 度でも通れば pass 扱いにする。
+          # ローカル 2-core 実測では素の失敗率 ~25%/run・短距離クラスタ (最大 2 連) だが、
+          # --retest-until-pass 5 で 20 試行とも green に収束 (残存赤 0/20)。本当に壊れた test は
+          # 全再試行で落ち続けるため regression 検知は維持される。gate 判定は colcon test-result の
+          # exit (colcon test 自体は test 失敗でも exit 0 を返すため、test-result を真の gate とする)。
+          colcon test --packages-select mapoi_server --retest-until-pass 5 \
+            --ctest-args -L launch_test \
             --event-handlers console_direct+
           colcon test-result --verbose
 

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -85,10 +85,7 @@ jobs:
           set -eo pipefail
           source "/opt/ros/${{ matrix.distro }}/setup.bash"
           source install/setup.bash
-          # critical-core の 4 package を明示。package rename / 消失で対象が静かに減るのを防ぐ。
-          colcon test --packages-select \
-              mapoi_server mapoi_rviz_plugins mapoi_turtlebot3_example mapoi_webui \
-            --ctest-args -LE launch_test \
+          colcon test --ctest-args -LE launch_test \
             --event-handlers console_direct+
           colcon test-result --verbose
 
@@ -98,6 +95,8 @@ jobs:
           # target 数 (gtest 4 + pytest 5 = 9; humble/jazzy 両 distro で実測) を数え、下限を割れば
           # fail。個々の case 数 (~130) ではなく target 数を不変量にして case 増減での誤検知を避ける。
           # target を意図的に増減した時は EXPECTED_TARGETS も更新する (silent drop を強制的に可視化)。
+          # NOTE: package を絞らず全 package を test 対象にしておくことで、新規 package の test が
+          # 静かに除外される穴を避ける (PR #289 review high-1)。下限 9 は build 漏れ等の損失を捕える。
           EXPECTED_TARGETS=9
           ran=$(find build -path '*test_results*' -name '*.xml' | wc -l)
           echo "ran ${ran} test target result file(s); expected >= ${EXPECTED_TARGETS}"


### PR DESCRIPTION
#193 残課題の CI hardening 2 件を `ros-test.yml` に追加。

## 1. テスト 0 件 silent green の hardening
`colcon test` は test target が 0 件でも exit 0 を返すため、gtest binary の build 漏れ・`BUILD_TESTING` off・ctest label 全除外などで critical-core test が静かに消えても CI が green になり得る。

- 実行された test 結果 file 数 (gtest 4 + pytest 5 = 9) を数え、下限 (`>= 9`) を割れば fail
- case 数 (~130) ではなく target 数を不変量にし、case 増減での誤検知を回避
- 全 package を test 対象にしておき (`--packages-select` で絞らない)、将来 test を持つ新規 package が静かに除外される穴を避ける (#289 review high-1 反映 / commit 2)

## 2. launch_test の非PR gate 化 (retry 付き)
統合 launch_test 3 本 (Nav2 mock 駆動, 120-180s) を main push / 週次 schedule (月曜) / 手動 dispatch でのみ実行し、integration regression を PR を止めずに拾う。PR では skip するため required status check には乗らない。

- `test_poi_event_route_integration` はタイミング依存で CPU 逼迫時に flake する
- `--retest-until-pass 5` で flake を吸収。本当に壊れた test は全再試行で落ちるため regression 検知は維持
- gate 判定は `colcon test-result` の exit (colcon test 自体は test 失敗でも exit 0 を返すため)

## 検証
ローカルの osrf/ros コンテナ (humble / jazzy) で確認:

- critical-core: 両 distro とも全 package 実行で test 結果 9 件・130 ケース pass、count-floor 動作
- launch_test: `-L launch_test` が 3 本選択。2-core 制約下の素の flake (~25%/run, route_integration) を `--retest-until-pass 5` が吸収し両 distro とも green に収束 (jazzy 0/20, humble 0/12)

## Refs #193 — チェックリスト 2 項目を消化
- [x] launch_test 3 本の gate 戦略 (main push / 週次)
- [x] ros-test の「テスト 0 件 silent green」hardening

残課題 (別 PR / sub-issue 想定): mapoi_rviz_plugins Qt カバレッジ (#169) / mapoi_webui SSE・config publish test。
