### PR TITLE
[codex] feat(webui): improve route editor workflow

### DIFF
--- a/mapoi_webui/tests/web/e2e/section-collapse.e2e.js
+++ b/mapoi_webui/tests/web/e2e/section-collapse.e2e.js
@@ -40,4 +40,39 @@ test.describe('D. section 折りたたみの app.js 実適用', () => {
     expect(await displayOf(page, '#tag-body')).toBe('none');        // 元の閉のまま (全開ではない)
     expect(await displayOf(page, '#poi-list')).not.toBe('none');    // 一覧復活
   });
+
+  test('Route 編集フォーム開で他 section と route-list が畳まれ、閉じると元の開閉に戻る', async ({ page }) => {
+    await loadApp(page);
+
+    await setSectionOpen(page, '#btn-nav-toggle', '#nav-body', true);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await setSectionOpen(page, '#btn-tag-toggle', '#tag-body', false);
+    await setSectionOpen(page, '#btn-route-toggle', '#route-body', true);
+
+    const navBefore = await displayOf(page, '#nav-body');
+    const poiBefore = await displayOf(page, '#poi-body');
+    const routeBefore = await displayOf(page, '#route-body');
+    expect(navBefore).not.toBe('none');
+    expect(poiBefore).not.toBe('none');
+    expect(routeBefore).not.toBe('none');
+    expect(await displayOf(page, '#tag-body')).toBe('none');
+
+    const routeItem = page.locator('.route-item').filter({ hasText: 'test_route' });
+    await routeItem.locator('.btn-edit').click();
+    await expect(page.locator('#route-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+
+    expect(await displayOf(page, '#nav-body')).toBe('none');
+    expect(await displayOf(page, '#poi-body')).toBe('none');
+    expect(await displayOf(page, '#tag-body')).toBe('none');
+    expect(await displayOf(page, '#route-body')).not.toBe('none');
+    expect(await displayOf(page, '#route-list')).toBe('none');
+
+    await page.locator('#btn-route-form-cancel').click();
+    await expect(page.locator('#route-edit-form')).toHaveClass(/(^|\s)hidden(\s|$)/);
+    expect(await displayOf(page, '#nav-body')).toBe(navBefore);
+    expect(await displayOf(page, '#poi-body')).toBe(poiBefore);
+    expect(await displayOf(page, '#tag-body')).toBe('none');
+    expect(await displayOf(page, '#route-body')).toBe(routeBefore);
+    expect(await displayOf(page, '#route-list')).not.toBe('none');
+  });
 });

