### PR TITLE
[codex] Sync Route edit selects from POI selection

### DIFF
--- a/mapoi_webui/tests/web/e2e/route-edit-poi-select.e2e.js
+++ b/mapoi_webui/tests/web/e2e/route-edit-poi-select.e2e.js
@@ -1,0 +1,45 @@
+const { test, expect } = require('@playwright/test');
+const { loadApp, poiCard, setSectionOpen } = require('./helpers');
+
+function routeItem(page, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return page.locator('.route-item').filter({
+    has: page.locator('.route-item-name', { hasText: new RegExp(`^${escaped}$`) }),
+  });
+}
+
+async function openRouteEdit(page) {
+  await loadApp(page);
+  await setSectionOpen(page, '#btn-route-toggle', '#route-body', true);
+  await routeItem(page, 'test_route').locator('.btn-edit').click();
+  await expect(page.locator('#route-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+}
+
+test.describe('Route edit POI candidate sync', () => {
+  test('POI list selection updates the matching route edit select', async ({ page }) => {
+    await openRouteEdit(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+
+    await poiCard(page, 'poi_wedge').locator('.poi-card-name').click();
+    await expect(page.locator('#route-wp-select')).toHaveValue('poi_wedge');
+    await expect(page.locator('#route-lm-select')).toHaveValue('');
+
+    await poiCard(page, 'poi_landmark').locator('.poi-card-name').click();
+    await expect(page.locator('#route-wp-select')).toHaveValue('');
+    await expect(page.locator('#route-lm-select')).toHaveValue('poi_landmark');
+  });
+
+  test('route edit map clicks sync selects while preserving add semantics', async ({ page }) => {
+    await openRouteEdit(page);
+
+    await page.locator('.poi-arrow-icon').nth(4).click();
+    await expect(page.locator('#route-lm-select')).toHaveValue('poi_landmark');
+    await expect(page.locator('#route-wp-select')).toHaveValue('');
+    await expect(page.locator('#route-waypoint-list .wp-item')).toHaveCount(3);
+
+    await page.locator('.poi-arrow-icon').nth(1).click();
+    await expect(page.locator('#route-wp-select')).toHaveValue('poi_wedge2');
+    await expect(page.locator('#route-lm-select')).toHaveValue('');
+    await expect(page.locator('#route-waypoint-list .wp-item')).toHaveCount(4);
+  });
+});

--- a/mapoi_webui/tests/web/route-editor-history.test.js
+++ b/mapoi_webui/tests/web/route-editor-history.test.js
@@ -115,6 +115,22 @@ describe('RouteEditor waypoint focus UI', () => {
     expect(editor.setDirty).not.toHaveBeenCalled();
   });
 
+  it('does not fire waypoint focus from row hover', () => {
+    document.body.innerHTML = '<div id="waypoints"></div>';
+    const editor = Object.create(RouteEditor.prototype);
+    editor.waypointListEl = document.getElementById('waypoints');
+    editor.editingWaypoints = ['A'];
+    editor.poiNames = ['A'];
+    editor.onWaypointFocus = vi.fn();
+
+    editor.renderWaypointList();
+    const row = editor.waypointListEl.querySelector('.wp-item');
+
+    row.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+
+    expect(editor.onWaypointFocus).not.toHaveBeenCalled();
+  });
+
   it('fires landmark focus from rendered rows without marking data dirty', () => {
     document.body.innerHTML = '<div id="landmarks"></div>';
     const editor = Object.create(RouteEditor.prototype);
@@ -134,6 +150,22 @@ describe('RouteEditor waypoint focus UI', () => {
     expect(editor.setDirty).not.toHaveBeenCalled();
   });
 
+  it('does not fire landmark focus from row hover', () => {
+    document.body.innerHTML = '<div id="landmarks"></div>';
+    const editor = Object.create(RouteEditor.prototype);
+    editor.landmarkListEl = document.getElementById('landmarks');
+    editor.editingLandmarks = ['L1'];
+    editor.landmarkNames = ['L1'];
+    editor.onLandmarkFocus = vi.fn();
+
+    editor.renderLandmarkList();
+    const row = editor.landmarkListEl.querySelector('.wp-item');
+
+    row.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+
+    expect(editor.onLandmarkFocus).not.toHaveBeenCalled();
+  });
+
   it('moves a dragged waypoint to the drop target index', () => {
     const editor = makeEditor();
     editor.dragWaypointIndex = 0;
@@ -142,5 +174,27 @@ describe('RouteEditor waypoint focus UI', () => {
 
     expect(editor.editingWaypoints).toEqual(['B', 'C', 'A']);
     expect(editor.dragWaypointIndex).toBe(-1);
+  });
+
+  it('syncs waypoint and landmark selects from a POI candidate name', () => {
+    const editor = Object.create(RouteEditor.prototype);
+    editor.poiNames = ['A'];
+    editor.landmarkNames = ['L1'];
+    editor.waypointSelect = { value: '' };
+    editor.landmarkSelect = { value: '' };
+    editor.onWaypointFocus = vi.fn();
+    editor.onLandmarkFocus = vi.fn();
+
+    expect(editor.selectPoiCandidate('A')).toBe('waypoint');
+    expect(editor.waypointSelect.value).toBe('A');
+    expect(editor.landmarkSelect.value).toBe('');
+    expect(editor.onWaypointFocus).toHaveBeenCalledWith('A');
+
+    expect(editor.selectPoiCandidate('L1')).toBe('landmark');
+    expect(editor.waypointSelect.value).toBe('');
+    expect(editor.landmarkSelect.value).toBe('L1');
+    expect(editor.onLandmarkFocus).toHaveBeenCalledWith('L1');
+
+    expect(editor.selectPoiCandidate('missing')).toBe('');
   });
 });

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -237,6 +237,13 @@
     }
   }
 
+  function syncRouteEditPoiCandidate(index) {
+    if (routeEditor.editingIndex === -1 || index < 0) return '';
+    const poi = poiEditor.pois[index];
+    if (!poi || !poi.name) return '';
+    return routeEditor.selectPoiCandidate(poi.name);
+  }
+
   poiEditor.onBeforeEditStart = () => {
     if (!isRouteEditingActive()) return true;
     alert('Finish or cancel route editing before editing POIs.');
@@ -291,11 +298,11 @@
     if (routeEditor.editingIndex !== -1) {
       const poi = poiEditor.pois[index];
       if (poi && poi.name) {
+        const candidateKind = syncRouteEditPoiCandidate(index);
+        if (candidateKind === 'landmark') return;
         // landmark POI は waypoint dropdown と整合させ、map click でも waypoint には
         // 入れない (Codex review #147 medium)。route.landmarks への追加は dropdown UI で行う。
-        if (MapoiPoiFilter.hasLandmarkTag(poi)) {
-          return;
-        }
+        if (MapoiPoiFilter.hasLandmarkTag(poi)) return;
         routeEditor.addWaypointByName(poi.name);
       }
       return;
@@ -340,6 +347,7 @@
   // POI selection in list
   poiEditor.onSelectionChange = (index) => {
     mapViewer.highlightPoi(index);
+    syncRouteEditPoiCandidate(index);
     // Refresh markers when dirty (POIs changed)
     if (poiEditor.dirty) {
       mapViewer.showPois(poiEditor.pois, poiEditor.visiblePois);

--- a/mapoi_webui/web/js/route-editor.js
+++ b/mapoi_webui/web/js/route-editor.js
@@ -313,7 +313,6 @@ class RouteEditor {
       row.dataset.poiName = wp;
       row.addEventListener('click', () => this.focusWaypointName(wp));
       row.addEventListener('focus', () => this.focusWaypointName(wp));
-      row.addEventListener('mouseenter', () => this.focusWaypointName(wp));
       row.addEventListener('dragover', (e) => this._onWaypointDragOver(e, row));
       row.addEventListener('dragleave', () => row.classList.remove('wp-drop-target'));
       row.addEventListener('drop', (e) => this._onWaypointDrop(e, i));
@@ -394,9 +393,28 @@ class RouteEditor {
     if (this.editingIndex === -1) return;
     this._pushEditUndo();
     this.editingWaypoints.push(name);
+    if (this.waypointSelect) this.waypointSelect.value = name;
+    if (this.landmarkSelect) this.landmarkSelect.value = '';
     this.renderWaypointList();
     this.focusWaypointName(name);
     this._fireEditingChange();
+  }
+
+  selectPoiCandidate(name) {
+    if (!name) return '';
+    if (this.poiNames.includes(name)) {
+      if (this.waypointSelect) this.waypointSelect.value = name;
+      if (this.landmarkSelect) this.landmarkSelect.value = '';
+      this.focusWaypointName(name);
+      return 'waypoint';
+    }
+    if (this.landmarkNames.includes(name)) {
+      if (this.landmarkSelect) this.landmarkSelect.value = name;
+      if (this.waypointSelect) this.waypointSelect.value = '';
+      this.focusLandmarkName(name);
+      return 'landmark';
+    }
+    return '';
   }
 
   moveWaypoint(index, dir) {
@@ -454,7 +472,6 @@ class RouteEditor {
       row.dataset.poiName = lm;
       row.addEventListener('click', () => this.focusLandmarkName(lm));
       row.addEventListener('focus', () => this.focusLandmarkName(lm));
-      row.addEventListener('mouseenter', () => this.focusLandmarkName(lm));
 
       const num = document.createElement('span');
       num.className = 'wp-num';


### PR DESCRIPTION
## Summary

This PR makes Route editing react to POI selection in both directions:

- selecting a waypoint POI while editing a route fills the Waypoints select
- selecting a landmark POI while editing a route fills the Landmarks select
- route-edit map clicks still append waypoint POIs as before
- route-edit map clicks on landmark POIs now focus the Landmark select instead of doing nothing
- landmark POIs remain excluded from route waypoints

## Validation

- `node --check mapoi_webui/web/js/app.js`
- `node --check mapoi_webui/web/js/route-editor.js`
- `node --check mapoi_webui/tests/web/e2e/route-edit-poi-select.e2e.js`
- `git diff --check`
- `npm test` in `mapoi_webui/tests/web`
- `npx playwright test e2e/route-edit-poi-select.e2e.js` in `mapoi_webui/tests/web`
- `npm run test:e2e` in `mapoi_webui/tests/web`

Closes #315.
