### PR TITLE
feat(webui): POI editor に Undo/Redo を追加 (snapshot stack)

### DIFF
--- a/mapoi_webui/tests/web/poi-editor-history-dirty.test.js
+++ b/mapoi_webui/tests/web/poi-editor-history-dirty.test.js
@@ -1,0 +1,73 @@
+// Dirty-state regression tests for PoiEditor undo/redo restore (#300).
+//
+// _applySnapshot() は DOM 再描画も呼ぶが、今回 pin したいのは history cap と
+// dirty 判定の関係だけ。constructor を通さず、必要な field / method だけを持つ
+// thin instance で検証する。
+import { describe, it, expect, vi } from 'vitest';
+import PoiEditor from '../../web/js/poi-editor.js';
+
+function poi(name, x = 0) {
+  return {
+    name,
+    pose: { x, y: 0, yaw: 0 },
+    tolerance: { xy: 0.5, yaw: 0.7854 },
+    tags: ['waypoint'],
+    description: '',
+  };
+}
+
+function makeEditor({ pois, originalPois, undoLength = 0 }) {
+  const editor = Object.create(PoiEditor.prototype);
+  editor.pois = JSON.parse(JSON.stringify(pois));
+  editor.originalPois = JSON.parse(JSON.stringify(originalPois));
+  editor.selectedIndex = 0;
+  editor.visiblePois = new Set([0]);
+  editor.editingIndex = 0;
+  editor.undoStack = Array.from({ length: undoLength }, (_, i) => ({ i }));
+  editor.redoStack = [];
+  editor.hideForm = vi.fn();
+  editor.renderList = vi.fn();
+  editor.setDirty = vi.fn((isDirty) => { editor.dirty = isDirty; });
+  editor.onSelectionChange = vi.fn();
+  editor.onVisibilityChange = vi.fn();
+  return editor;
+}
+
+describe('PoiEditor undo/redo dirty restore', () => {
+  it('marks clean when restored POI content matches the saved baseline, regardless of stack depth', () => {
+    const saved = [poi('saved')];
+    const editor = makeEditor({
+      pois: [poi('edited', 1)],
+      originalPois: saved,
+      undoLength: 49,
+    });
+
+    editor._applySnapshot({
+      pois: saved,
+      selectedIndex: 0,
+      visiblePois: [0],
+    });
+
+    expect(editor.setDirty).toHaveBeenCalledWith(false);
+    expect(editor.dirty).toBe(false);
+  });
+
+  it('keeps dirty when restored POI content differs, even if history is at the cap length', () => {
+    const saved = [poi('saved')];
+    const editor = makeEditor({
+      pois: saved,
+      originalPois: saved,
+      undoLength: 50,
+    });
+
+    editor._applySnapshot({
+      pois: [poi('edited', 1)],
+      selectedIndex: 0,
+      visiblePois: [0],
+    });
+
+    expect(editor.undoStack).toHaveLength(50);
+    expect(editor.setDirty).toHaveBeenCalledWith(true);
+    expect(editor.dirty).toBe(true);
+  });
+});

