### PR TITLE
[codex] Polish route and POI editing UX

### DIFF
--- a/mapoi_webui/tests/web/e2e/all-js-200.e2e.js
+++ b/mapoi_webui/tests/web/e2e/all-js-200.e2e.js
@@ -39,7 +39,7 @@ test.describe('A. 全 js 200 smoke', () => {
     const indexResp = await page.goto('/');
     expect(indexResp.status()).toBe(200);
     // 初期化 (loadMaps→…→showPois) 完了の合図として POI marker 描画を待つ。
-    await expect(page.locator('.poi-arrow-icon')).toHaveCount(4);
+    await expect(page.locator('.poi-arrow-icon')).toHaveCount(5);
 
     // --- HTML が列挙する /js/*.js を抽出し各々 200 ---
     const htmlJs = await page.$$eval('script[src^="/js/"]', (els) =>

--- a/mapoi_webui/tests/web/e2e/fixtures/state.json
+++ b/mapoi_webui/tests/web/e2e/fixtures/state.json
@@ -37,6 +37,13 @@
       "tolerance": { "xy": 0.4, "yaw": 1.5708 },
       "tags": ["waypoint", "pause"],
       "description": "Pause POI (dot pattern overlay)"
+    },
+    {
+      "name": "poi_landmark",
+      "pose": { "x": 1.5, "y": -1.5, "yaw": -0.4 },
+      "tolerance": { "xy": 0.35, "yaw": 0.7854 },
+      "tags": ["landmark"],
+      "description": "Landmark POI linked from test_route"
     }
   ],
   "tags": [
@@ -48,7 +55,7 @@
     {
       "name": "test_route",
       "waypoints": ["poi_wedge", "poi_disc", "poi_pause"],
-      "landmarks": []
+      "landmarks": ["poi_landmark"]
     }
   ],
   "nav_status": {

--- a/mapoi_webui/tests/web/e2e/helpers.js
+++ b/mapoi_webui/tests/web/e2e/helpers.js
@@ -6,7 +6,7 @@ const { expect } = require('@playwright/test');
 async function loadApp(page) {
   const resp = await page.goto('/');
   expect(resp.status()).toBe(200);
-  await expect(page.locator('.poi-arrow-icon')).toHaveCount(4);
+  await expect(page.locator('.poi-arrow-icon')).toHaveCount(5);
 }
 
 // POI 名の完全一致で card を返す。'poi_wedge' が 'poi_wedge2' に部分一致しないよう anchored regex。

--- a/mapoi_webui/tests/web/e2e/map-edit-polish.e2e.js
+++ b/mapoi_webui/tests/web/e2e/map-edit-polish.e2e.js
@@ -1,0 +1,127 @@
+const { test, expect } = require('@playwright/test');
+const { loadApp, poiCard, selectPoi, setSectionOpen } = require('./helpers');
+
+function routeItem(page, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return page.locator('.route-item').filter({
+    has: page.locator('.route-item-name', { hasText: new RegExp(`^${escaped}$`) }),
+  });
+}
+
+async function markerZ(locator) {
+  return locator.evaluate((el) => Number.parseInt(getComputedStyle(el).zIndex || '0', 10) || 0);
+}
+
+async function maxMarkerZ(page, selector) {
+  return page.locator(selector).evaluateAll((els) =>
+    Math.max(...els.map((el) => Number.parseInt(getComputedStyle(el).zIndex || '0', 10) || 0)));
+}
+
+test.describe('Map edit polish', () => {
+  test('sidebar sections are ordered Navigation, Tags, POIs, Routes', async ({ page }) => {
+    await loadApp(page);
+
+    const ids = await page.locator('#poi-panel > .panel-section').evaluateAll((els) =>
+      els.map((el) => el.id));
+
+    expect(ids).toEqual(['nav-section', 'tag-section', 'poi-section', 'route-section']);
+  });
+
+  test('Escape clears POI and route selection without opening edit forms', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await setSectionOpen(page, '#btn-route-toggle', '#route-body', true);
+
+    await selectPoi(page, 'poi_wedge');
+    await routeItem(page, 'test_route').locator('.route-item-name').click();
+    await expect(routeItem(page, 'test_route')).toHaveClass(/(^|\s)selected(\s|$)/);
+    await expect(page.locator('#nav-goal-select')).toHaveValue('poi_wedge');
+    await expect(page.locator('#nav-route-select')).toHaveValue('test_route');
+
+    await page.keyboard.press('Escape');
+
+    await expect(poiCard(page, 'poi_wedge')).not.toHaveClass(/(^|\s)selected(\s|$)/);
+    await expect(routeItem(page, 'test_route')).not.toHaveClass(/(^|\s)selected(\s|$)/);
+    await expect(page.locator('#nav-goal-select')).toHaveValue('');
+    await expect(page.locator('#nav-route-select')).toHaveValue('');
+    await expect(page.locator('#nav-initialpose-select')).toHaveValue('');
+    await expect(page.locator('#poi-edit-form')).toHaveClass(/(^|\s)hidden(\s|$)/);
+    await expect(page.locator('#route-edit-form')).toHaveClass(/(^|\s)hidden(\s|$)/);
+  });
+
+  test('POI edit and Route edit are mutually exclusive from sidebar actions', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-route-toggle', '#route-body', true);
+
+    await routeItem(page, 'test_route').locator('.btn-edit').click();
+    await expect(page.locator('#route-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+
+    let routeEditMessage = '';
+    page.once('dialog', async (dialog) => {
+      routeEditMessage = dialog.message();
+      await dialog.accept();
+    });
+    await poiCard(page, 'poi_wedge').locator('.btn-edit').click();
+    expect(routeEditMessage).toContain('route editing');
+    await expect(page.locator('#route-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await expect(page.locator('#poi-edit-form')).toHaveClass(/(^|\s)hidden(\s|$)/);
+
+    await page.locator('#btn-route-form-cancel').click();
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await poiCard(page, 'poi_wedge').locator('.btn-edit').click();
+    await expect(page.locator('#poi-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await setSectionOpen(page, '#btn-route-toggle', '#route-body', true);
+
+    let poiEditMessage = '';
+    page.once('dialog', async (dialog) => {
+      poiEditMessage = dialog.message();
+      await dialog.accept();
+    });
+    await routeItem(page, 'test_route').locator('.btn-edit').click();
+    expect(poiEditMessage).toContain('POI editing');
+    await expect(page.locator('#poi-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await expect(page.locator('#route-edit-form')).toHaveClass(/(^|\s)hidden(\s|$)/);
+  });
+
+  test('selected and editing routes show linked landmark POIs', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-route-toggle', '#route-body', true);
+
+    await routeItem(page, 'test_route').locator('.route-item-name').click();
+    await expect(page.locator('.route-landmark-badge')).toHaveCount(1);
+    await expect(page.locator('.route-landmark-radius-ring')).toHaveCount(1);
+
+    await routeItem(page, 'test_route').locator('.route-item-name').click();
+    await expect(page.locator('.route-landmark-badge')).toHaveCount(0);
+    await expect(page.locator('.route-landmark-radius-ring')).toHaveCount(0);
+
+    await routeItem(page, 'test_route').locator('.btn-edit').click();
+    await expect(page.locator('#route-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await expect(page.locator('.route-landmark-badge')).toHaveCount(1);
+    await expect(page.locator('.route-landmark-radius-ring')).toHaveCount(1);
+  });
+
+  test('marker layer priority follows editing and navigation modes', async ({ page }) => {
+    await loadApp(page);
+    await expect(page.locator('.robot-icon')).toHaveCount(1);
+
+    const defaultRobotZ = await markerZ(page.locator('.robot-icon'));
+    const defaultPoiZ = await maxMarkerZ(page, '.poi-arrow-icon');
+    expect(defaultRobotZ).toBeGreaterThan(defaultPoiZ);
+
+    await poiCard(page, 'poi_wedge').locator('.btn-edit').click();
+    const editingRobotZ = await markerZ(page.locator('.robot-icon'));
+    const editingPoiZ = await maxMarkerZ(page, '.poi-arrow-icon');
+    expect(editingPoiZ).toBeGreaterThan(editingRobotZ);
+
+    await page.locator('#btn-form-cancel').click();
+    await page.locator('#nav-route-select').selectOption('test_route');
+    await page.locator('#btn-nav-run').click();
+    await expect(page.locator('#nav-status-text')).toContainText('Navigating');
+
+    const navRobotZ = await markerZ(page.locator('.robot-icon'));
+    const navPoiZ = await maxMarkerZ(page, '.poi-arrow-icon');
+    expect(navRobotZ).toBeGreaterThan(navPoiZ);
+  });
+});

--- a/mapoi_webui/tests/web/route-editor-history.test.js
+++ b/mapoi_webui/tests/web/route-editor-history.test.js
@@ -115,6 +115,25 @@ describe('RouteEditor waypoint focus UI', () => {
     expect(editor.setDirty).not.toHaveBeenCalled();
   });
 
+  it('fires landmark focus from rendered rows without marking data dirty', () => {
+    document.body.innerHTML = '<div id="landmarks"></div>';
+    const editor = Object.create(RouteEditor.prototype);
+    editor.landmarkListEl = document.getElementById('landmarks');
+    editor.editingLandmarks = ['L1'];
+    editor.landmarkNames = ['L1'];
+    editor.onLandmarkFocus = vi.fn();
+    editor.setDirty = vi.fn();
+
+    editor.renderLandmarkList();
+    const row = editor.landmarkListEl.querySelector('.wp-item');
+
+    row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    row.dispatchEvent(new Event('focus'));
+
+    expect(editor.onLandmarkFocus).toHaveBeenCalledWith('L1');
+    expect(editor.setDirty).not.toHaveBeenCalled();
+  });
+
   it('moves a dragged waypoint to the drop target index', () => {
     const editor = makeEditor();
     editor.dragWaypointIndex = 0;

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -1034,6 +1034,36 @@ main {
   justify-content: center;
 }
 
+.route-landmark-marker {
+  background: transparent !important;
+  border: none !important;
+  pointer-events: none;
+}
+
+.route-landmark-radius-ring {
+  filter: drop-shadow(0 0 3px rgba(255,255,255,0.95));
+}
+
+.route-landmark-badge {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  border: 1px solid #fff;
+  color: #fff;
+  font-size: 0.58rem;
+  font-weight: 700;
+  line-height: 1;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.28);
+}
+
 /* Navigation panel */
 .nav-body {
   padding: 8px 16px 12px;

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -83,6 +83,28 @@
         </div>
       </div>
 
+      <div id="tag-section" class="panel-section">
+        <div class="section-header">
+          <span>Tags</span>
+          <div class="section-header-actions">
+            <button id="btn-tag-toggle" class="btn-section-toggle" title="Toggle">&#9660;</button>
+          </div>
+        </div>
+        <div id="tag-body">
+          <div id="tag-list" class="section-body"></div>
+          <div id="tag-add-form" class="tag-add-form">
+            <input type="text" id="tag-add-name" placeholder="Tag name" />
+            <input type="text" id="tag-add-desc" placeholder="Description" />
+            <button id="btn-tag-add">+ Add</button>
+          </div>
+          <div id="tag-toolbar">
+            <button id="btn-save-tags" title="Save tag changes" disabled>Save</button>
+            <button id="btn-discard-tags" title="Discard tag changes" disabled>Discard</button>
+            <span id="tag-dirty-indicator"></span>
+          </div>
+        </div>
+      </div>
+
       <div id="poi-section" class="panel-section">
         <div class="section-header">
           <span>POIs</span>
@@ -146,28 +168,6 @@
               <button id="btn-redo" class="btn-icon-command" title="Redo (Ctrl+Shift+Z)" aria-label="Redo POI edit" disabled>&#8631;</button>
             </span>
             <span id="dirty-indicator"></span>
-          </div>
-        </div>
-      </div>
-
-      <div id="tag-section" class="panel-section">
-        <div class="section-header">
-          <span>Tags</span>
-          <div class="section-header-actions">
-            <button id="btn-tag-toggle" class="btn-section-toggle" title="Toggle">&#9660;</button>
-          </div>
-        </div>
-        <div id="tag-body">
-          <div id="tag-list" class="section-body"></div>
-          <div id="tag-add-form" class="tag-add-form">
-            <input type="text" id="tag-add-name" placeholder="Tag name" />
-            <input type="text" id="tag-add-desc" placeholder="Description" />
-            <button id="btn-tag-add">+ Add</button>
-          </div>
-          <div id="tag-toolbar">
-            <button id="btn-save-tags" title="Save tag changes" disabled>Save</button>
-            <button id="btn-discard-tags" title="Discard tag changes" disabled>Discard</button>
-            <span id="tag-dirty-indicator"></span>
           </div>
         </div>
       </div>

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -19,6 +19,7 @@
   const compactMediaQuery = window.matchMedia('(max-width: 768px)');
   let currentMap = '';
   let currentNavigationCapabilities = null;
+  let currentNavStatus = 'idle';
 
   // --- Tag editor state ---
   let tagDirty = false;
@@ -185,7 +186,7 @@
       mapViewer.clearRoutes();
       const color = routeEditor.getEditingRouteColor() || '#2980b9';
       mapViewer.showEditingRoutePreview(
-        routeEditor.editingWaypoints, poiEditor.pois, color
+        routeEditor.editingWaypoints, poiEditor.pois, color, routeEditor.editingLandmarks
       );
     } else {
       mapViewer.showRoutes(routeEditor.routes, poiEditor.pois, routeEditor.visibleRoutes);
@@ -213,6 +214,40 @@
   }
 
   // --- Wire callbacks ---
+
+  function isRouteEditingActive() {
+    return routeEditor.editingIndex !== -1;
+  }
+
+  function isPoiEditingActive() {
+    return poiEditor.editingIndex !== -1 || poiEditor.placingMode;
+  }
+
+  function isNavigationActive() {
+    return ['navigating', 'paused', 'map_switching'].includes(currentNavStatus);
+  }
+
+  function updateMapLayerPriority() {
+    if (isNavigationActive()) {
+      mapViewer.setLayerPriorityMode('navigation');
+    } else if (isPoiEditingActive() || isRouteEditingActive()) {
+      mapViewer.setLayerPriorityMode('editing');
+    } else {
+      mapViewer.setLayerPriorityMode('default');
+    }
+  }
+
+  poiEditor.onBeforeEditStart = () => {
+    if (!isRouteEditingActive()) return true;
+    alert('Finish or cancel route editing before editing POIs.');
+    return false;
+  };
+
+  routeEditor.onBeforeEditStart = () => {
+    if (!isPoiEditingActive()) return true;
+    alert('Finish or cancel POI editing before editing routes.');
+    return false;
+  };
 
   // Helper: enable pose tool for the currently editing POI
   function enablePoseToolForEditing() {
@@ -316,7 +351,12 @@
     } else {
       mapViewer.disablePoseTool();
     }
+    updateMapLayerPriority();
     syncNavGoalSelect();
+  };
+
+  poiEditor.onPlacingModeChange = () => {
+    updateMapLayerPriority();
   };
 
   // POI visibility toggle
@@ -368,9 +408,10 @@
     // Cancel」で sidebar は B selected でも _activeRouteIdx は A のままになり、
     // robot connector が古い route の先頭 POI を指し続ける (PR #107 Codex round
     // 2/3 medium 残課題)。
-    if (routeEditor.selectedIndex >= 0) {
+    if (routeEditor.editingIndex === -1 && routeEditor.selectedIndex >= 0) {
       mapViewer.highlightRoute(routeEditor.selectedIndex);
     }
+    updateMapLayerPriority();
     syncNavRouteSelect();
   };
 
@@ -383,10 +424,17 @@
     mapViewer.highlightPoi(index);
   };
 
+  routeEditor.onLandmarkFocus = (name) => {
+    if (!name) return;
+    const index = poiEditor.pois.findIndex((p) => p.name === name);
+    if (index < 0) return;
+    mapViewer.highlightPoi(index);
+  };
+
   // Route visibility toggle
   routeEditor.onVisibilityChange = () => {
     redrawRoutes();
-    if (routeEditor.selectedIndex >= 0) {
+    if (routeEditor.editingIndex === -1 && routeEditor.selectedIndex >= 0) {
       mapViewer.highlightRoute(routeEditor.selectedIndex);
     }
   };
@@ -394,7 +442,7 @@
   // Route dirty state change — refresh routes on map and nav select after save/discard
   routeEditor.onDirtyChange = (isDirty) => {
     redrawRoutes();
-    if (routeEditor.selectedIndex >= 0) {
+    if (routeEditor.editingIndex === -1 && routeEditor.selectedIndex >= 0) {
       mapViewer.highlightRoute(routeEditor.selectedIndex);
     }
     if (!isDirty) {
@@ -606,12 +654,14 @@
 
   function updateNavStatus(status, target) {
     const s = status || 'idle';
+    currentNavStatus = s;
     navStatusDot.className = 'nav-status-dot nav-status-' + s;
     let label = statusLabels[s] || s;
     if (target && s !== 'idle') {
       label += ': ' + target;
     }
     navStatusText.textContent = label;
+    updateMapLayerPriority();
   }
 
   let navPollingTimer = null;
@@ -762,10 +812,12 @@
   poiEditor.onEditFormVisibilityChange = (isOpen) => {
     if (isOpen) activateSidebarFocus('poi');
     else restoreSidebarFocus('poi');
+    updateMapLayerPriority();
   };
   routeEditor.onEditFormVisibilityChange = (isOpen) => {
     if (isOpen) activateSidebarFocus('route');
     else restoreSidebarFocus('route');
+    updateMapLayerPriority();
   };
 
   // --- Initialize ---
@@ -804,13 +856,26 @@
   };
 
   // --- Keyboard shortcuts (#300 / #303) ---
-  // active editor の Undo/Redo を document レベルで拾う。入力欄 (name / x / y / tags 等) の
+  // active editor の Escape / Undo/Redo を document レベルで拾う。入力欄 (name / x / y / tags 等) の
   // 編集中はブラウザ標準の text undo を優先するため無視する (pose tool の Escape ガード
   // map-viewer.js #270 と同方針)。owned key のみ preventDefault し、他ハンドラを妨げない。
   document.addEventListener('keydown', (e) => {
     const t = e.target;
     if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA'
         || t.tagName === 'SELECT' || t.isContentEditable)) {
+      return;
+    }
+    if (e.key === 'Escape') {
+      if (mapViewer.isPoseToolActive() || isPoiEditingActive() || isRouteEditingActive()) return;
+      const hadSelection = poiEditor.selectedIndex >= 0 || routeEditor.selectedIndex >= 0
+        || navGoalSelect.value || navRouteSelect.value || navInitialPoseSelect.value;
+      if (!hadSelection) return;
+      e.preventDefault();
+      poiEditor.clearSelection();
+      routeEditor.clearSelection();
+      navGoalSelect.value = '';
+      navRouteSelect.value = '';
+      navInitialPoseSelect.value = '';
       return;
     }
     if (!(e.ctrlKey || e.metaKey)) return;

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -50,6 +50,10 @@ class MapViewer {
     this._lastRobotPose = null;  // 最新 pose (updateRobotMarker で更新)
     this._robotConnectorLayers = []; // 現在のロボット位置 → active route 先頭 POI への connector
     this._reachedRouteSignatures = new Set(); // 到達済み route の "name|firstWaypoint" signature 集合 (page 内 sticky)
+    this._routeLandmarkLayers = []; // selected/editing route に紐づく landmark POI の badge/ring
+    this._cachedPois = null; // showPois の POI array。landmark overlay の再描画に使う
+    this._cachedPoiVisibility = null; // showPois の visibleSet snapshot。landmark overlay の可視性判定に使う
+    this._layerPriorityMode = 'default'; // default | editing | navigation
 
     // ロボットの実寸 (m)。connector 到達閾値とロボットマーカーサイズの両方に
     // 使う (#116)。default は TurtleBot3 burger (~0.105m) に余裕を持たせた値。
@@ -199,6 +203,96 @@ class MapViewer {
     });
   }
 
+  setLayerPriorityMode(mode) {
+    const next = ['default', 'editing', 'navigation'].includes(mode) ? mode : 'default';
+    if (this._layerPriorityMode === next) return;
+    this._layerPriorityMode = next;
+    this._applyLayerPriority();
+    this._updateRobotConnector();
+  }
+
+  isPoseToolActive() {
+    return !!this._poseTool;
+  }
+
+  _zIndex(kind) {
+    const byMode = {
+      default: {
+        poi: 0,
+        poiHighlight: 1000,
+        routeMarker: 800,
+        landmark: 1100,
+        yawHandle: 1500,
+        robotConnector: 1200,
+        robot: 2000,
+      },
+      editing: {
+        poi: 2400,
+        poiHighlight: 2800,
+        routeMarker: 2600,
+        landmark: 2700,
+        yawHandle: 3000,
+        robotConnector: 250,
+        robot: 300,
+      },
+      navigation: {
+        poi: 0,
+        poiHighlight: 1000,
+        routeMarker: 1200,
+        landmark: 1100,
+        yawHandle: 1500,
+        robotConnector: 3100,
+        robot: 3200,
+      },
+    };
+    return (byMode[this._layerPriorityMode] || byMode.default)[kind] || 0;
+  }
+
+  _poiZIndex(isHighlighted) {
+    return this._zIndex(isHighlighted ? 'poiHighlight' : 'poi');
+  }
+
+  _applyLayerPriority() {
+    this.poiMarkers.forEach((item) => {
+      item.marker.setZIndexOffset(this._poiZIndex(item.index === this._highlightedPoiIndex));
+    });
+    if (this._yawHandle) this._yawHandle.setZIndexOffset(this._zIndex('yawHandle'));
+    if (this.robotMarker) this.robotMarker.setZIndexOffset(this._zIndex('robot'));
+    this._routePolylines.forEach((item) => {
+      this._applyRouteLinePriority(item.line);
+      this._applyRouteLinePriority(item.hitLine);
+      [...(item.arrowMarkers || []), ...(item.labelMarkers || [])].forEach((marker) => {
+        marker.setZIndexOffset(this._zIndex('routeMarker'));
+      });
+    });
+    (this._editingPreviewLayers || []).forEach((layer) => {
+      if (typeof layer.setZIndexOffset === 'function') {
+        layer.setZIndexOffset(this._zIndex('routeMarker'));
+      } else {
+        this._applyRouteLinePriority(layer);
+      }
+    });
+    this._routeLandmarkLayers.forEach((layer) => {
+      if (typeof layer.setZIndexOffset === 'function') {
+        layer.setZIndexOffset(this._zIndex('landmark'));
+      }
+      if (this._layerPriorityMode === 'navigation' && typeof layer.bringToBack === 'function') {
+        layer.bringToBack();
+      } else if (typeof layer.bringToFront === 'function') {
+        layer.bringToFront();
+      }
+    });
+  }
+
+  _applyRouteLinePriority(line) {
+    if (!line || typeof line.bringToBack !== 'function') return;
+    if (this._layerPriorityMode === 'editing' && typeof line.bringToFront === 'function') {
+      line.bringToFront();
+    } else {
+      line.bringToBack();
+    }
+  }
+
   /**
    * Tag-based color for POI markers.
    */
@@ -238,6 +332,8 @@ class MapViewer {
    */
   showPois(pois, visibleSet) {
     this.clearPois();
+    this._cachedPois = pois;
+    this._cachedPoiVisibility = visibleSet ? new Set(visibleSet) : null;
     pois.forEach((poi, index) => {
       if (!poi.pose) return;
       if (visibleSet && !visibleSet.has(index)) return;
@@ -253,7 +349,11 @@ class MapViewer {
       const icon = this.createArrowIcon(color, yaw, false);
       // draggable: true で生成して drag ハンドラを用意するが既定は disable。選択された
       // marker だけ highlightPoi (_applyPoiDraggable) が enable する (#239)。
-      const marker = L.marker(latlng, { icon, draggable: true }).addTo(this.map);
+      const marker = L.marker(latlng, {
+        icon,
+        draggable: true,
+        zIndexOffset: this._poiZIndex(false),
+      }).addTo(this.map);
       if (marker.dragging) marker.dragging.disable();
 
       marker.bindTooltip(poi.name || `POI ${index}`, {
@@ -284,6 +384,8 @@ class MapViewer {
 
       this.poiMarkers.push({ marker, poi, index, color, yaw });
     });
+    this._applyLayerPriority();
+    this._refreshActiveRouteLandmarks();
   }
 
   /**
@@ -340,9 +442,9 @@ class MapViewer {
       const icon = this.createArrowIcon(item.color, item.yaw, isHighlighted);
       item.marker.setIcon(icon);
       if (isHighlighted) {
-        item.marker.setZIndexOffset(1000);
+        item.marker.setZIndexOffset(this._poiZIndex(true));
       } else {
-        item.marker.setZIndexOffset(0);
+        item.marker.setZIndexOffset(this._poiZIndex(false));
       }
       // 選択中 marker だけドラッグ可 (#239)
       this._applyPoiDraggable(item, isHighlighted);
@@ -423,7 +525,11 @@ class MapViewer {
     const icon = L.divIcon({
       className: 'poi-yaw-handle', html: svg, iconSize: [18, 18], iconAnchor: [9, 9],
     });
-    const handle = L.marker(tipLL, { icon, draggable: true, zIndexOffset: 1500 }).addTo(this.map);
+    const handle = L.marker(tipLL, {
+      icon,
+      draggable: true,
+      zIndexOffset: this._zIndex('yawHandle'),
+    }).addTo(this.map);
     const yawFrom = (ll) => MapoiPoiInteractions.yawFromDelta(
       ll.lat - centerLL.lat, ll.lng - centerLL.lng,
     );
@@ -613,6 +719,7 @@ class MapViewer {
     item.yaw = yaw;
     const icon = this.createArrowIcon(item.color, yaw, true);
     item.marker.setIcon(icon);
+    item.marker.setZIndexOffset(this._poiZIndex(true));
   }
 
   /**
@@ -635,6 +742,73 @@ class MapViewer {
       this.sectorLayers.forEach((l) => this.map.removeLayer(l));
     }
     this.sectorLayers = [];
+    this.clearRouteLandmarkHighlights();
+  }
+
+  clearRouteLandmarkHighlights() {
+    if (!this._routeLandmarkLayers) return;
+    this._routeLandmarkLayers.forEach((layer) => {
+      this.map.removeLayer(layer);
+    });
+    this._routeLandmarkLayers = [];
+  }
+
+  showRouteLandmarkHighlights(landmarkNames, pois, color) {
+    this.clearRouteLandmarkHighlights();
+    if (!this.metadata || !landmarkNames || !pois) return;
+    const poiByName = new Map();
+    pois.forEach((poi, index) => {
+      if (poi && poi.name) poiByName.set(poi.name, { poi, index });
+    });
+    [...new Set(landmarkNames)].forEach((name) => {
+      const entry = poiByName.get(name);
+      if (!entry || !entry.poi.pose) return;
+      if (this._cachedPoiVisibility && !this._cachedPoiVisibility.has(entry.index)) return;
+      const { pose } = entry.poi;
+      const radius = entry.poi.tolerance && entry.poi.tolerance.xy;
+      if (typeof radius === 'number' && Number.isFinite(radius) && radius > 0) {
+        const ring = L.polyline(this._circlePoints(pose.x, pose.y, radius), {
+          color: color || '#8e44ad',
+          weight: 3,
+          opacity: 0.95,
+          interactive: false,
+          className: 'route-landmark-radius-ring',
+        }).addTo(this.map);
+        ring.bringToFront();
+        this._routeLandmarkLayers.push(ring);
+      }
+      const marker = L.marker(this.worldToLatLng(pose.x, pose.y), {
+        icon: this._createRouteLandmarkIcon(color || '#8e44ad'),
+        interactive: false,
+        zIndexOffset: this._zIndex('landmark'),
+      }).addTo(this.map);
+      marker.bindTooltip(`Landmark: ${name}`, {
+        permanent: false,
+        direction: 'top',
+        offset: [0, -22],
+      });
+      this._routeLandmarkLayers.push(marker);
+    });
+    this._applyLayerPriority();
+  }
+
+  _createRouteLandmarkIcon(color) {
+    return L.divIcon({
+      className: 'route-landmark-marker',
+      html: `<span class="route-landmark-badge" style="background: ${color};">LM</span>`,
+      iconSize: [28, 20],
+      iconAnchor: [14, 24],
+    });
+  }
+
+  _refreshActiveRouteLandmarks() {
+    const item = this._routePolylines.find((it) => it.routeIdx === this._activeRouteIdx);
+    if (!item) {
+      this.clearRouteLandmarkHighlights();
+      return;
+    }
+    const pois = this._cachedPois || (this._cachedRoutesArgs && this._cachedRoutesArgs.pois);
+    this.showRouteLandmarkHighlights(item.landmarks, pois, item.color);
   }
 
   /**
@@ -647,6 +821,16 @@ class MapViewer {
   _wedgePoints(cx, cy, r, yawCenter, yawTol) {
     return MapoiPoiInteractions.wedgePointsWorld(cx, cy, r, yawCenter, yawTol)
       .map((p) => this.worldToLatLng(p.x, p.y));
+  }
+
+  _circlePoints(cx, cy, r) {
+    const N_CIRCLE = 36;
+    const points = [];
+    for (let i = 0; i <= N_CIRCLE; i += 1) {
+      const a = (2 * Math.PI * i) / N_CIRCLE;
+      points.push(this.worldToLatLng(cx + r * Math.cos(a), cy + r * Math.sin(a)));
+    }
+    return points;
   }
 
   /**
@@ -687,15 +871,8 @@ class MapViewer {
 
     const color = this.getPoiColor(poi);
 
-    // 円の頂点列 (36 角形 = 10 度刻み)。i = N_CIRCLE で起点に戻り polyline が自然に閉じる。
-    const N_CIRCLE = 36;
-    const circlePoints = [];
-    for (let i = 0; i <= N_CIRCLE; i += 1) {
-      const a = (2 * Math.PI * i) / N_CIRCLE;
-      const wx = poi.pose.x + r * Math.cos(a);
-      const wy = poi.pose.y + r * Math.sin(a);
-      circlePoints.push(this.worldToLatLng(wx, wy));
-    }
+    // 円の頂点列 (36 角形 = 10 度刻み)。最後に起点へ戻り polyline が自然に閉じる。
+    const circlePoints = this._circlePoints(poi.pose.x, poi.pose.y, r);
 
     // xy 判定領域 (円 outline): 控えめな細実線で常時表示 (#179)
     const circle = L.polyline(circlePoints, {
@@ -905,7 +1082,7 @@ class MapViewer {
         offset: [0, -8],
       });
 
-      line.bringToBack();
+      this._applyRouteLinePriority(line);
       this.routeLayers.push(line);
 
       // Invisible wider hit area for easier clicking
@@ -923,7 +1100,7 @@ class MapViewer {
         if (this.onRouteClick) this.onRouteClick(routeIdx);
       });
 
-      hitLine.bringToBack();
+      this._applyRouteLinePriority(hitLine);
       this.routeLayers.push(hitLine);
 
       const arrowMarkers = [];
@@ -946,6 +1123,7 @@ class MapViewer {
         const arrowMarker = L.marker([midLat, midLng], {
           icon: arrowIcon,
           interactive: false,
+          zIndexOffset: this._zIndex('routeMarker'),
         }).addTo(this.map);
         this.routeLayers.push(arrowMarker);
         arrowMarkers.push(arrowMarker);
@@ -965,6 +1143,7 @@ class MapViewer {
         const labelMarker = L.marker(latlng, {
           icon: icon,
           interactive: false,
+          zIndexOffset: this._zIndex('routeMarker'),
         }).addTo(this.map);
         this.routeLayers.push(labelMarker);
         labelMarkers.push(labelMarker);
@@ -973,6 +1152,7 @@ class MapViewer {
       this._routePolylines.push({
         line, hitLine, arrowMarkers, labelMarkers,
         routeIdx, routeName: route.name || '', firstWaypointName,
+        landmarks: route.landmarks || [],
         color,
         // latlngs: raw (POI 物理座標)。robot connector の到達判定など物理距離を
         //   評価する用途で使う
@@ -981,6 +1161,7 @@ class MapViewer {
         latlngs: rawLatlngs, displayLatlngs,
       });
     });
+    this._applyLayerPriority();
   }
 
   /**
@@ -999,6 +1180,7 @@ class MapViewer {
     // _cachedRoutesArgs が再設定されるので race にはならない。
     this._cachedRoutesArgs = null;
     this.clearEditingRoutePreview();
+    this.clearRouteLandmarkHighlights();
     this._clearRobotConnector();
     // 到達履歴 (_reachedRouteSignatures) は clearRoutes では reset しない。
     // clearRoutes は visibility toggle / 編集 preview 出入り等の表示再描画でも
@@ -1039,6 +1221,7 @@ class MapViewer {
       }
     });
     this._activeRouteIdx = routeIdx;
+    this._refreshActiveRouteLandmarks();
     this._updateRobotConnector();
     // route 切替で marker 色も追従させる (pose 未受信時は updateRobotMarker が
     // early return するので safe)。
@@ -1061,9 +1244,11 @@ class MapViewer {
    * @param {Array} waypoints - waypoint name array (editingWaypoints)
    * @param {Array} pois - POI array to resolve names
    * @param {string} color - route color
+   * @param {Array} landmarks - landmark POI names linked to this route
    */
-  showEditingRoutePreview(waypoints, pois, color) {
+  showEditingRoutePreview(waypoints, pois, color, landmarks) {
     this.clearEditingRoutePreview();
+    this.clearRouteLandmarkHighlights();
     if (!this.metadata || !waypoints || !pois) return;
 
     const poiByName = {};
@@ -1089,7 +1274,7 @@ class MapViewer {
         weight: 5,
         opacity: 0.9,
       }).addTo(this.map);
-      line.bringToBack();
+      this._applyRouteLinePriority(line);
       this._editingPreviewLayers.push(line);
 
       // Directional teardrop markers
@@ -1108,6 +1293,7 @@ class MapViewer {
         const arrowMarker = L.marker([midLat, midLng], {
           icon: arrowIcon,
           interactive: false,
+          zIndexOffset: this._zIndex('routeMarker'),
         }).addTo(this.map);
         this._editingPreviewLayers.push(arrowMarker);
       }
@@ -1124,9 +1310,12 @@ class MapViewer {
       const labelMarker = L.marker(latlng, {
         icon: icon,
         interactive: false,
+        zIndexOffset: this._zIndex('routeMarker'),
       }).addTo(this.map);
       this._editingPreviewLayers.push(labelMarker);
     });
+    this.showRouteLandmarkHighlights(landmarks || [], pois, color);
+    this._applyLayerPriority();
   }
 
   /**
@@ -1255,11 +1444,12 @@ class MapViewer {
     if (this.robotMarker) {
       this.robotMarker.setLatLng(latlng);
       this.robotMarker.setIcon(icon);
+      this.robotMarker.setZIndexOffset(this._zIndex('robot'));
     } else {
       this.robotMarker = L.marker(latlng, {
         icon,
         interactive: false,
-        zIndexOffset: 2000,
+        zIndexOffset: this._zIndex('robot'),
       }).addTo(this.map);
     }
     this._updateRobotConnector();
@@ -1329,7 +1519,8 @@ class MapViewer {
       dashArray: '4, 6',
       interactive: false,
     }).addTo(this.map);
-    line.bringToBack();
+    if (this._layerPriorityMode === 'navigation') line.bringToFront();
+    else line.bringToBack();
     this._robotConnectorLayers.push(line);
 
     const midLat = (robotLatLng.lat + firstLatLngVisual.lat) / 2;
@@ -1344,6 +1535,7 @@ class MapViewer {
     const arrowMarker = L.marker([midLat, midLng], {
       icon: arrowIcon,
       interactive: false,
+      zIndexOffset: this._zIndex('robotConnector'),
     }).addTo(this.map);
     this._robotConnectorLayers.push(arrowMarker);
   }

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -25,6 +25,7 @@ class PoiEditor {
     this.onSelectionChange = null; // callback(index)
     this.onPlacingModeChange = null; // callback(isPlacing)
     this.onVisibilityChange = null;  // callback(visibleSet)
+    this.onBeforeEditStart = null; // callback(action) -> false blocks POI edit/add/copy/delete
     // 編集フォームの開閉 (#240)。開いたら app.js 側で他セクションを畳んでフォームに集中
     // させ、閉じたら元の表示状態へ戻す。showForm/hideForm で必ず発火する。
     this.onEditFormVisibilityChange = null; // callback(isOpen)
@@ -183,10 +184,20 @@ class PoiEditor {
     }
   }
 
+  clearSelection() {
+    if (this.selectedIndex === -1) return;
+    this.selectedIndex = -1;
+    this.renderList();
+    if (this.onSelectionChange) {
+      this.onSelectionChange(-1);
+    }
+  }
+
   /**
    * Open edit form for a POI.
    */
   editPoi(index) {
+    if (!this._canStartEdit('edit')) return;
     this.editingIndex = index;
     const poi = this.pois[index];
     this.formTitle.textContent = 'Edit POI';
@@ -199,6 +210,7 @@ class PoiEditor {
    * Delete a POI.
    */
   deletePoi(index) {
+    if (!this._canStartEdit('delete')) return;
     this._pushUndo();
     this.pois.splice(index, 1);
     if (this.selectedIndex === index) this.selectedIndex = -1;
@@ -222,6 +234,7 @@ class PoiEditor {
    * Copy a POI (deep clone with "_copy" suffix, open in edit form).
    */
   copyPoi(index) {
+    if (!this._canStartEdit('copy')) return;
     this._pushUndo();
     const original = this.pois[index];
     const copy = JSON.parse(JSON.stringify(original));
@@ -245,6 +258,7 @@ class PoiEditor {
       this.cancelPlacing();
       return;
     }
+    if (!this._canStartEdit('add')) return;
     this.placingMode = true;
     this.btnAddPoi.textContent = 'Click map...';
     this.btnAddPoi.classList.add('placing');
@@ -705,6 +719,11 @@ class PoiEditor {
     this.visiblePois = new Set();
     this.renderList();
     if (this.onVisibilityChange) this.onVisibilityChange(this.visiblePois);
+  }
+
+  _canStartEdit(action) {
+    if (!this.onBeforeEditStart) return true;
+    return this.onBeforeEditStart(action) !== false;
   }
 }
 

--- a/mapoi_webui/web/js/route-editor.js
+++ b/mapoi_webui/web/js/route-editor.js
@@ -24,7 +24,9 @@ class RouteEditor {
     this.onEditingChange = null; // callback(isEditing) - fired when editing starts/stops
     this.onSelectionChange = null; // callback(index) - fired when selection changes
     this.onWaypointFocus = null; // callback(poiName) - fired when waypoint UI previews a POI
+    this.onLandmarkFocus = null; // callback(poiName) - fired when landmark UI previews a POI
     this.onEditFormVisibilityChange = null; // callback(isOpen)
+    this.onBeforeEditStart = null; // callback(action) -> false blocks route edit/add/copy/delete
 
     // DOM references
     this.listEl = document.getElementById('route-list');
@@ -57,6 +59,10 @@ class RouteEditor {
     this.btnAddWaypoint.addEventListener('click', () => this.addWaypointFromSelect());
     this.waypointSelect.addEventListener('change', () => this.focusWaypointName(this.waypointSelect.value));
     this.waypointSelect.addEventListener('focus', () => this.focusWaypointName(this.waypointSelect.value));
+    if (this.landmarkSelect) {
+      this.landmarkSelect.addEventListener('change', () => this.focusLandmarkName(this.landmarkSelect.value));
+      this.landmarkSelect.addEventListener('focus', () => this.focusLandmarkName(this.landmarkSelect.value));
+    }
     if (this.btnUndo) this.btnUndo.addEventListener('click', () => this.undo());
     if (this.btnRedo) this.btnRedo.addEventListener('click', () => this.redo());
     if (this.btnAddLandmark) {
@@ -198,6 +204,7 @@ class RouteEditor {
    * Open edit form for a route.
    */
   editRoute(index) {
+    if (!this._canStartEdit('edit')) return;
     this.editingIndex = index;
     this.selectedIndex = index;
     const route = this.routes[index];
@@ -213,6 +220,7 @@ class RouteEditor {
    * Delete a route.
    */
   deleteRoute(index) {
+    if (!this._canStartEdit('delete')) return;
     const name = this.routes[index].name;
     this.routes.splice(index, 1);
     this.visibleRoutes.delete(name);
@@ -228,6 +236,7 @@ class RouteEditor {
    * Copy a route (deep clone with "_copy" suffix, open in edit form).
    */
   copyRoute(index) {
+    if (!this._canStartEdit('copy')) return;
     const original = this.routes[index];
     const copy = JSON.parse(JSON.stringify(original));
     copy.name = original.name + '_copy';
@@ -249,6 +258,7 @@ class RouteEditor {
    * Start adding a new route.
    */
   startAddRoute() {
+    if (!this._canStartEdit('add')) return;
     this.editingIndex = -2;
     this.formTitle.textContent = 'New Route';
     this.fillForm({ name: '', waypoints: [] });
@@ -440,6 +450,11 @@ class RouteEditor {
     this.editingLandmarks.forEach((lm, i) => {
       const row = document.createElement('div');
       row.className = 'wp-item';
+      row.tabIndex = 0;
+      row.dataset.poiName = lm;
+      row.addEventListener('click', () => this.focusLandmarkName(lm));
+      row.addEventListener('focus', () => this.focusLandmarkName(lm));
+      row.addEventListener('mouseenter', () => this.focusLandmarkName(lm));
 
       const num = document.createElement('span');
       num.className = 'wp-num';
@@ -484,6 +499,7 @@ class RouteEditor {
     this.editingLandmarks.push(val);
     this.landmarkSelect.value = '';
     this.renderLandmarkList();
+    this.focusLandmarkName(val);
     this._fireEditingChange();
   }
 
@@ -587,6 +603,10 @@ class RouteEditor {
 
   focusWaypointName(name) {
     if (this.onWaypointFocus) this.onWaypointFocus(name || '');
+  }
+
+  focusLandmarkName(name) {
+    if (this.onLandmarkFocus) this.onLandmarkFocus(name || '');
   }
 
   _onWaypointDragStart(e, index) {
@@ -747,6 +767,13 @@ class RouteEditor {
     if (this.onSelectionChange) this.onSelectionChange(this.selectedIndex);
   }
 
+  clearSelection() {
+    if (this.selectedIndex === -1) return;
+    this.selectedIndex = -1;
+    this.renderList();
+    if (this.onSelectionChange) this.onSelectionChange(-1);
+  }
+
   /**
    * Returns the editing route color, or null if not editing an existing route.
    */
@@ -759,6 +786,11 @@ class RouteEditor {
   /** @private */
   _fireEditingChange() {
     if (this.onEditingChange) this.onEditingChange(this.editingIndex !== -1);
+  }
+
+  _canStartEdit(action) {
+    if (!this.onBeforeEditStart) return true;
+    return this.onBeforeEditStart(action) !== false;
   }
 }
 


### PR DESCRIPTION
## Summary

This PR follows the UX issues created after #306 and tightens the route/POI editing flow:

- shows selected-route landmark POIs with an `LM` ring/badge, including route edit preview
- makes Escape clear POI/route/navigation dropdown selection when not editing
- reorders sidebar sections to Navigation, Tags, POIs, Routes
- adjusts map layer priority so POI/route editing brings edit targets forward, while navigation brings the robot marker forward
- prevents POI edit and Route edit from being active at the same time from sidebar actions

## Validation

- `node --check mapoi_webui/web/js/app.js`
- `node --check mapoi_webui/web/js/map-viewer.js`
- `node --check mapoi_webui/web/js/poi-editor.js`
- `node --check mapoi_webui/web/js/route-editor.js`
- `node --check mapoi_webui/tests/web/e2e/map-edit-polish.e2e.js`
- `git diff --check`
- `npm test` in `mapoi_webui/tests/web`
- `npm run test:e2e` in `mapoi_webui/tests/web`

Closes #307.
Closes #308.
Closes #309.
Closes #310.
Closes #311.
