### PR TITLE
[codex] Disclose full tag descriptions

### DIFF
--- a/mapoi_webui/tests/web/e2e/fixtures/state.json
+++ b/mapoi_webui/tests/web/e2e/fixtures/state.json
@@ -48,7 +48,7 @@
   ],
   "tags": [
     { "name": "waypoint", "description": "Navigation waypoint", "is_system": true },
-    { "name": "landmark", "description": "Reference POI (not a navigation target)", "is_system": true },
+    { "name": "landmark", "description": "Reference POI used for route context and radius monitoring; not sent to Nav2 as a navigation target", "is_system": true },
     { "name": "pause", "description": "Robot pauses at this POI", "is_system": true }
   ],
   "routes": [

--- a/mapoi_webui/tests/web/e2e/tag-description.e2e.js
+++ b/mapoi_webui/tests/web/e2e/tag-description.e2e.js
@@ -1,0 +1,52 @@
+const { test, expect } = require('@playwright/test');
+const { loadApp, setSectionOpen } = require('./helpers');
+
+const LANDMARK_DESC = 'Reference POI used for route context and radius monitoring; not sent to Nav2 as a navigation target';
+
+function tagItem(page, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return page.locator('.tag-item').filter({
+    has: page.locator('.tag-item-name', { hasText: new RegExp(`^${escaped}$`) }),
+  });
+}
+
+test.describe('Tag description disclosure', () => {
+  test('desktop keeps compact layout while exposing full description by title and keyboard expansion', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-tag-toggle', '#tag-body', true);
+
+    const desc = tagItem(page, 'landmark').locator('.tag-item-desc');
+    await expect(desc).toHaveAttribute('title', LANDMARK_DESC);
+    await expect(desc).toHaveAttribute('aria-expanded', 'false');
+    await expect(desc).toHaveCSS('white-space', 'nowrap');
+
+    await desc.focus();
+    await page.keyboard.press('Enter');
+
+    await expect(desc).toHaveAttribute('aria-expanded', 'true');
+    await expect(desc).toHaveCSS('white-space', 'normal');
+
+    await desc.focus();
+    await page.keyboard.press('Enter');
+    await expect(desc).toHaveAttribute('aria-expanded', 'false');
+    await expect(desc).toHaveCSS('white-space', 'nowrap');
+  });
+
+  test('mobile can tap a tag description to expand and collapse the full text inline', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 900 });
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-tag-toggle', '#tag-body', true);
+
+    const desc = tagItem(page, 'landmark').locator('.tag-item-desc');
+    await expect(desc).toHaveAttribute('aria-expanded', 'false');
+    await expect(desc).toHaveCSS('white-space', 'nowrap');
+
+    await desc.click();
+    await expect(desc).toHaveAttribute('aria-expanded', 'true');
+    await expect(desc).toHaveCSS('white-space', 'normal');
+
+    await desc.click();
+    await expect(desc).toHaveAttribute('aria-expanded', 'false');
+    await expect(desc).toHaveCSS('white-space', 'nowrap');
+  });
+});

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -839,6 +839,10 @@ main {
   border-left: 3px solid transparent;
 }
 
+.tag-item.tag-desc-expanded {
+  align-items: flex-start;
+}
+
 .tag-item-system {
   border-left-color: #3498db;
 }