--- a/mapoi_webui/tests/web/route-editor-history.test.js
+++ b/mapoi_webui/tests/web/route-editor-history.test.js
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+//
+// RouteEditor waypoint UX regression tests (#303/#304/#305).
+//
+// RouteEditor is DOM-heavy, so most tests use a thin Object.create harness and
+// pin the state transitions that are easy to regress: edit-form history,
+// arbitrary waypoint reordering, and waypoint focus callbacks.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as history from '../../web/js/poi-history.js';
+import RouteEditor from '../../web/js/route-editor.js';
+
+function makeEditor() {
+  const editor = Object.create(RouteEditor.prototype);
+  editor.editingIndex = 0;
+  editor.inputRouteName = { value: 'route-a' };
+  editor.editingWaypoints = ['A', 'B', 'C'];
+  editor.editingLandmarks = ['L1'];
+  editor.undoStack = [];
+  editor.redoStack = [];
+  editor.HISTORY_CAP = 50;
+  editor.dragWaypointIndex = -1;
+  editor.btnUndo = { disabled: true };
+  editor.btnRedo = { disabled: true };
+  editor.waypointListEl = { querySelectorAll: () => [] };
+  editor.renderWaypointList = vi.fn();
+  editor.renderLandmarkList = vi.fn();
+  editor.onEditingChange = vi.fn();
+  return editor;
+}
+
+beforeEach(() => {
+  globalThis.MapoiPoiHistory = history;
+});
+
+describe('RouteEditor edit-form history', () => {
+  it('undoes and redoes arbitrary waypoint reordering', () => {
+    const editor = makeEditor();
+
+    editor.moveWaypointTo(0, 2);
+
+    expect(editor.editingWaypoints).toEqual(['B', 'C', 'A']);
+    expect(editor.btnUndo.disabled).toBe(false);
+    expect(editor.btnRedo.disabled).toBe(true);
+
+    editor.undo();
+    expect(editor.editingWaypoints).toEqual(['A', 'B', 'C']);
+    expect(editor.btnUndo.disabled).toBe(true);
+    expect(editor.btnRedo.disabled).toBe(false);
+
+    editor.redo();
+    expect(editor.editingWaypoints).toEqual(['B', 'C', 'A']);
+    expect(editor.btnUndo.disabled).toBe(false);
+    expect(editor.btnRedo.disabled).toBe(true);
+  });
+
+  it('clears the redo future when a new waypoint edit happens after undo', () => {
+    const editor = makeEditor();
+    editor.onWaypointFocus = vi.fn();
+
+    editor.removeWaypoint(1);
+    editor.undo();
+    expect(editor.redoStack).toHaveLength(1);
+
+    editor.addWaypointByName('D');
+
+    expect(editor.editingWaypoints).toEqual(['A', 'B', 'C', 'D']);
+    expect(editor.onWaypointFocus).toHaveBeenCalledWith('D');
+    expect(editor.redoStack).toEqual([]);
+    expect(editor.btnRedo.disabled).toBe(true);
+  });
+
+  it('includes landmark add/remove in the same edit-form history', () => {
+    const editor = makeEditor();
+
+    editor.removeLandmark(0);
+    expect(editor.editingLandmarks).toEqual([]);
+
+    editor.undo();
+    expect(editor.editingLandmarks).toEqual(['L1']);
+
+    editor.redo();
+    expect(editor.editingLandmarks).toEqual([]);
+  });
+
+  it('does not mutate history or redraw for invalid/no-op reorders', () => {
+    const editor = makeEditor();
+
+    editor.moveWaypointTo(1, 1);
+    editor.moveWaypointTo(-1, 1);
+    editor.moveWaypointTo(1, 99);
+
+    expect(editor.editingWaypoints).toEqual(['A', 'B', 'C']);
+    expect(editor.undoStack).toEqual([]);
+    expect(editor.renderWaypointList).not.toHaveBeenCalled();
+  });
+});
+
+describe('RouteEditor waypoint focus UI', () => {
+  it('fires waypoint focus from rendered rows without marking data dirty', () => {
+    document.body.innerHTML = '<div id="waypoints"></div>';
+    const editor = Object.create(RouteEditor.prototype);
+    editor.waypointListEl = document.getElementById('waypoints');
+    editor.editingWaypoints = ['A'];
+    editor.poiNames = ['A'];
+    editor.onWaypointFocus = vi.fn();
+    editor.setDirty = vi.fn();
+
+    editor.renderWaypointList();
+    const row = editor.waypointListEl.querySelector('.wp-item');
+
+    row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    row.dispatchEvent(new Event('focus'));
+
+    expect(editor.onWaypointFocus).toHaveBeenCalledWith('A');
+    expect(editor.setDirty).not.toHaveBeenCalled();
+  });
+
+  it('moves a dragged waypoint to the drop target index', () => {
+    const editor = makeEditor();
+    editor.dragWaypointIndex = 0;
+
+    editor._onWaypointDrop({ preventDefault: vi.fn() }, 2);
+
+    expect(editor.editingWaypoints).toEqual(['B', 'C', 'A']);
+    expect(editor.dragWaypointIndex).toBe(-1);
+  });
+});

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -106,25 +106,54 @@ main {
   border-left: 1px solid #ddd;
 }
 
-#poi-toolbar {
+.editor-toolbar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
+  gap: 6px;
+  padding: 6px 12px;
   flex-wrap: wrap;
   border-top: 1px solid #ddd;
   background: #f5f5f5;
   flex-shrink: 0;
 }
 