--- a/mapoi_webui/tests/web/poi-history.test.js
+++ b/mapoi_webui/tests/web/poi-history.test.js
@@ -1,0 +1,147 @@
+// vitest unit tests for the pure undo/redo history-stack helpers in
+// mapoi_webui/web/js/poi-history.js (#300).
+//
+// 対象: MapoiPoiHistory.{recordChange, stepUndo, stepRedo}
+//
+// テスト方針: Undo/Redo の正しさ (LIFO 順序 / redo 無効化 / 容量制限 / 空 stack no-op) は
+//   編集データの取り違え・ロストに直結する致命核。DOM 非依存の純 stack ロジックに切り出した
+//   ここを厚く pin し、poi-editor.js 側の配線 (capture 点 / restore 再描画) は手動 / e2e に委ねる。
+import { describe, it, expect } from 'vitest';
+import * as history from '../../web/js/poi-history.js';
+
+describe('recordChange', () => {
+  it('pushes the snapshot onto undoStack', () => {
+    const undo = [];
+    const redo = [];
+    history.recordChange(undo, redo, 's0');
+    expect(undo).toEqual(['s0']);
+    expect(redo).toEqual([]);
+  });
+
+  it('clears the redo stack (a new edit invalidates the redo future)', () => {
+    const undo = ['a'];
+    const redo = ['x', 'y'];
+    history.recordChange(undo, redo, 'b');
+    expect(undo).toEqual(['a', 'b']);
+    expect(redo).toEqual([]);
+  });
+
+  it('enforces the cap by dropping the oldest entries', () => {
+    const undo = [];
+    const redo = [];
+    history.recordChange(undo, redo, 's0', 2);
+    history.recordChange(undo, redo, 's1', 2);
+    history.recordChange(undo, redo, 's2', 2);
+    // s0 (oldest) dropped, newest kept
+    expect(undo).toEqual(['s1', 's2']);
+  });
+
+  it('is unbounded when cap is omitted or non-positive', () => {
+    const undo = [];
+    const redo = [];
+    for (let i = 0; i < 5; i += 1) history.recordChange(undo, redo, `s${i}`);
+    expect(undo).toHaveLength(5);
+    const undo0 = [];
+    for (let i = 0; i < 5; i += 1) history.recordChange(undo0, [], `s${i}`, 0);
+    expect(undo0).toHaveLength(5);
+  });
+});
+
+describe('stepUndo', () => {
+  it('returns null and does not mutate when undoStack is empty', () => {
+    const undo = [];
+    const redo = [];
+    expect(history.stepUndo(undo, redo, 'current')).toBeNull();
+    expect(undo).toEqual([]);
+    expect(redo).toEqual([]);
+  });
+
+  it('moves current onto redoStack and returns the popped snapshot', () => {
+    const undo = ['s0', 's1'];
+    const redo = [];
+    const restored = history.stepUndo(undo, redo, 's2');
+    expect(restored).toBe('s1');
+    expect(undo).toEqual(['s0']);
+    expect(redo).toEqual(['s2']);
+  });
+});
+
+describe('stepRedo', () => {
+  it('returns null and does not mutate when redoStack is empty', () => {
+    const undo = ['s0'];
+    const redo = [];
+    expect(history.stepRedo(undo, redo, 'current')).toBeNull();
+    expect(undo).toEqual(['s0']);
+    expect(redo).toEqual([]);
+  });
+
+  it('moves current onto undoStack and returns the popped snapshot (mirror of undo)', () => {
+    const undo = ['s0'];
+    const redo = ['s2'];
+    const restored = history.stepRedo(undo, redo, 's1');
+    expect(restored).toBe('s2');
+    expect(undo).toEqual(['s0', 's1']);
+    expect(redo).toEqual([]);
+  });
+});
+
+describe('integration: capture-before-mutate editor sequence', () => {
+  // poi-editor.js の使い方を再現する小さなドライバ。state は変異後の値、record は
+  // 「変異直前の state」を積む。undo/redo は返ってきた snapshot を state に適用する。
+  function makeDriver(cap) {
+    const undo = [];
+    const redo = [];
+    let state = 's0';
+    return {
+      undo, redo,
+      get state() { return state; },
+      edit(next) { history.recordChange(undo, redo, state, cap); state = next; },
+      stepBack() { const s = history.stepUndo(undo, redo, state); if (s !== null) state = s; return s; },
+      stepFwd() { const s = history.stepRedo(undo, redo, state); if (s !== null) state = s; return s; },
+    };
+  }
+
+  it('undo reverts edits one step at a time, then no-ops at the baseline', () => {
+    const d = makeDriver();
+    d.edit('s1');
+    d.edit('s2');
+    expect(d.state).toBe('s2');
+    d.stepBack();
+    expect(d.state).toBe('s1');
+    d.stepBack();
+    expect(d.state).toBe('s0');
+    expect(d.stepBack()).toBeNull(); // nothing left to undo
+    expect(d.state).toBe('s0');
+  });
+
+  it('redo re-applies undone edits, then no-ops', () => {
+    const d = makeDriver();
+    d.edit('s1');
+    d.edit('s2');
+    d.stepBack();
+    d.stepBack();
+    expect(d.state).toBe('s0');
+    d.stepFwd();
+    expect(d.state).toBe('s1');
+    d.stepFwd();
+    expect(d.state).toBe('s2');
+    expect(d.stepFwd()).toBeNull(); // nothing left to redo
+    expect(d.state).toBe('s2');
+  });
+
+  it('a new edit after undo discards the redo future', () => {
+    const d = makeDriver();
+    d.edit('s1');
+    d.edit('s2');
+    d.stepBack(); // back to s1, redo future = [s2]
+    expect(d.state).toBe('s1');
+    expect(d.redo).toEqual(['s2']);
+    d.edit('s9'); // new edit diverges
+    expect(d.state).toBe('s9');
+    expect(d.redo).toEqual([]); // s2 future gone
+    expect(d.stepFwd()).toBeNull();
+    // undo now returns to the divergence point, not the discarded s2 line
+    d.stepBack();
+    expect(d.state).toBe('s1');
+  });
+});

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -139,6 +139,8 @@
             <button id="btn-add-poi" title="Add POI">+ Add POI</button>
             <button id="btn-save" title="Save changes" disabled>Save</button>
             <button id="btn-discard" title="Discard changes" disabled>Discard</button>