@@ -862,9 +866,45 @@ main {
   min-width: 0;
   font-size: 0.8rem;
   color: #888;
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.tag-item-desc.has-description {
+  cursor: pointer;
+}
+
+.tag-item-desc.has-description::after {
+  content: '\25BE';
+  display: inline-block;
+  margin-left: 4px;
+  font-size: 0.65rem;
+  color: #95a5a6;
+}
+
+.tag-item-desc.expanded {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.tag-item-desc.expanded::after {
+  transform: rotate(180deg);
+}
+
+.tag-item-desc:focus-visible {
+  outline: 2px solid #3498db;
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.tag-item-desc:disabled {
+  cursor: default;
 }
 
 .tag-type-label {

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -24,6 +24,7 @@
   // --- Tag editor state ---
   let tagDirty = false;
   let editingTags = []; // working copy of tags (both system + custom)
+  const expandedTagDescriptions = new Set();
   const tagList = document.getElementById('tag-list');
   const tagAddName = document.getElementById('tag-add-name');
   const tagAddDesc = document.getElementById('tag-add-desc');
@@ -37,12 +38,63 @@
     editingTags.forEach((tag, i) => {
       const div = document.createElement('div');
       div.className = 'tag-item ' + (tag.is_system ? 'tag-item-system' : 'tag-item-custom');
-      const icon = tag.is_system ? '<span class="tag-lock">&#128274;</span>' : '';
-      const typeLabel = tag.is_system ? '<span class="tag-type-label tag-type-system">system</span>' : '<span class="tag-type-label tag-type-custom">custom</span>';
-      const deleteBtn = tag.is_system
-        ? '<button class="tag-delete-btn" disabled title="System tags cannot be deleted">&#10005;</button>'
-        : `<button class="tag-delete-btn" data-index="${i}" title="Delete tag">&#10005;</button>`;
-      div.innerHTML = `${icon}<span class="tag-item-name">${tag.name}</span><span class="tag-item-desc">${tag.description || ''}</span>${typeLabel}${deleteBtn}`;
+      const tagKey = tag.name || String(i);
+      const description = tag.description || '';
+      const isExpanded = expandedTagDescriptions.has(tagKey);
+      if (isExpanded) div.classList.add('tag-desc-expanded');
+
+      if (tag.is_system) {
+        const icon = document.createElement('span');
+        icon.className = 'tag-lock';
+        icon.textContent = '\u{1F512}';
+        div.appendChild(icon);
+      }
+
+      const name = document.createElement('span');
+      name.className = 'tag-item-name';
+      name.textContent = tag.name;
+      name.title = tag.name;
+      div.appendChild(name);
+
+      const desc = document.createElement('button');
+      desc.type = 'button';
+      desc.className = 'tag-item-desc';
+      desc.textContent = description;
+      desc.title = description;
+      desc.disabled = !description;
+      desc.setAttribute('aria-label', description ? `Tag description: ${description}` : 'No tag description');
+      desc.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+      if (description) desc.classList.add('has-description');
+      if (isExpanded) desc.classList.add('expanded');
+      desc.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (!description) return;
+        if (expandedTagDescriptions.has(tagKey)) {
+          expandedTagDescriptions.delete(tagKey);
+        } else {
+          expandedTagDescriptions.add(tagKey);
+        }
+        renderTagList();
+      });
+      div.appendChild(desc);
+
+      const typeLabel = document.createElement('span');
+      typeLabel.className = tag.is_system
+        ? 'tag-type-label tag-type-system'
+        : 'tag-type-label tag-type-custom';
+      typeLabel.textContent = tag.is_system ? 'system' : 'custom';
+      div.appendChild(typeLabel);
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.className = 'tag-delete-btn';
+      deleteBtn.title = tag.is_system ? 'System tags cannot be deleted' : 'Delete tag';
+      deleteBtn.innerHTML = '&#10005;';
+      if (tag.is_system) {
+        deleteBtn.disabled = true;
+      } else {
+        deleteBtn.dataset.index = String(i);
+      }
+      div.appendChild(deleteBtn);
       tagList.appendChild(div);
     });
     // Attach delete handlers


### PR DESCRIPTION
## Summary

This PR improves the Tags section so long tag descriptions can be inspected without losing the compact sidebar layout.

- exposes the full tag name/description via `title`
- makes descriptions keyboard/tap expandable with `aria-expanded`
- keeps desktop rows compact by default
- lets mobile/touch users tap the description to wrap the full text inline
- adds Playwright coverage for desktop keyboard expansion and mobile tap expansion

## Validation

- `node --check mapoi_webui/web/js/app.js`
- `node --check mapoi_webui/tests/web/e2e/tag-description.e2e.js`
- `git diff --check`
- `npm test` in `mapoi_webui/tests/web`
- `npx playwright test e2e/tag-description.e2e.js` in `mapoi_webui/tests/web`
- `npm run test:e2e` in `mapoi_webui/tests/web`

Closes #313.