-#poi-toolbar button {
-  padding: 8px 16px;
+.toolbar-command-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.editor-toolbar button {
+  padding: 6px 10px;
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 0.9rem;
-  min-height: 44px;
-  min-width: 44px;
+  font-size: 0.82rem;
+  min-height: 34px;
+  min-width: 34px;
+}
+
+.editor-toolbar button:disabled {
+  background: #bbb;
+  cursor: default;
+}
+
+.btn-icon-command {
+  width: 34px;
+  padding: 4px 0;
+  border: 1px solid #ccd1d1;
+  background: #ecf0f1;
+  color: #2c3e50;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.btn-icon-command:hover:not(:disabled) {
+  background: #dfe6e9;
+}
+
+.btn-icon-command:disabled {
+  color: #888;
 }
 
 #btn-add-poi {
@@ -610,8 +639,34 @@ main {
   font-size: 0.85rem;
 }
 
+.wp-item:focus {
+  outline: 2px solid #3498db;
+  outline-offset: -2px;
+  background: #eef5fc;
+}
+
+.wp-item.wp-drop-target {
+  background: #e8f6f3;
+  box-shadow: inset 3px 0 0 #16a085;
+}
+
 .wp-item:last-child {
   border-bottom: none;
+}
+
+.wp-drag-handle {
+  width: 18px;
+  color: #7f8c8d;
+  cursor: grab;
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  line-height: 1;
+  text-align: center;
+  user-select: none;
+}
+
+.wp-drag-handle:active {
+  cursor: grabbing;
 }
 
 .wp-num {
@@ -725,23 +780,7 @@ main {
   background: #219a52;
 }
 
-/* Route toolbar */
-#route-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 16px;
-  flex-wrap: wrap;
-}
-
-#route-toolbar button {
-  padding: 6px 12px;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.8rem;
-  min-height: 36px;
-}
+/* Route toolbar shares .editor-toolbar */
 
 #btn-add-route {
   background: #8e44ad;

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -135,12 +135,16 @@
               <button id="btn-form-cancel">Cancel</button>
             </div>
           </div>
-          <div id="poi-toolbar">
-            <button id="btn-add-poi" title="Add POI">+ Add POI</button>
-            <button id="btn-save" title="Save changes" disabled>Save</button>
-            <button id="btn-discard" title="Discard changes" disabled>Discard</button>
-            <button id="btn-undo" title="Undo (Ctrl+Z)" disabled>Undo</button>
-            <button id="btn-redo" title="Redo (Ctrl+Shift+Z)" disabled>Redo</button>
+          <div id="poi-toolbar" class="editor-toolbar">
+            <button id="btn-add-poi" class="toolbar-primary" title="Add POI">+ Add POI</button>
+            <span class="toolbar-command-group">
+              <button id="btn-save" title="Save changes" disabled>Save</button>
+              <button id="btn-discard" title="Discard changes" disabled>Discard</button>
+            </span>
+            <span class="toolbar-command-group toolbar-history-group" aria-label="POI history">
+              <button id="btn-undo" class="btn-icon-command" title="Undo (Ctrl+Z)" aria-label="Undo POI edit" disabled>&#8630;</button>
+              <button id="btn-redo" class="btn-icon-command" title="Redo (Ctrl+Shift+Z)" aria-label="Redo POI edit" disabled>&#8631;</button>
+            </span>
             <span id="dirty-indicator"></span>
           </div>
         </div>
@@ -213,10 +217,16 @@
               <button id="btn-route-form-cancel">Cancel</button>
             </div>
           </div>
-          <div id="route-toolbar">
-            <button id="btn-add-route" title="Add Route">+ Add Route</button>
-            <button id="btn-save-routes" title="Save route changes" disabled>Save</button>
-            <button id="btn-discard-routes" title="Discard route changes" disabled>Discard</button>
+          <div id="route-toolbar" class="editor-toolbar">
+            <button id="btn-add-route" class="toolbar-primary" title="Add Route">+ Add Route</button>
+            <span class="toolbar-command-group">
+              <button id="btn-save-routes" title="Save route changes" disabled>Save</button>
+              <button id="btn-discard-routes" title="Discard route changes" disabled>Discard</button>
+            </span>
+            <span class="toolbar-command-group toolbar-history-group" aria-label="Route history">
+              <button id="btn-route-undo" class="btn-icon-command" title="Undo route edit (Ctrl+Z)" aria-label="Undo route edit" disabled>&#8630;</button>
+              <button id="btn-route-redo" class="btn-icon-command" title="Redo route edit (Ctrl+Shift+Z)" aria-label="Redo route edit" disabled>&#8631;</button>
+            </span>
             <span id="route-dirty-indicator"></span>
           </div>
         </div>

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -374,6 +374,15 @@
     syncNavRouteSelect();
   };
 