+            <button id="btn-undo" title="Undo (Ctrl+Z)" disabled>Undo</button>
+            <button id="btn-redo" title="Redo (Ctrl+Shift+Z)" disabled>Redo</button>
             <span id="dirty-indicator"></span>
           </div>
         </div>
@@ -233,6 +235,9 @@
   <!-- poi-interactions.js は MapoiPoiInteractions を window に attach する pure helper 群 (#273)。
        map-viewer.js より前に読み込む (クリック判別 / wedge 幾何 / 座標変換で参照される)。 -->
   <script src="/js/poi-interactions.js"></script>
+  <!-- poi-history.js は MapoiPoiHistory を window に attach する pure helper 群 (#300)。
+       poi-editor.js より前に読み込む (Undo/Redo の stack 操作で参照される)。 -->
+  <script src="/js/poi-history.js"></script>
   <script src="/js/map-viewer.js"></script>
   <script src="/js/poi-editor.js"></script>
   <script src="/js/route-editor.js"></script>

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -773,4 +773,25 @@
     // EventSource は readyState=CONNECTING に戻って自動 reconnect する
     console.warn('SSE connection error, browser will auto-reconnect:', err);
   };
+
+  // --- Keyboard shortcuts (#300) ---
+  // POI editor の Undo/Redo を document レベルで拾う。入力欄 (name / x / y / tags 等) の
+  // 編集中はブラウザ標準の text undo を優先するため無視する (pose tool の Escape ガード
+  // map-viewer.js #270 と同方針)。owned key のみ preventDefault し、他ハンドラを妨げない。
+  document.addEventListener('keydown', (e) => {
+    const t = e.target;
+    if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA'
+        || t.tagName === 'SELECT' || t.isContentEditable)) {
+      return;
+    }
+    if (!(e.ctrlKey || e.metaKey)) return;
+    const key = e.key.toLowerCase();
+    if (key === 'z' && !e.shiftKey) {
+      e.preventDefault();
+      poiEditor.undo();
+    } else if ((key === 'z' && e.shiftKey) || key === 'y') {
+      e.preventDefault();
+      poiEditor.redo();
+    }
+  });
 })();

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -15,11 +15,9 @@ class PoiEditor {
 
     // Undo/Redo: capture-before-mutate スナップショットの stack (#300)。
     // 変異メソッド先頭で _pushUndo() し、redo は新編集で無効化される (poi-history.js)。
-    // savedBaselineDepth = 直近 load/save 時の undoStack 長。undo/redo 後の dirty は
-    // この深さとの差で導出する (履歴は線形なので深さ一致 = saved baseline と同一状態)。
+    // undo/redo 後の dirty は履歴深さではなく、保存済み POI との内容比較で導出する。
     this.undoStack = [];
     this.redoStack = [];
-    this.savedBaselineDepth = 0;
     this.HISTORY_CAP = 50;
 
     this.tagDefinitions = [];  // [{name, description, is_system}, ...]
@@ -82,7 +80,6 @@ class PoiEditor {
     // 復元させない (#300 安全要件)。
     this.undoStack = [];
     this.redoStack = [];
-    this.savedBaselineDepth = 0;
     this.setDirty(false);
     this.hideForm();
     this.renderList();
@@ -589,11 +586,16 @@ class PoiEditor {
     };
   }
 
+  _isPoiContentDirty() {
+    return JSON.stringify(this.pois) !== JSON.stringify(this.originalPois);
+  }
+
   /**
    * snapshot を working copy へ復元し、map / list を再描画する (#300)。
-   * 開いている編集フォームは閉じる (stale な入力値が残るのを避ける MVP 方針)。dirty は
-   * saved baseline からの stack 深さ差で導出。onSelectionChange / onVisibilityChange を
-   * 発火して app.js 側に Leaflet marker の再描画 (showPois / highlightPoi) を委ねる。
+   * 開いている編集フォームは閉じる (stale な入力値が残るのを避ける MVP 方針)。
+   * dirty は保存済み POI との内容差で導出し、history cap で stack 深さが変化しても
+   * Save ボタン状態が実データとずれないようにする。onSelectionChange / onVisibilityChange
+   * を発火して app.js 側に Leaflet marker の再描画 (showPois / highlightPoi) を委ねる。
    */
   _applySnapshot(snap) {
     this.pois = JSON.parse(JSON.stringify(snap.pois));
@@ -602,7 +604,7 @@ class PoiEditor {
     this.editingIndex = -1;
     this.hideForm();
     this.renderList();
-    this.setDirty(this.undoStack.length !== this.savedBaselineDepth);
+    this.setDirty(this._isPoiContentDirty());
     if (this.onSelectionChange) this.onSelectionChange(this.selectedIndex);
     if (this.onVisibilityChange) this.onVisibilityChange(this.visiblePois);
   }
@@ -651,9 +653,8 @@ class PoiEditor {
       }
       if (result.ok && result.success) {
         this.originalPois = JSON.parse(JSON.stringify(this.pois));
-        // save 後も undo 履歴は残す。現在の stack 深さを新 baseline とし、undo/redo 後の
-        // dirty 判定はこの深さとの差で行う (save 直後は一致するので clean) (#300)。
-        this.savedBaselineDepth = this.undoStack.length;
+        // save 後も undo 履歴は残す。undo/redo 後の dirty 判定は originalPois との
+        // 内容比較で行うため、履歴上限で古い stack entry が drop されても clean/dirty がずれない。
         // backend が再計算した最新 version を frontend に反映 (#241)。
         if (result.config_version) this.configVersion = result.config_version;
         this.setDirty(false);
@@ -680,7 +681,6 @@ class PoiEditor {
     // クリーン基準へ戻すので履歴も捨てる (discard を跨いで undo させない) (#300)。
     this.undoStack = [];
     this.redoStack = [];
-    this.savedBaselineDepth = 0;
     this.setDirty(false);
     this.hideForm();
     this.renderList();

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -13,6 +13,15 @@ class PoiEditor {
     // 楽観的競合検出用 yaml ハッシュ (#241)。GET 時に backend から受け取り、Save 時に送り返す。
     this.configVersion = null;
 
+    // Undo/Redo: capture-before-mutate スナップショットの stack (#300)。
+    // 変異メソッド先頭で _pushUndo() し、redo は新編集で無効化される (poi-history.js)。
+    // savedBaselineDepth = 直近 load/save 時の undoStack 長。undo/redo 後の dirty は
+    // この深さとの差で導出する (履歴は線形なので深さ一致 = saved baseline と同一状態)。
+    this.undoStack = [];
+    this.redoStack = [];
+    this.savedBaselineDepth = 0;
+    this.HISTORY_CAP = 50;
+
     this.tagDefinitions = [];  // [{name, description, is_system}, ...]
     this.onDirtyChange = null;     // callback(isDirty)
     this.onSelectionChange = null; // callback(index)
@@ -33,6 +42,8 @@ class PoiEditor {
     this.btnDiscard = document.getElementById('btn-discard');
     this.btnAddPoi = document.getElementById('btn-add-poi');
     this.dirtyIndicator = document.getElementById('dirty-indicator');
+    this.btnUndo = document.getElementById('btn-undo');
+    this.btnRedo = document.getElementById('btn-redo');
 
     // Form inputs
     this.inputName = document.getElementById('poi-name');
@@ -50,6 +61,9 @@ class PoiEditor {
     this.btnAddPoi.addEventListener('click', () => this.startAddPoi());
     this.btnSave.addEventListener('click', () => this.save());
     this.btnDiscard.addEventListener('click', () => this.discard());
+    // Undo/Redo ボタンは無くても (DOM harness 等) インスタンス化できるよう null guard (#300)。
+    if (this.btnUndo) this.btnUndo.addEventListener('click', () => this.undo());
+    if (this.btnRedo) this.btnRedo.addEventListener('click', () => this.redo());
   }
 
   /**
@@ -63,6 +77,12 @@ class PoiEditor {
     this.visiblePois = new Set(pois.map((_, i) => i));
     // 楽観的競合検出 token (#241)。後続の save() で backend に送り返す。
     this.configVersion = configVersion || null;
+    // loadPois は全 reload (初期 load / map 切替 / 409 onConflictReload / SSE config_changed) の
+    // 単一 funnel。ここで履歴を捨て、別 map や conflict 前バージョンの POI を undo で
+    // 復元させない (#300 安全要件)。
+    this.undoStack = [];
+    this.redoStack = [];
+    this.savedBaselineDepth = 0;
     this.setDirty(false);
     this.hideForm();
     this.renderList();
@@ -182,6 +202,7 @@ class PoiEditor {
    * Delete a POI.
    */
   deletePoi(index) {
+    this._pushUndo();
     this.pois.splice(index, 1);
     if (this.selectedIndex === index) this.selectedIndex = -1;
     if (this.selectedIndex > index) this.selectedIndex--;
@@ -204,6 +225,7 @@ class PoiEditor {
    * Copy a POI (deep clone with "_copy" suffix, open in edit form).
    */
   copyPoi(index) {
+    this._pushUndo();
     const original = this.pois[index];
     const copy = JSON.parse(JSON.stringify(original));
     copy.name = original.name + '_copy';
@@ -416,6 +438,9 @@ class PoiEditor {
       alert(tagValidation.error);
       return;
     }
+    // validation を全て通過し実際に変異する直前で履歴に積む。alert で早期 return した
+    // 経路 (変異なし) では積まない (#300)。
+    this._pushUndo();
     if (this.editingIndex === -2) {
       // New POI
       this.pois.push(poi);
@@ -474,6 +499,7 @@ class PoiEditor {
   updateDraggedPosition(index, x, y) {
     const poi = this.pois[index];
     if (!poi || !poi.pose) return;
+    this._pushUndo();
     poi.pose.x = MapoiPoiFilter.roundTo(x, MapoiPoiFilter.POSE_XY_DIGITS);
     poi.pose.y = MapoiPoiFilter.roundTo(y, MapoiPoiFilter.POSE_XY_DIGITS);
     if (this.editingIndex === index) {
@@ -492,6 +518,7 @@ class PoiEditor {
   updateDraggedYaw(index, yaw) {
     const poi = this.pois[index];
     if (!poi || !poi.pose) return;
+    this._pushUndo();
     poi.pose.yaw = MapoiPoiFilter.roundTo(yaw, MapoiPoiFilter.POSE_YAW_DIGITS);
     if (this.editingIndex === index) {
       this.inputYaw.value = poi.pose.yaw;
@@ -522,9 +549,80 @@ class PoiEditor {
     this.btnSave.disabled = !isDirty;
     this.btnDiscard.disabled = !isDirty;
     this.dirtyIndicator.textContent = isDirty ? 'Unsaved changes' : '';
+    this._updateUndoButtons();
     if (this.onDirtyChange) {
       this.onDirtyChange(isDirty);
     }
+  }
+
+  /**
+   * Undo/Redo ボタンの有効/無効を stack 長に同期する (#300)。setDirty が全変異 /
+   * undo / redo / load / save / discard で必ず呼ばれるので、ここを単一同期点にする。
+   */
+  _updateUndoButtons() {
+    if (this.btnUndo) this.btnUndo.disabled = this.undoStack.length === 0;
+    if (this.btnRedo) this.btnRedo.disabled = this.redoStack.length === 0;
+  }
+
+  /**
+   * 変異直前に現在状態の snapshot を undo stack へ積む (#300)。redo の無効化は
+   * poi-history.recordChange 内で行われる。各変異メソッドの「変異が確定する直前」で呼ぶ。
+   */
+  _pushUndo() {
+    MapoiPoiHistory.recordChange(
+      this.undoStack,
+      this.redoStack,
+      this._snapshot(),
+      this.HISTORY_CAP,
+    );
+  }
+
+  /**
+   * undo/redo で積む・復元する state の deep clone。pois 本体に加え、delete の index
+   * shift を replay 無しで巻き戻せるよう selectedIndex / visiblePois も含める (#300)。
+   */
+  _snapshot() {
+    return {
+      pois: JSON.parse(JSON.stringify(this.pois)),
+      selectedIndex: this.selectedIndex,
+      visiblePois: Array.from(this.visiblePois),
+    };
+  }
+
+  /**
+   * snapshot を working copy へ復元し、map / list を再描画する (#300)。
+   * 開いている編集フォームは閉じる (stale な入力値が残るのを避ける MVP 方針)。dirty は
+   * saved baseline からの stack 深さ差で導出。onSelectionChange / onVisibilityChange を
+   * 発火して app.js 側に Leaflet marker の再描画 (showPois / highlightPoi) を委ねる。
+   */
+  _applySnapshot(snap) {
+    this.pois = JSON.parse(JSON.stringify(snap.pois));
+    this.selectedIndex = snap.selectedIndex;
+    this.visiblePois = new Set(snap.visiblePois);
+    this.editingIndex = -1;
+    this.hideForm();
+    this.renderList();
+    this.setDirty(this.undoStack.length !== this.savedBaselineDepth);
+    if (this.onSelectionChange) this.onSelectionChange(this.selectedIndex);
+    if (this.onVisibilityChange) this.onVisibilityChange(this.visiblePois);
+  }
+
+  /**
+   * 1 手戻す。戻せる履歴が無ければ no-op (#300)。
+   */
+  undo() {
+    const snap = MapoiPoiHistory.stepUndo(this.undoStack, this.redoStack, this._snapshot());
+    if (!snap) return;
+    this._applySnapshot(snap);
+  }
+
+  /**
+   * 1 手やり直す。やり直せる履歴が無ければ no-op (#300)。
+   */
+  redo() {
+    const snap = MapoiPoiHistory.stepRedo(this.undoStack, this.redoStack, this._snapshot());
+    if (!snap) return;
+    this._applySnapshot(snap);
   }
 
   /**
@@ -553,6 +651,9 @@ class PoiEditor {
       }
       if (result.ok && result.success) {
         this.originalPois = JSON.parse(JSON.stringify(this.pois));
+        // save 後も undo 履歴は残す。現在の stack 深さを新 baseline とし、undo/redo 後の
+        // dirty 判定はこの深さとの差で行う (save 直後は一致するので clean) (#300)。
+        this.savedBaselineDepth = this.undoStack.length;
         // backend が再計算した最新 version を frontend に反映 (#241)。
         if (result.config_version) this.configVersion = result.config_version;
         this.setDirty(false);
@@ -576,6 +677,10 @@ class PoiEditor {
     this.pois = JSON.parse(JSON.stringify(this.originalPois));
     this.selectedIndex = -1;
     this.editingIndex = -1;
+    // クリーン基準へ戻すので履歴も捨てる (discard を跨いで undo させない) (#300)。
+    this.undoStack = [];
+    this.redoStack = [];
+    this.savedBaselineDepth = 0;
     this.setDirty(false);
     this.hideForm();
     this.renderList();

--- a/mapoi_webui/web/js/poi-history.js
+++ b/mapoi_webui/web/js/poi-history.js
@@ -1,0 +1,92 @@
+/**
+ * Pure undo/redo history-stack helpers for the POI editor (#300).
+ *
+ * poi-editor.js の Undo/Redo コアを DOM / インスタンス非依存の純関数に切り出し、
+ * 単体テスト (mapoi_webui/tests/web/poi-history.test.js) で回帰検知できるようにする
+ * (poi-interactions.js / poi-filter.js #273 と同じ dual-export パターン)。
+ *
+ * 扱う state は不透明な「snapshot」(呼び出し側が deep clone した plain object) で、
+ * このモジュールは push / pop の順序と redo 無効化・容量制限だけを責務とする。
+ * snapshot の中身 (pois / selectedIndex / visiblePois) や clone 方法は poi-editor.js 側。
+ *
+ * Browser からは `MapoiPoiHistory.*` のグローバルとして使い、Node (vitest) からは
+ * `module.exports` 経由で import する (Leaflet / DOM / window 非依存)。
+ */
+(function () {
+  'use strict';
+
+  /**
+   * 変異直前の snapshot を記録する (capture-before-mutate)。
+   *
+   * - undoStack に snapshot を push する
+   * - redoStack をクリアする (新しい編集が入った時点で redo の未来は無効化される —
+   *   この単一 choke point に集約することで per-op の付け忘れを防ぐ)
+   * - cap が正の数なら、それを超えた古い entry を先頭から drop する
+   *
+   * 両 stack を in-place で破壊的に更新する (poi-editor.js が保持する this.undoStack /
+   * this.redoStack をそのまま渡す前提)。
+   *
+   * @param {Array} undoStack
+   * @param {Array} redoStack
+   * @param {*} snapshot 変異直前の状態 (呼び出し側で deep clone 済)
+   * @param {number} [cap] undoStack の最大長 (省略 / 0 以下なら無制限)
+   */
+  function recordChange(undoStack, redoStack, snapshot, cap) {
+    undoStack.push(snapshot);
+    redoStack.length = 0;
+    if (typeof cap === 'number' && cap > 0) {
+      while (undoStack.length > cap) {
+        undoStack.shift();
+      }
+    }
+  }
+
+  /**
+   * 1 手戻す。undoStack が空なら null を返し何もしない。
+   *
+   * currentSnapshot (= 現在の状態) を redoStack に積み、undoStack の先端を pop して
+   * 「復元すべき snapshot」として返す。呼び出し側はこの戻り値を state に適用する。
+   *
+   * @param {Array} undoStack
+   * @param {Array} redoStack
+   * @param {*} currentSnapshot 現在の状態 (呼び出し側で deep clone 済)
+   * @returns {*|null} 復元すべき snapshot、戻せない時は null
+   */
+  function stepUndo(undoStack, redoStack, currentSnapshot) {
+    if (undoStack.length === 0) {
+      return null;
+    }
+    redoStack.push(currentSnapshot);
+    return undoStack.pop();
+  }
+
+  /**
+   * 1 手やり直す。redoStack が空なら null を返し何もしない (stepUndo の鏡像)。
+   *
+   * @param {Array} undoStack
+   * @param {Array} redoStack
+   * @param {*} currentSnapshot 現在の状態 (呼び出し側で deep clone 済)
+   * @returns {*|null} 復元すべき snapshot、やり直せない時は null
+   */
+  function stepRedo(undoStack, redoStack, currentSnapshot) {
+    if (redoStack.length === 0) {
+      return null;
+    }
+    undoStack.push(currentSnapshot);
+    return redoStack.pop();
+  }
+
+  const api = {
+    recordChange,
+    stepUndo,
+    stepRedo,
+  };
+
+  if (typeof window !== 'undefined') {
+    window.MapoiPoiHistory = window.MapoiPoiHistory || {};
+    Object.assign(window.MapoiPoiHistory, api);
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+}());


### PR DESCRIPTION
## 概要

POI editor (Web UI) に multi-level Undo/Redo を追加する。Closes #300。

POI 編集 (追加 / 編集 / コピー / 削除 / ドラッグ移動 / yaw 回転) を 1 手単位で取り消し / やり直しできるようにする。現状は誤操作を戻す手段が無く、`Discard` で全未保存変更を破棄するしかなかった。

## 変更

- **`web/js/poi-history.js` (新規)**: 純モジュール `MapoiPoiHistory` (`recordChange` / `stepUndo` / `stepRedo`)。stack 順序・redo 無効化・容量制限のみを責務とし DOM 非依存 (`poi-interactions.js` / `poi-filter.js` と同じ dual-export #273)。
- **`web/js/poi-editor.js`**: `undoStack` / `redoStack` / `savedBaselineDepth`、`_pushUndo` / `_snapshot` / `_applySnapshot` / `undo` / `redo`。capture 点 = `deletePoi` / `copyPoi` / `formOk` (validation 通過後) / `updateDraggedPosition` / `updateDraggedYaw` (drag・yaw は `dragend` 確定で 1 ジェスチャ = 1 ステップ)。`loadPois` (全 reload funnel) と `discard` で履歴リセット、`save` 成功で baseline 深さ更新。
- **`web/js/app.js`**: document レベルの keydown ルータ。Ctrl/Cmd+Z = undo、Ctrl+Shift+Z・Ctrl+Y = redo。入力欄 (INPUT/TEXTAREA/SELECT/contenteditable) focus 中は無視し、欄内のブラウザ標準 text undo を温存 (pose tool の Escape ガード #270 と同方針)。
- **`web/index.html`**: `#poi-toolbar` に Undo/Redo ボタン (stack 空で disabled)、`poi-history.js` を読み込み。
- **`tests/web/poi-history.test.js` (新規)**: vitest 11 件。

## 設計判断

- snapshot-stack を採用 (command パターン不採用)。state が小さく既存 `originalPois` も JSON deep-clone 復元のため、inverse 操作を書くより全状態クローンが安全 (`readForm` の未知 YAML フィールド保持も自動的に守られる)。
- 重い jsdom DOM ハーネスは避け、純 stack コアを厚くテスト (risk-based)。配線 (capture 点 / restore 再描画) は手動 / e2e に委ねる。

## reload / 安全性

`loadPois` は初期 load / map 切替 / 409 `onConflictReload` / SSE `config_changed` の単一 funnel。ここで履歴を捨てるため、**別 map や conflict 前バージョンの POI を undo で復元することはない**。

## 既知の制約

- 未保存編集が `HISTORY_CAP` (50) を超えて古い履歴が drop されると、undo/redo 後の dirty 判定が稀にずれ得る (データ消失なし、Save ボタン状態のみ)。
- route editor との統合 Undo は scope 外 (route-editor は別 state、app.js coordinator が要る #241)。content-based dirty / `beforeunload` / 削除 confirm / 個別 POI ロックも別 issue/PR。

## テスト

- `cd mapoi_webui/tests/web && npx vitest run` → 全 38 件パス (新規 poi-history 11 件)。
- `node --check` で `poi-history.js` / `poi-editor.js` / `app.js` 構文 OK。
- ライブ動作確認 (Ctrl+Z 実機) は `dev` サービス (bind mount) で別途。
