### PR TITLE
test(rviz): config_path_update_policy の純関数 unit test を再追加 (Close #169)

### DIFF
--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -92,12 +92,12 @@ jobs:
           # 「テスト 0 件でも colcon が green」を塞ぐ hardening (#193)。
           # gtest binary の build 漏れ / BUILD_TESTING off / ctest label 全除外などで test
           # target が静かに消えても colcon test 自体は exit 0 になる。実際に結果を出した test
-          # target 数 (gtest 4 + pytest 6 = 10; humble/jazzy 両 distro で実測) を数え、下限を割れば
-          # fail。個々の case 数 (~140) ではなく target 数を不変量にして case 増減での誤検知を避ける。
+          # target 数 (gtest 5 + pytest 6 = 11; humble/jazzy 両 distro で実測) を数え、下限を割れば
+          # fail。個々の case 数 (~150) ではなく target 数を不変量にして case 増減での誤検知を避ける。
           # target を意図的に増減した時は EXPECTED_TARGETS も更新する (silent drop を強制的に可視化)。
           # NOTE: package を絞らず全 package を test 対象にしておくことで、新規 package の test が
-          # 静かに除外される穴を避ける (PR #289 review high-1)。下限 10 は build 漏れ等の損失を捕える。
-          EXPECTED_TARGETS=10
+          # 静かに除外される穴を避ける (PR #289 review high-1)。下限 11 は build 漏れ等の損失を捕える。
+          EXPECTED_TARGETS=11
           ran=$(find build -path '*test_results*' -name '*.xml' | wc -l)
           echo "ran ${ran} test target result file(s); expected >= ${EXPECTED_TARGETS}"
           if [ "${ran}" -lt "${EXPECTED_TARGETS}" ]; then

--- a/mapoi_rviz_plugins/CMakeLists.txt
+++ b/mapoi_rviz_plugins/CMakeLists.txt
@@ -34,6 +34,11 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_poi_editor_helpers
     test/test_poi_editor_helpers.cpp
   )
+  # config_path_update_policy.hpp の ConfigPathCallback 分岐判定 (Reinit/Refresh/Noop) の
+  # unit test (#169)。Panel callback はこの判定を UI 更新へ写像するだけ。header は Qt/ROS 非依存。
+  ament_auto_add_gtest(test_config_path_update_policy
+    test/test_config_path_update_policy.cpp
+  )
 endif()
 
 # 将来のROS 2（Kilted Kaiju以降）と互換性を持たせるため

