### PR TITLE
docs: 旧 POI/route 名の docs 横断棚卸し (Close #237)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,28 @@ For releases prior to v0.2.0, see the
 Unreleased
 ==========
 
+Samples
+-------
+
+* The ``turtlebot3_world`` demo was redesigned into a **feature-catalog**
+  layout (#230, PR #235): POI count 9 -> 5, with routes restructured
+  into one-feature-per-route tutorials plus an all-in-one ``tour_full``.
+  This renames/removes the sample POI and route names, so launch files,
+  clients, tutorials, or scripts that pin the old ``turtlebot3_world``
+  names must migrate.
+
+  - **POIs** (new): ``start`` / ``basic_waypoint`` / ``pause_waypoint``
+    / ``goal`` / ``audio_landmark``. The old office-tour POIs
+    (``elevator_hall``, ``corridor_a`` / ``corridor_b``,
+    ``conference_room``, ``model_exhibit`` and the landmark variants)
+    were removed.
+  - **Routes** (new): ``tutorial_01_basic`` / ``tutorial_02_landmark``
+    / ``tutorial_03_pause`` / ``tour_full``. The previous ``tour_full``
+    / ``tour_short`` pair was replaced; ``tour_short`` is gone.
+  - Consecutive-``pause`` coverage (old ``corridor_a`` + ``corridor_b``)
+    moved into the ``test_poi_event_route_integration`` launch_test
+    (#236) instead of the demo config.
+
 
 0.4.0 (2026-05-08)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,10 +30,13 @@ Samples
     / ``goal`` / ``audio_landmark``. The old office-tour POIs
     (``elevator_hall``, ``corridor_a`` / ``corridor_b``,
     ``conference_room``, ``model_exhibit`` and the landmark variants)
-    were removed.
+    were removed. This is **not a 1:1 rename**: the demo was rebuilt
+    around the feature-catalog layout, so old POIs have no direct
+    new-name counterpart.
   - **Routes** (new): ``tutorial_01_basic`` / ``tutorial_02_landmark``
-    / ``tutorial_03_pause`` / ``tour_full``. The previous ``tour_full``
-    / ``tour_short`` pair was replaced; ``tour_short`` is gone.
+    / ``tutorial_03_pause`` / ``tour_full``. ``tour_full`` keeps its
+    name but its waypoints / landmarks were rebuilt for the new POI set;
+    the old ``tour_short`` was removed.
   - Consecutive-``pause`` coverage (old ``corridor_a`` + ``corridor_b``)
     moved into the ``test_poi_event_route_integration`` launch_test
     (#236) instead of the demo config.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -76,10 +76,11 @@ amcl:
 
 ```yaml
 poi:
-  - name: elevator_hall   # この POI が default 初期位置になる (POI list 先頭)
+  # POI 名は構造を示す汎用例 (turtlebot3 demo の実 POI 名とは独立)
+  - name: entrance        # この POI が default 初期位置になる (POI list 先頭)
     pose: {x: -2.0, y: -0.5, yaw: 0.0}
     tags: [waypoint]
-  - name: meeting_room_a
+  - name: room_a
     pose: {x: 1.0, y: 0.5, yaw: 1.57}
     tags: [waypoint]
 ```

--- a/mapoi_server/README.md
+++ b/mapoi_server/README.md
@@ -354,11 +354,12 @@ map:
   localization: map_file_name
 
 poi:
-  - name: elevator_hall
+  # POI 名は構造を示す汎用例 (turtlebot3 demo の実 POI 名とは独立)
+  - name: entrance
     pose: {x: -2.0, y: -0.5, yaw: 0.0}
     tolerance: {xy: 0.5, yaw: 0.785}
     tags: [waypoint]                # POI list 先頭が default initial pose に採用される (#144)
-    description: エレベーターホール
+    description: エントランス
   - name: checkpoint_a
     pose: {x: 0.5, y: 0.5, yaw: 0.0}
     tolerance: {xy: 0.5, yaw: 0.785}
@@ -372,7 +373,7 @@ poi:
 
 route:
   - name: route_1
-    waypoints: [elevator_hall, info_point_a]
+    waypoints: [entrance, info_point_a]
 ```
 
 ### フィールド説明


### PR DESCRIPTION
## 概要

Close #237。PR #235 (#230 最終形) で `turtlebot3_world` の POI / route 名を機能カタログ命名に刷新した際、docs 側に残った旧名を横断で棚卸しする。

## 変更

### 1. 汎用 YAML 例の旧名を汎用名化 + 「demo と独立」明示
demo データを参照する手順書ではなく config 構造を示す汎用例なので、旧 demo 名 (`elevator_hall` 等) を将来の demo 改名で再ドリフトしない汎用名に置換し、「実 POI 名とは独立」とコメントで明示 (issue 第2案)。

- `docs/integration.md`: `elevator_hall` / `meeting_room_a` → `entrance` / `room_a`
- `mapoi_server/README.md`: `elevator_hall` → `entrance` (description も追随)、`route_1` waypoints 追随
  - `checkpoint_a` / `info_point_a` は元々汎用名のため、追加した「汎用例」コメントで被覆し据え置き

### 2. CHANGELOG に #235 の破壊的改名を記録
空だった `Unreleased` に `Samples` 節を新設し、#235 の catalog 化 (9→5 POI、route 刷新、旧 office-tour 名の除去) を migration note として記録。旧名を pin している launch / client / script の移行が必要な旨を明示。

## 意図的に残した旧名 (履歴・説明)
- `CHANGELOG.rst` の 0.4.0 エントリ (#146 sample rework の当時の記録)
- `test_poi_event_route_integration.py` / `mapoi_turtlebot3_example/README.md` の「旧 `corridor_a`/`corridor_b` の連続 pause demo は #235 で削除、#236 で launch_test に移管」説明コメント

## issue チェックリスト対応
- [x] `docs/integration.md` の YAML 例
- [x] `mapoi_server/README.md` の設定例
- [x] repo 全体の旧名残存 grep 棚卸し (残存は上記「意図的に残した」もののみ)
- [x] CHANGELOG に旧→新マッピング (redesign のため厳密 1:1 ではなく新構造 + 旧名除去として記載)

## テスト
docs (md / rst) のみの変更でコード非依存。