+  // Waypoint candidate/row focus during route editing highlights the matching POI marker.
+  // This is preview-only UI feedback: it must not mutate route / POI dirty state (#305).
+  routeEditor.onWaypointFocus = (name) => {
+    if (!name) return;
+    const index = poiEditor.pois.findIndex((p) => p.name === name);
+    if (index < 0) return;
+    mapViewer.highlightPoi(index);
+  };
+
   // Route visibility toggle
   routeEditor.onVisibilityChange = () => {
     redrawRoutes();
@@ -442,7 +451,7 @@
   // compact viewport 初期表示で開く section は nav-controls.js に集約 (#199)。
   const initialSections = MapoiNavControls.initialSectionOpenStates(compactInitial);
   const routeToggle = setupSectionToggle('btn-route-toggle', document.getElementById('route-body'), initialSections.route);
-  setupSectionToggle('btn-poi-toggle', document.getElementById('poi-body'), initialSections.poi);
+  const poiToggle = setupSectionToggle('btn-poi-toggle', document.getElementById('poi-body'), initialSections.poi);
   const tagToggle = setupSectionToggle('btn-tag-toggle', document.getElementById('tag-body'), initialSections.tag);
   if (typeof compactMediaQuery.addEventListener === 'function') {
     compactMediaQuery.addEventListener('change', refreshResponsiveLayout);
@@ -708,35 +717,55 @@
   const navToggle = setupSectionToggle('btn-nav-toggle', document.getElementById('nav-body'), initialSections.nav);
   startNavStatusPolling();
 
-  // --- 編集モード時のセクション折りたたみ (#240) ---
-  // POI 編集フォームを開いたら他セクション (Navigation / Tags / Routes) を畳み、POI 一覧も
-  // 隠してフォームに集中させる (狭い sidebar で「非常に見づらい」状態の解消)。Save/Discard/
-  // Add は poi-toolbar に残るので編集継続・保存は可能。閉じたら元の開閉状態へ戻す。
+  // --- 編集モード時の sidebar focus (#240 / #302) ---
+  // POI / Route の edit form を開いたら他セクションを畳み、対象 list も隠して form +
+  // compact toolbar に集中させる。閉じたら元の開閉状態と list 表示へ戻す。
   const poiListEl = document.getElementById('poi-list');
-  let savedSectionStates = null;
-  function collapseSectionsForEditing() {
-    if (savedSectionStates) return; // 既に畳み済 (編集 POI 切替の二重呼び出し等) は状態を保持
-    savedSectionStates = {
+  const routeListEl = document.getElementById('route-list');
+  let savedSidebarFocus = null;
+  let activeSidebarFocus = null;
+  function activateSidebarFocus(editor) {
+    if (activeSidebarFocus === editor) return;
+    if (activeSidebarFocus) restoreSidebarFocus(activeSidebarFocus);
+    savedSidebarFocus = {
       nav: navToggle.isOpen(),
+      poi: poiToggle.isOpen(),
       tag: tagToggle.isOpen(),
       route: routeToggle.isOpen(),
+      poiListDisplay: poiListEl ? poiListEl.style.display : '',
+      routeListDisplay: routeListEl ? routeListEl.style.display : '',
     };
+    activeSidebarFocus = editor;
     navToggle.setOpen(false);
     tagToggle.setOpen(false);
-    routeToggle.setOpen(false);
-    if (poiListEl) poiListEl.style.display = 'none';
+    if (editor === 'poi') {
+      poiToggle.setOpen(true);
+      routeToggle.setOpen(false);
+      if (poiListEl) poiListEl.style.display = 'none';
+    } else if (editor === 'route') {
+      poiToggle.setOpen(false);
+      routeToggle.setOpen(true);
+      if (routeListEl) routeListEl.style.display = 'none';
+    }
   }
-  function restoreSectionsAfterEditing() {
-    if (poiListEl) poiListEl.style.display = '';
-    if (!savedSectionStates) return; // 畳んでいない (初期 hideForm 等) なら何もしない
-    navToggle.setOpen(savedSectionStates.nav);
-    tagToggle.setOpen(savedSectionStates.tag);
-    routeToggle.setOpen(savedSectionStates.route);
-    savedSectionStates = null;
+  function restoreSidebarFocus(editor) {
+    if (activeSidebarFocus !== editor || !savedSidebarFocus) return;
+    if (poiListEl) poiListEl.style.display = savedSidebarFocus.poiListDisplay;
+    if (routeListEl) routeListEl.style.display = savedSidebarFocus.routeListDisplay;
+    navToggle.setOpen(savedSidebarFocus.nav);
+    poiToggle.setOpen(savedSidebarFocus.poi);
+    tagToggle.setOpen(savedSidebarFocus.tag);
+    routeToggle.setOpen(savedSidebarFocus.route);
+    savedSidebarFocus = null;
+    activeSidebarFocus = null;
   }
   poiEditor.onEditFormVisibilityChange = (isOpen) => {
-    if (isOpen) collapseSectionsForEditing();
-    else restoreSectionsAfterEditing();
+    if (isOpen) activateSidebarFocus('poi');
+    else restoreSidebarFocus('poi');
+  };
+  routeEditor.onEditFormVisibilityChange = (isOpen) => {
+    if (isOpen) activateSidebarFocus('route');
+    else restoreSidebarFocus('route');
   };
 
   // --- Initialize ---
@@ -774,8 +803,8 @@
     console.warn('SSE connection error, browser will auto-reconnect:', err);
   };
 
-  // --- Keyboard shortcuts (#300) ---
-  // POI editor の Undo/Redo を document レベルで拾う。入力欄 (name / x / y / tags 等) の
+  // --- Keyboard shortcuts (#300 / #303) ---
+  // active editor の Undo/Redo を document レベルで拾う。入力欄 (name / x / y / tags 等) の
   // 編集中はブラウザ標準の text undo を優先するため無視する (pose tool の Escape ガード
   // map-viewer.js #270 と同方針)。owned key のみ preventDefault し、他ハンドラを妨げない。
   document.addEventListener('keydown', (e) => {
@@ -788,10 +817,12 @@
     const key = e.key.toLowerCase();
     if (key === 'z' && !e.shiftKey) {
       e.preventDefault();
-      poiEditor.undo();
+      if (routeEditor.editingIndex !== -1) routeEditor.undo();
+      else poiEditor.undo();
     } else if ((key === 'z' && e.shiftKey) || key === 'y') {
       e.preventDefault();
-      poiEditor.redo();
+      if (routeEditor.editingIndex !== -1) routeEditor.redo();
+      else poiEditor.redo();
     }
   });
 })();

--- a/mapoi_webui/web/js/route-editor.js
+++ b/mapoi_webui/web/js/route-editor.js
@@ -14,11 +14,17 @@ class RouteEditor {
     this.landmarkNames = [];     // landmark POI names (route.landmarks candidate, #143)
     this.editingWaypoints = []; // working waypoint list for form
     this.editingLandmarks = []; // working landmark list for form (#143)
+    this.undoStack = [];
+    this.redoStack = [];
+    this.HISTORY_CAP = 50;
+    this.dragWaypointIndex = -1;
 
     this.onDirtyChange = null;
     this.onVisibilityChange = null;
     this.onEditingChange = null; // callback(isEditing) - fired when editing starts/stops
     this.onSelectionChange = null; // callback(index) - fired when selection changes
+    this.onWaypointFocus = null; // callback(poiName) - fired when waypoint UI previews a POI
+    this.onEditFormVisibilityChange = null; // callback(isOpen)
 
     // DOM references
     this.listEl = document.getElementById('route-list');
@@ -28,6 +34,8 @@ class RouteEditor {
     this.btnDiscardRoutes = document.getElementById('btn-discard-routes');
     this.btnAddRoute = document.getElementById('btn-add-route');
     this.dirtyIndicator = document.getElementById('route-dirty-indicator');
+    this.btnUndo = document.getElementById('btn-route-undo');
+    this.btnRedo = document.getElementById('btn-route-redo');
 
     // Form inputs - waypoints
     this.inputRouteName = document.getElementById('route-name');
@@ -47,6 +55,10 @@ class RouteEditor {
     this.btnSaveRoutes.addEventListener('click', () => this.save());
     this.btnDiscardRoutes.addEventListener('click', () => this.discard());
     this.btnAddWaypoint.addEventListener('click', () => this.addWaypointFromSelect());
+    this.waypointSelect.addEventListener('change', () => this.focusWaypointName(this.waypointSelect.value));
+    this.waypointSelect.addEventListener('focus', () => this.focusWaypointName(this.waypointSelect.value));
+    if (this.btnUndo) this.btnUndo.addEventListener('click', () => this.undo());
+    if (this.btnRedo) this.btnRedo.addEventListener('click', () => this.redo());
     if (this.btnAddLandmark) {
       this.btnAddLandmark.addEventListener('click', () => this.addLandmarkFromSelect());
     }
@@ -68,6 +80,7 @@ class RouteEditor {
     this.editingIndex = -1;
     this.selectedIndex = -1;
     this.visibleRoutes = new Set(routes.map((r) => r.name));
+    this._resetEditHistory();
     this.setDirty(false);
     this.hideForm();
     this.renderList();
@@ -190,6 +203,7 @@ class RouteEditor {
     const route = this.routes[index];
     this.formTitle.textContent = 'Edit Route';
     this.fillForm(route);
+    this._resetEditHistory();
     this.showForm();
     this.renderList();
     this._fireEditingChange();
@@ -224,6 +238,7 @@ class RouteEditor {
     this.selectedIndex = newIdx;
     this.formTitle.textContent = 'Edit Route (Copy)';
     this.fillForm(copy);
+    this._resetEditHistory();
     this.showForm();
     this.setDirty(true);
     this.renderList();
@@ -237,6 +252,7 @@ class RouteEditor {
     this.editingIndex = -2;
     this.formTitle.textContent = 'New Route';
     this.fillForm({ name: '', waypoints: [] });
+    this._resetEditHistory();
     this.showForm();
     this.renderList();
     this._fireEditingChange();
@@ -283,6 +299,23 @@ class RouteEditor {
     this.editingWaypoints.forEach((wp, i) => {
       const row = document.createElement('div');
       row.className = 'wp-item';
+      row.tabIndex = 0;
+      row.dataset.poiName = wp;
+      row.addEventListener('click', () => this.focusWaypointName(wp));
+      row.addEventListener('focus', () => this.focusWaypointName(wp));
+      row.addEventListener('mouseenter', () => this.focusWaypointName(wp));
+      row.addEventListener('dragover', (e) => this._onWaypointDragOver(e, row));
+      row.addEventListener('dragleave', () => row.classList.remove('wp-drop-target'));
+      row.addEventListener('drop', (e) => this._onWaypointDrop(e, i));
+
+      const dragHandle = document.createElement('span');
+      dragHandle.className = 'wp-drag-handle';
+      dragHandle.textContent = '\u22EE\u22EE';
+      dragHandle.title = 'Drag to reorder';
+      dragHandle.draggable = true;
+      dragHandle.addEventListener('click', (e) => e.stopPropagation());
+      dragHandle.addEventListener('dragstart', (e) => this._onWaypointDragStart(e, i));
+      dragHandle.addEventListener('dragend', () => this._clearWaypointDropTargets());
 
       const num = document.createElement('span');
       num.className = 'wp-num';
@@ -325,6 +358,7 @@ class RouteEditor {
       btns.appendChild(downBtn);
       btns.appendChild(removeBtn);
 
+      row.appendChild(dragHandle);
       row.appendChild(num);
       row.appendChild(name);
       row.appendChild(btns);
@@ -335,9 +369,11 @@ class RouteEditor {
   addWaypointFromSelect() {
     const val = this.waypointSelect.value;
     if (!val) return;
+    this._pushEditUndo();
     this.editingWaypoints.push(val);
     this.waypointSelect.value = '';
     this.renderWaypointList();
+    this.focusWaypointName(val);
     this._fireEditingChange();
   }
 
@@ -346,22 +382,31 @@ class RouteEditor {
    */
   addWaypointByName(name) {
     if (this.editingIndex === -1) return;
+    this._pushEditUndo();
     this.editingWaypoints.push(name);
     this.renderWaypointList();
+    this.focusWaypointName(name);
     this._fireEditingChange();
   }
 
   moveWaypoint(index, dir) {
-    const newIndex = index + dir;
+    this.moveWaypointTo(index, index + dir);
+  }
+
+  moveWaypointTo(index, newIndex) {
+    if (index < 0 || index >= this.editingWaypoints.length) return;
     if (newIndex < 0 || newIndex >= this.editingWaypoints.length) return;
-    const tmp = this.editingWaypoints[index];
-    this.editingWaypoints[index] = this.editingWaypoints[newIndex];
-    this.editingWaypoints[newIndex] = tmp;
+    if (index === newIndex) return;
+    this._pushEditUndo();
+    const [wp] = this.editingWaypoints.splice(index, 1);
+    this.editingWaypoints.splice(newIndex, 0, wp);
     this.renderWaypointList();
     this._fireEditingChange();
   }
 
   removeWaypoint(index) {
+    if (index < 0 || index >= this.editingWaypoints.length) return;
+    this._pushEditUndo();
     this.editingWaypoints.splice(index, 1);
     this.renderWaypointList();
     this._fireEditingChange();
@@ -435,6 +480,7 @@ class RouteEditor {
       this.landmarkSelect.value = '';
       return;  // 重複追加を防ぐ
     }
+    this._pushEditUndo();
     this.editingLandmarks.push(val);
     this.landmarkSelect.value = '';
     this.renderLandmarkList();
@@ -442,6 +488,8 @@ class RouteEditor {
   }
 
   removeLandmark(index) {
+    if (index < 0 || index >= this.editingLandmarks.length) return;
+    this._pushEditUndo();
     this.editingLandmarks.splice(index, 1);
     this.renderLandmarkList();
     this._fireEditingChange();
@@ -499,6 +547,7 @@ class RouteEditor {
       this.routes[this.editingIndex] = route;
     }
     this.editingIndex = -1;
+    this._resetEditHistory();
     this.setDirty(true);
     this.hideForm();
     this.renderList();
@@ -511,6 +560,7 @@ class RouteEditor {
    */
   formCancel() {
     this.editingIndex = -1;
+    this._resetEditHistory();
     this.hideForm();
     this.renderList();
     this._fireEditingChange();
@@ -518,10 +568,12 @@ class RouteEditor {
 
   showForm() {
     this.formEl.classList.remove('hidden');
+    if (this.onEditFormVisibilityChange) this.onEditFormVisibilityChange(true);
   }
 
   hideForm() {
     this.formEl.classList.add('hidden');
+    if (this.onEditFormVisibilityChange) this.onEditFormVisibilityChange(false);
   }
 
   setDirty(isDirty) {
@@ -529,7 +581,111 @@ class RouteEditor {
     this.btnSaveRoutes.disabled = !isDirty;
     this.btnDiscardRoutes.disabled = !isDirty;
     this.dirtyIndicator.textContent = isDirty ? 'Unsaved changes' : '';
+    this._updateUndoButtons();
     if (this.onDirtyChange) this.onDirtyChange(isDirty);
+  }
+
+  focusWaypointName(name) {
+    if (this.onWaypointFocus) this.onWaypointFocus(name || '');
+  }
+
+  _onWaypointDragStart(e, index) {
+    this.dragWaypointIndex = index;
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/plain', String(index));
+    }
+  }
+
+  _onWaypointDragOver(e, row) {
+    if (e.preventDefault) e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+    row.classList.add('wp-drop-target');
+  }
+
+  _onWaypointDrop(e, targetIndex) {
+    if (e.preventDefault) e.preventDefault();
+    const sourceIndex = this._dragSourceIndexFromEvent(e);
+    this._clearWaypointDropTargets();
+    this.moveWaypointTo(sourceIndex, targetIndex);
+  }
+
+  _dragSourceIndexFromEvent(e) {
+    if (this.dragWaypointIndex >= 0) return this.dragWaypointIndex;
+    const raw = e.dataTransfer ? e.dataTransfer.getData('text/plain') : '';
+    const index = Number.parseInt(raw, 10);
+    return Number.isFinite(index) ? index : -1;
+  }
+
+  _clearWaypointDropTargets() {
+    this.dragWaypointIndex = -1;
+    if (!this.waypointListEl) return;
+    this.waypointListEl.querySelectorAll('.wp-drop-target').forEach((el) => {
+      el.classList.remove('wp-drop-target');
+    });
+  }
+
+  _resetEditHistory() {
+    this.undoStack = [];
+    this.redoStack = [];
+    this._updateUndoButtons();
+  }
+
+  _updateUndoButtons() {
+    const active = this.editingIndex !== -1;
+    if (this.btnUndo) this.btnUndo.disabled = !active || this.undoStack.length === 0;
+    if (this.btnRedo) this.btnRedo.disabled = !active || this.redoStack.length === 0;
+  }
+
+  _pushEditUndo() {
+    if (this.editingIndex === -1) return;
+    MapoiPoiHistory.recordChange(
+      this.undoStack,
+      this.redoStack,
+      this._snapshotEditForm(),
+      this.HISTORY_CAP,
+    );
+    this._updateUndoButtons();
+  }
+
+  _snapshotEditForm() {
+    return {
+      routeName: this.inputRouteName.value,
+      editingWaypoints: [...this.editingWaypoints],
+      editingLandmarks: [...this.editingLandmarks],
+    };
+  }
+
+  _applyEditSnapshot(snap) {
+    this.inputRouteName.value = snap.routeName || '';
+    this.editingWaypoints = [...(snap.editingWaypoints || [])];
+    this.editingLandmarks = [...(snap.editingLandmarks || [])];
+    this.renderWaypointList();
+    this.renderLandmarkList();
+    this._updateUndoButtons();
+    this._fireEditingChange();
+  }
+
+  undo() {
+    if (this.editingIndex === -1) return;
+    const snap = MapoiPoiHistory.stepUndo(
+      this.undoStack,
+      this.redoStack,
+      this._snapshotEditForm(),
+    );
+    if (!snap) return;
+    this._applyEditSnapshot(snap);
+  }
+
+  redo() {
+    if (this.editingIndex === -1) return;
+    const snap = MapoiPoiHistory.stepRedo(
+      this.undoStack,
+      this.redoStack,
+      this._snapshotEditForm(),
+    );
+    if (!snap) return;
+    this._applyEditSnapshot(snap);
   }
 
   /**
@@ -563,6 +719,7 @@ class RouteEditor {
     this.routes = JSON.parse(JSON.stringify(this.originalRoutes));
     this.editingIndex = -1;
     this.visibleRoutes = new Set(this.routes.map((r) => r.name));
+    this._resetEditHistory();
     this.setDirty(false);
     this.hideForm();
     this.renderList();
@@ -603,4 +760,8 @@ class RouteEditor {
   _fireEditingChange() {
     if (this.onEditingChange) this.onEditingChange(this.editingIndex !== -1);
   }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = RouteEditor;
 }


### PR DESCRIPTION
## Summary

- Reworked POI/Route editor toolbars into compact command groups so Undo/Redo does not keep expanding the sidebar.
- Added Route edit focus mode: opening the Route form collapses other sidebar sections and hides the route list, mirroring POI edit behavior.
- Added Route waypoint UX improvements: POI highlight on waypoint select/row focus/map-click add, drag-to-reorder rows, and form-local Undo/Redo history.
- Added unit and E2E coverage for Route editor history, waypoint focus, drag reorder internals, and Route edit sidebar focus restore.

## Validation

- `npm test`
- `node --check mapoi_webui/web/js/app.js`
- `node --check mapoi_webui/web/js/route-editor.js`
- `git diff --check`
- `npm run test:e2e`

Closes #302
Closes #303
Closes #304
Closes #305