--- a/mapoi_rviz_plugins/test/test_config_path_update_policy.cpp
+++ b/mapoi_rviz_plugins/test/test_config_path_update_policy.cpp
@@ -1,0 +1,86 @@
+// config_path_update_policy.hpp の純粋判定 helper の unit test (#169)。
+//
+// PoiEditorPanel / MapoiPanel の ConfigPathCallback は ROS subscription で受けた
+// config_path から map 名を取り出し、この helper の判定結果 (ReinitializeMap /
+// RefreshCurrentMap / Noop) を UI 更新関数 (InitConfigs / UpdatePoiTable /
+// SetMapComboBox 等) へ写像するだけ。判定そのものは Qt / ROS 非依存の純関数なので、
+// 分岐表をここで pin し、リファクタで条件を踏み外す回帰 (`!=`↔`==` 反転、抑制対象の
+// 取り違え等) を安く捕える。header は <string> のみ依存。
+#include <gtest/gtest.h>
+
+#include "mapoi_rviz_plugins/config_path_update_policy.hpp"
+
+using mapoi_rviz_plugins::detail::ConfigPathUpdateAction;
+using mapoi_rviz_plugins::detail::decide_poi_editor_config_path_action;
+using mapoi_rviz_plugins::detail::apply_poi_editor_content_update_suppression;
+using mapoi_rviz_plugins::detail::decide_mapoi_panel_config_path_action;
+
+// --- decide_poi_editor_config_path_action ---
+
+TEST(DecidePoiEditorConfigPathAction, EmptyConfigPathReinitializesEvenForSameMap)
+{
+  // 初回受信 (config_path 未設定) は同一 map 名でも full 再初期化が要る。
+  EXPECT_EQ(
+    decide_poi_editor_config_path_action("mapA", "mapA", ""),
+    ConfigPathUpdateAction::ReinitializeMap);
+}
+
+TEST(DecidePoiEditorConfigPathAction, DifferentMapReinitializes)
+{
+  EXPECT_EQ(
+    decide_poi_editor_config_path_action("mapA", "mapB", "/maps/mapA/mapoi_config.yaml"),
+    ConfigPathUpdateAction::ReinitializeMap);
+}
+
+TEST(DecidePoiEditorConfigPathAction, SameMapWithPathRefreshesContent)
+{
+  // 同一 map の内容変更 (save 後 reload による再 publish) は table 再 fetch のみで足りる。
+  EXPECT_EQ(
+    decide_poi_editor_config_path_action("mapA", "mapA", "/maps/mapA/mapoi_config.yaml"),
+    ConfigPathUpdateAction::RefreshCurrentMap);
+}
+
+// --- apply_poi_editor_content_update_suppression ---
+
+TEST(ApplyPoiEditorContentUpdateSuppression, RefreshSuppressedBecomesNoop)
+{
+  // 自分自身の save 直後 (1.5s の SAVED! feedback 保護) は content refresh を抑制する。
+  EXPECT_EQ(
+    apply_poi_editor_content_update_suppression(
+      ConfigPathUpdateAction::RefreshCurrentMap, true),
+    ConfigPathUpdateAction::Noop);
+}
+
+TEST(ApplyPoiEditorContentUpdateSuppression, RefreshNotSuppressedPassesThrough)
+{
+  EXPECT_EQ(
+    apply_poi_editor_content_update_suppression(
+      ConfigPathUpdateAction::RefreshCurrentMap, false),
+    ConfigPathUpdateAction::RefreshCurrentMap);
+}
+
+TEST(ApplyPoiEditorContentUpdateSuppression, ReinitializeIsNeverSuppressed)
+{
+  // 抑制は RefreshCurrentMap だけに効く。map 切替の再初期化は suppress でも維持される。
+  EXPECT_EQ(
+    apply_poi_editor_content_update_suppression(
+      ConfigPathUpdateAction::ReinitializeMap, true),
+    ConfigPathUpdateAction::ReinitializeMap);
+}
+
+// --- decide_mapoi_panel_config_path_action ---
+
+TEST(DecideMapoiPanelConfigPathAction, DifferentMapReinitializes)
+{
+  EXPECT_EQ(
+    decide_mapoi_panel_config_path_action("mapA", "mapB"),
+    ConfigPathUpdateAction::ReinitializeMap);
+}
+
+TEST(DecideMapoiPanelConfigPathAction, SameMapRefreshes)
+{
+  // MapoiPanel には Noop 抑制が無く、同一 map でも goal/route combo は再 fetch する。
+  EXPECT_EQ(
+    decide_mapoi_panel_config_path_action("mapA", "mapA"),
+    ConfigPathUpdateAction::RefreshCurrentMap);
+}


### PR DESCRIPTION
#169 の `config_path_update_policy` 純関数 unit test を slim 版で再追加する。

## 致命性の判定 (close 根拠)
PoiEditorPanel / MapoiPanel の `ConfigPathCallback` は ROS subscription で受けた config_path から map 名を取り出し、`config_path_update_policy.hpp` の判定 (ReinitializeMap / RefreshCurrentMap / Noop) を UI 更新関数 (InitConfigs / UpdatePoiTable / SetMapComboBox 等) へ写像するだけ。

- **ナビ実行に波及しない**: robot のナビは mapoi_server / nav2_bridge 経由でこの panel を通らない
- **yaml データ整合に波及しない**: 表示更新のみ。保存時の整合は #241 の楽観的競合検出 (config_version) が別途 test 済
- **最悪ケース**は RViz オペレータコンソールの表示劣化 (stale table / combo、再初期化漏れ・過剰、自己 refresh 抑制漏れ) で、手動 reload で回復可

→ **致命核ではない**。ただし純関数で 〜25 行・<0.01s・Qt/ROS 非依存と破格に安いため、リファクタで条件を踏み外す regression (`!=`↔`==` 反転、抑制対象の取り違え等) を安く防ぐ guard として再追加し #169 を close する。PR2 (#287) の broad trim で削除されたカバレッジの slim 版復活。

## 変更
- `mapoi_rviz_plugins/test/test_config_path_update_policy.cpp` 新規 (3 関数 × 分岐 = 8 ケース)
- `mapoi_rviz_plugins/CMakeLists.txt`: gtest target 登録
- `.github/workflows/ros-test.yml`: gtest +1 で count-floor の `EXPECTED_TARGETS` を 10→11

## 検証
ローカルの osrf/ros コンテナ humble / jazzy を**単独実行**で、いずれも 8/8 pass・全 package colcon test green (152 ケース)・結果 file 数 11 を確認 (並行実行は CPU contention で timing 系 test が flake するため単独で取得)。

Close #169
