### PR TITLE
docs(docker): Intel/AMD iGPU の DRI override 追加 + 混在 GUI の GL 失敗回避を整備 (Close #229)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -223,6 +223,16 @@ Documentation
   common ``maps_path``-points-to-config-file misuse with the actual
   FATAL log output.
 
+* Docker + Intel/AMD 内蔵 GPU で RViz / Gazebo の **片方だけ** GUI を
+  出す組合せ (例 ``gazebo_gui:=false``) のとき RViz が GL 初期化失敗で
+  crash する問題 (#229) の回避手段を整備。``docker-compose.dri.yml``
+  (Intel/AMD iGPU 向け ``/dev/dri`` 共有 + ``group_add: [video, render]``
+  の override) を新設し、``docs/docker.md`` に DRI override の使い方・
+  GID 不一致時の対処・GPU 共有できない環境向けの software 経路
+  (``gazebo_gui:=false`` で gz-sim を headless にして RViz だけ
+  ``LIBGL_ALWAYS_SOFTWARE=1`` で起動) を追記。launch / アプリコードの
+  変更はなし。
+
 Internal / tests
 ----------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -225,7 +225,7 @@ Documentation
 
 * Docker + Intel/AMD 内蔵 GPU で RViz / Gazebo の **片方だけ** GUI を
   出す組合せ (例 ``gazebo_gui:=false``) のとき RViz が GL 初期化失敗で
-  crash する問題 (#229) の回避手段を整備。``docker-compose.dri.yml``
+  crash する問題 (#229, PR #296) の回避手段を整備。``docker-compose.dri.yml``
   (Intel/AMD iGPU 向け ``/dev/dri`` 共有 + ``group_add: [video, render]``
   の override) を新設し、``docs/docker.md`` に DRI override の使い方・
   GID 不一致時の対処・GPU 共有できない環境向けの software 経路

--- a/docker-compose.dri.yml
+++ b/docker-compose.dri.yml
@@ -1,0 +1,41 @@
+# Intel / AMD 内蔵 GPU (DRI) 対応 override
+#
+# 用途:
+#   Docker (Jazzy / gz-sim) で RViz2 と Gazebo GUI の **片方だけ** GUI を出す組合せ
+#   (例: gazebo_gui:=false で RViz だけ) のとき、container 内から host GPU の DRM device
+#   (/dev/dri) にアクセスできず RViz (OGRE classic) が GL 初期化失敗で crash する問題 (#229)
+#   を、container に /dev/dri を共有して hardware GL を使わせることで解消する。
+#   NVIDIA discrete GPU 機は docker-compose.gpu.yml を使ってください (こちらは Intel/AMD iGPU 用)。
+#
+# ホスト要件:
+#   - Intel / AMD の内蔵 GPU + Mesa driver を持つ Linux ホスト
+#   - host 側で /dev/dri/{card*, renderD*} が存在すること (`ls -l /dev/dri` で確認)
+#
+# 利用方法:
+#   xhost +local:docker
+#   docker compose -f docker-compose.yml -f docker-compose.dri.yml up demo
+#
+# 注意 (GID 不一致):
+#   hardware GL は render node (/dev/dri/renderD128, host の `render` group 所有) 経由で動く。
+#   container 側 `render` / `video` group の GID が host と一致しないと、device は見えても
+#   permission denied で hardware 経路に乗れず software (llvmpipe) に落ちることがある。
+#   その場合は `ls -l /dev/dri/renderD128` の host GID を控え、override に numeric GID を
+#   `group_add: ["<host renderD128 GID>"]` の形で足してください。
+#   それでも不調なら GPU 共有を諦め、software 経路 (docs/docker.md「混在組合せの GL」節:
+#   gazebo_gui:=false + LIBGL_ALWAYS_SOFTWARE=1) を使ってください。
+#
+# GPU 共有なしの通常起動は docker-compose.yml 単体で OK (default は CPU/llvmpipe 経路)。
+services:
+  dev:
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - video
+      - render
+
+  demo:
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - video
+      - render

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -208,12 +208,23 @@ NVIDIA discrete GPU ではなく Intel / AMD の内蔵 GPU を使う場合は、
 
 ```sh
 xhost +local:docker
+
+# お試し/デモ (demo service)
 docker compose -f docker-compose.yml -f docker-compose.dri.yml up demo
+
+# 開発用 (dev service。override は dev にも付くので bind mount 開発でも同様に重ねる)
+docker compose -f docker-compose.yml -f docker-compose.dri.yml run --rm dev
 ```
 
 これは `/dev/dri` の共有と `group_add: [video, render]` を dev / demo に足すだけの override です。これがないと、後述の「RViz / Gazebo の片方だけ GUI を出すと GL 初期化に失敗する」問題 (#229) が起きます。
 
+前提として host 側に `/dev/dri/{card*, renderD*}` が存在すること (`ls -l /dev/dri` で確認)。**GPU device の無い host (SSH-only / CI 等) でこの override を重ねると `/dev/dri` バインド失敗で container が起動できない**ため、その環境では override を重ねず `docker-compose.yml` 単体 (software 経路) を使ってください。
+
+> **container image 側の group**: 本 image のベース (`osrf/ros:<distro>-desktop-full`, Ubuntu 24.04) は `video` / `render` group を持つため `group_add` は名前解決できます。独自ベース image に差し替えてこれらの group が無いと compose が `group_add` でエラーになるので、その場合は numeric GID 指定 (下記) に切替えてください。
+
 > **GID 不一致の注意**: hardware GL は render node (`/dev/dri/renderD128`, host の `render` group 所有) 経由で動きます。container 側 `render` / `video` group の GID が host と一致しないと、device は見えても permission denied で software (llvmpipe) に落ちます。その場合は `ls -l /dev/dri/renderD128` で host 側の GID を確認し、override の `group_add` に numeric GID (`group_add: ["<その GID>"]`) を足してください。それでも不調なら GPU 共有を諦め、次節の software 経路を使ってください。
+
+> **HW GL が効いているかの確認**: override を重ねて起動したら、`docker compose ... exec dev glxinfo | grep "OpenGL renderer"` (要 `mesa-utils`) で renderer 名を見ます。Intel/AMD の GPU 名 (例 `Mesa Intel(R) ...`) が出れば hardware GL、`llvmpipe` なら software に落ちています (GID 不一致を疑う)。手早くは RViz 起動ログに `failed to load driver: iris` / `glx: failed to create dri3 screen` が出ていないかでも判別できます。
 
 ## RViz / Gazebo の片方だけ GUI を出すと GL 初期化に失敗する (Docker / Intel iGPU)
 
@@ -233,6 +244,8 @@ docker compose -f docker-compose.yml -f docker-compose.dri.yml up demo
 software 経路の例 (gz-sim は server only、RViz だけ表示):
 
 ```sh
+# 重要: LIBGL_ALWAYS_SOFTWARE=1 は必ず gazebo_gui:=false (gz-sim を headless) とセットで使う。
+# gazebo_gui を default (true) のままにすると現象 2 (gz-sim GUI が出ない) を踏む。
 docker run --rm -it --network host --ipc host \
   -e DISPLAY=$DISPLAY -e LIBGL_ALWAYS_SOFTWARE=1 \
   -v /tmp/.X11-unix:/tmp/.X11-unix \

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -202,6 +202,47 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up demo
 
 GPU を使わない通常起動は `docker-compose.yml` 単体、`--gpus all` 無しの `docker run` を使ってください（既存手順そのまま）。
 
+## Intel / AMD 内蔵 GPU (DRI) で加速する
+
+NVIDIA discrete GPU ではなく Intel / AMD の内蔵 GPU を使う場合は、container に host の DRM device (`/dev/dri`) を共有して hardware GL を使わせます。`docker-compose.dri.yml` を override で重ねてください:
+
+```sh
+xhost +local:docker
+docker compose -f docker-compose.yml -f docker-compose.dri.yml up demo
+```
+
+これは `/dev/dri` の共有と `group_add: [video, render]` を dev / demo に足すだけの override です。これがないと、後述の「RViz / Gazebo の片方だけ GUI を出すと GL 初期化に失敗する」問題 (#229) が起きます。
+
+> **GID 不一致の注意**: hardware GL は render node (`/dev/dri/renderD128`, host の `render` group 所有) 経由で動きます。container 側 `render` / `video` group の GID が host と一致しないと、device は見えても permission denied で software (llvmpipe) に落ちます。その場合は `ls -l /dev/dri/renderD128` で host 側の GID を確認し、override の `group_add` に numeric GID (`group_add: ["<その GID>"]`) を足してください。それでも不調なら GPU 共有を諦め、次節の software 経路を使ってください。
+
+## RViz / Gazebo の片方だけ GUI を出すと GL 初期化に失敗する (Docker / Intel iGPU)
+
+`docker-compose.dri.yml` を使わず、かつ `rviz` / `gazebo_gui` の **片方だけ** を `false` にすると、Docker + Intel iGPU 環境で GUI が起動できないことがあります (#229)。原因は RViz (OGRE classic) と Gazebo gz-sim (OGRE2) で GL フォールバックの挙動が異なるためです。
+
+- **`gazebo_gui:=false` (RViz だけ GUI)**: container が `/dev/dri` にアクセスできないと RViz の Mesa iris driver ロードが失敗します。RViz は software (llvmpipe) へ自動フォールバックしないため crash します (gz-sim GUI は自動フォールバックを持つので default の両 GUI 起動では露見しません)。
+- **`LIBGL_ALWAYS_SOFTWARE=1` を shell 全体に export**: RViz は software で起動しますが、gz-sim GUI まで llvmpipe に巻き込まれて起動が極端に遅延 / silently 失敗します。env を一律設定すると片方が壊れます。
+
+解決経路は次の 3 つです。
+
+| 状況 | 推奨 |
+|---|---|
+| host に使える GPU がある | `docker-compose.dri.yml` (Intel/AMD) または `docker-compose.gpu.yml` (NVIDIA) を重ねて hardware GL を共有 |
+| GPU 共有できない / SSH-only / CI | `gazebo_gui:=false` で gz-sim を headless にした上で `LIBGL_ALWAYS_SOFTWARE=1` を設定 (gz-sim GUI が無いので現象 2 を踏まず、RViz だけ software で起動) |
+| GUI が一切不要 | `gazebo_gui:=false rviz:=false` で fully headless 起動 (WebUI / nav は動く) |
+
+software 経路の例 (gz-sim は server only、RViz だけ表示):
+
+```sh
+docker run --rm -it --network host --ipc host \
+  -e DISPLAY=$DISPLAY -e LIBGL_ALWAYS_SOFTWARE=1 \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  ghcr.io/shimz-robotics/mapoi:jazzy \
+  bash -lc "source /opt/ros/\${ROS_DISTRO}/setup.bash && source /ros2_ws/install/setup.bash && \
+    ros2 launch mapoi_turtlebot3_example turtlebot3_navigation.launch.yaml gazebo_gui:=false"
+```
+
+> `LIBGL_ALWAYS_SOFTWARE=1` を gz-sim GUI と同居させると現象 2 (gz-sim GUI が出ない) を踏むため、software 経路では必ず `gazebo_gui:=false` (gz-sim を headless) と組合せてください。両 GUI を hardware で出したい場合は上の DRI / NVIDIA override を使います。
+
 ## Humble で compose から試す
 
 `docker compose` の default は `jazzy` (primary distro) ですが、`ARG ROS_DISTRO` で Humble (Gazebo Classic) に切り替え可能です:


### PR DESCRIPTION
Close #229

## 背景

Docker (Jazzy / gz-sim) + Intel/AMD 内蔵 GPU で `rviz` / `gazebo_gui` の **片方だけ** GUI を出す組合せ (例 `gazebo_gui:=false` で RViz だけ) のとき、container 内から host GPU の DRM device (`/dev/dri`) にアクセスできず RViz (OGRE classic) が GL 初期化失敗で crash する (#229)。gz-sim GUI (OGRE2) は llvmpipe へ自動フォールバックするため default の両 GUI 起動では露見しない。

issue の推奨 (短期=案D docs / 中期=案B docker-compose で `/dev/dri` 共有) に沿って実装。

## 変更点

- **`docker-compose.dri.yml` (新規)**: Intel/AMD iGPU 向け override。`/dev/dri` 共有 + `group_add: [video, render]` で container に hardware GL を使わせる。既存 `docker-compose.gpu.yml` は NVIDIA 専用で経路が別のため分離。
  - 現代 Mesa の HW GL は render node (`/dev/dri/renderD128`, host の `render` group 所有) 経由なので、`video` だけでなく `render` も `group_add` する (issue 提案の `video` のみだと現象1 が残りうる)。GID 不一致時は numeric GID を足す対処をコメントに明記。
- **`docs/docker.md`**: 「Intel/AMD 内蔵 GPU (DRI) で加速する」節と、「片方だけ GUI で GL 失敗」トラブルシュート節 (現象解説 + 解決3経路の表 + software 経路の実行例) を追記。
- **`CHANGELOG.rst`**: Documentation 節にエントリ追加。

launch / アプリコードの変更はなし (docs + compose override のみ)。

## 解決経路 (docs に表で記載)

| 状況 | 推奨 |
|---|---|
| host に使える GPU がある | `docker-compose.dri.yml` (Intel/AMD) / `docker-compose.gpu.yml` (NVIDIA) を重ねて HW GL 共有 |
| GPU 共有できない / SSH-only / CI | `gazebo_gui:=false` で gz-sim を headless にして RViz だけ `LIBGL_ALWAYS_SOFTWARE=1` で起動 |
| GUI 一切不要 | `gazebo_gui:=false rviz:=false` で fully headless |

## 検証

- `docker compose -f docker-compose.yml -f docker-compose.dri.yml config` → rc=0、dev/demo に `/dev/dri` device と `group_add` が正しくマージされることを確認。
- `CHANGELOG.rst` を docutils で構文チェック → warning なし。
- Intel iris の実機再現は環境制約で未実施 (検証機は別 GPU 構成)。診断は #229 の詳細分析に依拠。compose / docs のみで launch 非変更のため動作リスクは限定的。