### PR TITLE
[codex] Add route map-insert toggle

### DIFF
--- a/mapoi_webui/tests/web/e2e/route-edit-poi-select.e2e.js
+++ b/mapoi_webui/tests/web/e2e/route-edit-poi-select.e2e.js
@@ -29,9 +29,24 @@ test.describe('Route edit POI candidate sync', () => {
     await expect(page.locator('#route-lm-select')).toHaveValue('poi_landmark');
   });
 
-  test('route edit map clicks sync selects while preserving add semantics', async ({ page }) => {
+  test('route edit map clicks sync selects without auto-add by default', async ({ page }) => {
     await openRouteEdit(page);
 
+    await page.locator('.poi-arrow-icon').nth(4).click();
+    await expect(page.locator('#route-lm-select')).toHaveValue('poi_landmark');
+    await expect(page.locator('#route-wp-select')).toHaveValue('');
+    await expect(page.locator('#route-waypoint-list .wp-item')).toHaveCount(3);
+
+    await page.locator('.poi-arrow-icon').nth(1).click();
+    await expect(page.locator('#route-wp-select')).toHaveValue('poi_wedge2');
+    await expect(page.locator('#route-lm-select')).toHaveValue('');
+    await expect(page.locator('#route-waypoint-list .wp-item')).toHaveCount(3);
+  });
+
+  test('route edit click-to-add toggle preserves fast waypoint entry', async ({ page }) => {
+    await openRouteEdit(page);
+
+    await page.locator('#route-click-add-toggle').check();
     await page.locator('.poi-arrow-icon').nth(4).click();
     await expect(page.locator('#route-lm-select')).toHaveValue('poi_landmark');
     await expect(page.locator('#route-wp-select')).toHaveValue('');

--- a/mapoi_webui/tests/web/e2e/route-edit-poi-select.e2e.js
+++ b/mapoi_webui/tests/web/e2e/route-edit-poi-select.e2e.js
@@ -43,10 +43,14 @@ test.describe('Route edit POI candidate sync', () => {
     await expect(page.locator('#route-waypoint-list .wp-item')).toHaveCount(3);
   });
 
-  test('route edit click-to-add toggle preserves fast waypoint entry', async ({ page }) => {
+  test('route edit map insert toggle inserts after the selected waypoint', async ({ page }) => {
     await openRouteEdit(page);
 
-    await page.locator('#route-click-add-toggle').check();
+    await expect(page.locator('#route-waypoint-list .wp-item')).toHaveCount(3);
+    await page.locator('#route-waypoint-list .wp-item').nth(0).click();
+    await expect(page.locator('#route-waypoint-list .wp-item').nth(0)).toHaveClass(/(^|\s)selected(\s|$)/);
+
+    await page.locator('#route-map-insert-toggle').check();
     await page.locator('.poi-arrow-icon').nth(4).click();
     await expect(page.locator('#route-lm-select')).toHaveValue('poi_landmark');
     await expect(page.locator('#route-wp-select')).toHaveValue('');
@@ -56,5 +60,12 @@ test.describe('Route edit POI candidate sync', () => {
     await expect(page.locator('#route-wp-select')).toHaveValue('poi_wedge2');
     await expect(page.locator('#route-lm-select')).toHaveValue('');
     await expect(page.locator('#route-waypoint-list .wp-item')).toHaveCount(4);
+    await expect(page.locator('#route-waypoint-list .wp-name')).toHaveText([
+      'poi_wedge',
+      'poi_wedge2',
+      'poi_disc',
+      'poi_pause',
+    ]);
+    await expect(page.locator('#route-waypoint-list .wp-item').nth(1)).toHaveClass(/(^|\s)selected(\s|$)/);
   });
 });

--- a/mapoi_webui/tests/web/route-editor-history.test.js
+++ b/mapoi_webui/tests/web/route-editor-history.test.js
@@ -19,6 +19,7 @@ function makeEditor() {
   editor.redoStack = [];
   editor.HISTORY_CAP = 50;
   editor.dragWaypointIndex = -1;
+  editor.selectedWaypointIndex = -1;
   editor.btnUndo = { disabled: true };
   editor.btnRedo = { disabled: true };
   editor.waypointListEl = { querySelectorAll: () => [] };
@@ -64,9 +65,22 @@ describe('RouteEditor edit-form history', () => {
     editor.addWaypointByName('D');
 
     expect(editor.editingWaypoints).toEqual(['A', 'B', 'C', 'D']);
+    expect(editor.selectedWaypointIndex).toBe(3);
     expect(editor.onWaypointFocus).toHaveBeenCalledWith('D');
     expect(editor.redoStack).toEqual([]);
     expect(editor.btnRedo.disabled).toBe(true);
+  });
+
+  it('inserts a waypoint after the selected waypoint', () => {
+    const editor = makeEditor();
+    editor.selectedWaypointIndex = 0;
+    editor.onWaypointFocus = vi.fn();
+
+    editor.insertWaypointAfterSelected('D');
+
+    expect(editor.editingWaypoints).toEqual(['A', 'D', 'B', 'C']);
+    expect(editor.selectedWaypointIndex).toBe(1);
+    expect(editor.onWaypointFocus).toHaveBeenCalledWith('D');
   });
 
   it('includes landmark add/remove in the same edit-form history', () => {
@@ -93,6 +107,26 @@ describe('RouteEditor edit-form history', () => {
     expect(editor.undoStack).toEqual([]);
     expect(editor.renderWaypointList).not.toHaveBeenCalled();
   });
+
+  it('keeps the selected waypoint attached to the moved item', () => {
+    const editor = makeEditor();
+    editor.selectedWaypointIndex = 1;
+
+    editor.moveWaypointTo(1, 0);
+
+    expect(editor.editingWaypoints).toEqual(['B', 'A', 'C']);
+    expect(editor.selectedWaypointIndex).toBe(0);
+  });
+
+  it('keeps waypoint selection on a nearby item after removal', () => {
+    const editor = makeEditor();
+    editor.selectedWaypointIndex = 1;
+
+    editor.removeWaypoint(1);
+
+    expect(editor.editingWaypoints).toEqual(['A', 'C']);
+    expect(editor.selectedWaypointIndex).toBe(1);
+  });
 });
 
 describe('RouteEditor waypoint focus UI', () => {
@@ -102,6 +136,7 @@ describe('RouteEditor waypoint focus UI', () => {
     editor.waypointListEl = document.getElementById('waypoints');
     editor.editingWaypoints = ['A'];
     editor.poiNames = ['A'];
+    editor.selectedWaypointIndex = -1;
     editor.onWaypointFocus = vi.fn();
     editor.setDirty = vi.fn();
 
@@ -112,6 +147,8 @@ describe('RouteEditor waypoint focus UI', () => {
     row.dispatchEvent(new Event('focus'));
 
     expect(editor.onWaypointFocus).toHaveBeenCalledWith('A');
+    expect(editor.selectedWaypointIndex).toBe(0);
+    expect(row.classList.contains('selected')).toBe(true);
     expect(editor.setDirty).not.toHaveBeenCalled();
   });
 
@@ -121,6 +158,7 @@ describe('RouteEditor waypoint focus UI', () => {
     editor.waypointListEl = document.getElementById('waypoints');
     editor.editingWaypoints = ['A'];
     editor.poiNames = ['A'];
+    editor.selectedWaypointIndex = -1;
     editor.onWaypointFocus = vi.fn();
 
     editor.renderWaypointList();
@@ -198,15 +236,15 @@ describe('RouteEditor waypoint focus UI', () => {
     expect(editor.selectPoiCandidate('missing')).toBe('');
   });
 
-  it('keeps click-to-add disabled by default for each edit session', () => {
+  it('keeps map insertion disabled by default for each edit session', () => {
     const editor = Object.create(RouteEditor.prototype);
     editor.formEl = document.createElement('div');
-    editor.clickAddMode = true;
-    editor.clickAddToggle = { checked: true };
+    editor.mapInsertMode = true;
+    editor.mapInsertToggle = { checked: true };
 
     editor.showForm();
 
-    expect(editor.isClickAddModeEnabled()).toBe(false);
-    expect(editor.clickAddToggle.checked).toBe(false);
+    expect(editor.isMapInsertModeEnabled()).toBe(false);
+    expect(editor.mapInsertToggle.checked).toBe(false);
   });
 });

--- a/mapoi_webui/tests/web/route-editor-history.test.js
+++ b/mapoi_webui/tests/web/route-editor-history.test.js
@@ -197,4 +197,16 @@ describe('RouteEditor waypoint focus UI', () => {
 
     expect(editor.selectPoiCandidate('missing')).toBe('');
   });
+
+  it('keeps click-to-add disabled by default for each edit session', () => {
+    const editor = Object.create(RouteEditor.prototype);
+    editor.formEl = document.createElement('div');
+    editor.clickAddMode = true;
+    editor.clickAddToggle = { checked: true };
+
+    editor.showForm();
+
+    expect(editor.isClickAddModeEnabled()).toBe(false);
+    expect(editor.clickAddToggle.checked).toBe(false);
+  });
 });

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -756,11 +756,27 @@ main {
 
 .route-wp-select {
   flex: 1;
+  min-width: 0;
   padding: 4px 8px;
   border: 1px solid #ccc;
   border-radius: 4px;
   font-size: 0.85rem;
   min-height: 32px;
+}
+
+.route-click-add-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 0.82rem;
+  color: #4d5f6f;
+  cursor: pointer;
+  user-select: none;
+}
+
+.route-click-add-toggle input {
+  margin: 0;
 }
 
 .btn-add-wp {

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -645,6 +645,15 @@ main {
   background: #eef5fc;
 }
 
+.wp-item.selected {
+  background: #e8f6f3;
+  box-shadow: inset 3px 0 0 #16a085;
+}
+
+.wp-item.selected:focus {
+  background: #ddf1ed;
+}
+
 .wp-item.wp-drop-target {
   background: #e8f6f3;
   box-shadow: inset 3px 0 0 #16a085;
@@ -764,7 +773,7 @@ main {
   min-height: 32px;
 }
 
-.route-click-add-toggle {
+.route-map-insert-toggle {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -775,7 +784,7 @@ main {
   user-select: none;
 }
 
-.route-click-add-toggle input {
+.route-map-insert-toggle input {
   margin: 0;
 }
 

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -198,9 +198,13 @@
                 </select>
                 <button type="button" id="btn-add-waypoint" class="btn-add-wp">+</button>
               </div>
-              <label class="route-click-add-toggle">
-                <input type="checkbox" id="route-click-add-toggle" />
-                <span>Click to add</span>
+              <label class="route-map-insert-toggle" title="Map clicks insert after the selected waypoint">
+                <input
+                  type="checkbox"
+                  id="route-map-insert-toggle"
+                  aria-label="Insert map-clicked POIs after the selected waypoint"
+                />
+                <span>Map click inserts after selected</span>
               </label>
             </div>
             <!-- route.landmarks (#143): この route 走行中に意識する補助 POI 群 (Nav2 へは送らず radius 監視のみ) -->

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -198,7 +198,10 @@
                 </select>
                 <button type="button" id="btn-add-waypoint" class="btn-add-wp">+</button>
               </div>
-              <div class="route-wp-map-hint">Click a POI on the map to add it as a waypoint</div>
+              <label class="route-click-add-toggle">
+                <input type="checkbox" id="route-click-add-toggle" />
+                <span>Click to add</span>
+              </label>
             </div>
             <!-- route.landmarks (#143): この route 走行中に意識する補助 POI 群 (Nav2 へは送らず radius 監視のみ) -->
             <div class="route-wp-section">

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -346,16 +346,17 @@
 
   // POI marker click on map
   mapViewer.onPoiClick = (index) => {
-    // If route editing is active, add the clicked POI as a waypoint
+    // Route editing uses map clicks for candidate selection by default.
+    // Optional click-to-add keeps fast waypoint entry available without making
+    // accidental route mutations the default interaction.
     if (routeEditor.editingIndex !== -1) {
       const poi = poiEditor.pois[index];
       if (poi && poi.name) {
         const candidateKind = syncRouteEditPoiCandidate(index);
-        if (candidateKind === 'landmark') return;
-        // landmark POI は waypoint dropdown と整合させ、map click でも waypoint には
-        // 入れない (Codex review #147 medium)。route.landmarks への追加は dropdown UI で行う。
-        if (MapoiPoiFilter.hasLandmarkTag(poi)) return;
-        routeEditor.addWaypointByName(poi.name);
+        if (candidateKind !== 'waypoint') return;
+        if (routeEditor.isClickAddModeEnabled()) {
+          routeEditor.addWaypointByName(poi.name);
+        }
       }
       return;
     }

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -354,8 +354,8 @@
       if (poi && poi.name) {
         const candidateKind = syncRouteEditPoiCandidate(index);
         if (candidateKind !== 'waypoint') return;
-        if (routeEditor.isClickAddModeEnabled()) {
-          routeEditor.addWaypointByName(poi.name);
+        if (routeEditor.isMapInsertModeEnabled()) {
+          routeEditor.insertWaypointAfterSelected(poi.name);
         }
       }
       return;

--- a/mapoi_webui/web/js/route-editor.js
+++ b/mapoi_webui/web/js/route-editor.js
@@ -18,7 +18,8 @@ class RouteEditor {
     this.redoStack = [];
     this.HISTORY_CAP = 50;
     this.dragWaypointIndex = -1;
-    this.clickAddMode = false;
+    this.selectedWaypointIndex = -1;
+    this.mapInsertMode = false;
 
     this.onDirtyChange = null;
     this.onVisibilityChange = null;
@@ -45,7 +46,7 @@ class RouteEditor {
     this.waypointListEl = document.getElementById('route-waypoint-list');
     this.waypointSelect = document.getElementById('route-wp-select');
     this.btnAddWaypoint = document.getElementById('btn-add-waypoint');
-    this.clickAddToggle = document.getElementById('route-click-add-toggle');
+    this.mapInsertToggle = document.getElementById('route-map-insert-toggle');
 
     // Form inputs - landmarks (#143)
     this.landmarkListEl = document.getElementById('route-landmark-list');
@@ -59,9 +60,9 @@ class RouteEditor {
     this.btnSaveRoutes.addEventListener('click', () => this.save());
     this.btnDiscardRoutes.addEventListener('click', () => this.discard());
     this.btnAddWaypoint.addEventListener('click', () => this.addWaypointFromSelect());
-    if (this.clickAddToggle) {
-      this.clickAddToggle.addEventListener('change', () => {
-        this.clickAddMode = this.clickAddToggle.checked;
+    if (this.mapInsertToggle) {
+      this.mapInsertToggle.addEventListener('change', () => {
+        this.mapInsertMode = this.mapInsertToggle.checked;
       });
     }
     this.waypointSelect.addEventListener('change', () => this.focusWaypointName(this.waypointSelect.value));
@@ -106,8 +107,8 @@ class RouteEditor {
     this.poiNames = names || [];
   }
 
-  isClickAddModeEnabled() {
-    return !!this.clickAddMode;
+  isMapInsertModeEnabled() {
+    return !!this.mapInsertMode;
   }
 
   /**
@@ -285,6 +286,7 @@ class RouteEditor {
   fillForm(route) {
     this.inputRouteName.value = route.name || '';
     this.editingWaypoints = [...(route.waypoints || [])];
+    this.selectedWaypointIndex = this.editingWaypoints.length > 0 ? this.editingWaypoints.length - 1 : -1;
     this.editingLandmarks = [...(route.landmarks || [])];   // #143
     this.renderWaypointList();
     this.populateWaypointSelect();
@@ -310,6 +312,7 @@ class RouteEditor {
    */
   renderWaypointList() {
     this.waypointListEl.innerHTML = '';
+    this._normalizeSelectedWaypointIndex();
     if (this.editingWaypoints.length === 0) {
       const empty = document.createElement('div');
       empty.className = 'wp-empty';
@@ -319,11 +322,12 @@ class RouteEditor {
     }
     this.editingWaypoints.forEach((wp, i) => {
       const row = document.createElement('div');
-      row.className = 'wp-item';
+      row.className = 'wp-item' + (i === this.selectedWaypointIndex ? ' selected' : '');
       row.tabIndex = 0;
       row.dataset.poiName = wp;
-      row.addEventListener('click', () => this.focusWaypointName(wp));
-      row.addEventListener('focus', () => this.focusWaypointName(wp));
+      row.setAttribute('aria-selected', i === this.selectedWaypointIndex ? 'true' : 'false');
+      row.addEventListener('click', () => this.selectWaypoint(i));
+      row.addEventListener('focus', () => this.selectWaypoint(i));
       row.addEventListener('dragover', (e) => this._onWaypointDragOver(e, row));
       row.addEventListener('dragleave', () => row.classList.remove('wp-drop-target'));
       row.addEventListener('drop', (e) => this._onWaypointDrop(e, i));
@@ -358,21 +362,30 @@ class RouteEditor {
       upBtn.textContent = '\u25B2';
       upBtn.title = 'Move up';
       upBtn.disabled = i === 0;
-      upBtn.addEventListener('click', () => this.moveWaypoint(i, -1));
+      upBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.moveWaypoint(i, -1);
+      });
 
       const downBtn = document.createElement('button');
       downBtn.type = 'button';
       downBtn.textContent = '\u25BC';
       downBtn.title = 'Move down';
       downBtn.disabled = i === this.editingWaypoints.length - 1;
-      downBtn.addEventListener('click', () => this.moveWaypoint(i, 1));
+      downBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.moveWaypoint(i, 1);
+      });
 
       const removeBtn = document.createElement('button');
       removeBtn.type = 'button';
       removeBtn.textContent = '\u00D7';
       removeBtn.title = 'Remove';
       removeBtn.className = 'wp-remove';
-      removeBtn.addEventListener('click', () => this.removeWaypoint(i));
+      removeBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.removeWaypoint(i);
+      });
 
       btns.appendChild(upBtn);
       btns.appendChild(downBtn);
@@ -389,21 +402,23 @@ class RouteEditor {
   addWaypointFromSelect() {
     const val = this.waypointSelect.value;
     if (!val) return;
-    this._pushEditUndo();
-    this.editingWaypoints.push(val);
+    this.insertWaypointAfterSelected(val);
     this.waypointSelect.value = '';
-    this.renderWaypointList();
-    this.focusWaypointName(val);
-    this._fireEditingChange();
   }
 
   /**
    * Add a waypoint by POI name (e.g. from map click).
    */
   addWaypointByName(name) {
+    this.insertWaypointAfterSelected(name);
+  }
+
+  insertWaypointAfterSelected(name) {
     if (this.editingIndex === -1) return;
     this._pushEditUndo();
-    this.editingWaypoints.push(name);
+    const insertIndex = this._waypointInsertIndex();
+    this.editingWaypoints.splice(insertIndex, 0, name);
+    this.selectedWaypointIndex = insertIndex;
     if (this.waypointSelect) this.waypointSelect.value = name;
     if (this.landmarkSelect) this.landmarkSelect.value = '';
     this.renderWaypointList();
@@ -439,6 +454,7 @@ class RouteEditor {
     this._pushEditUndo();
     const [wp] = this.editingWaypoints.splice(index, 1);
     this.editingWaypoints.splice(newIndex, 0, wp);
+    this._moveSelectedWaypointIndex(index, newIndex);
     this.renderWaypointList();
     this._fireEditingChange();
   }
@@ -447,6 +463,11 @@ class RouteEditor {
     if (index < 0 || index >= this.editingWaypoints.length) return;
     this._pushEditUndo();
     this.editingWaypoints.splice(index, 1);
+    if (this.selectedWaypointIndex > index) {
+      this.selectedWaypointIndex -= 1;
+    } else if (this.selectedWaypointIndex === index) {
+      this.selectedWaypointIndex = Math.min(index, this.editingWaypoints.length - 1);
+    }
     this.renderWaypointList();
     this._fireEditingChange();
   }
@@ -612,15 +633,16 @@ class RouteEditor {
 
   showForm() {
     this.formEl.classList.remove('hidden');
-    this.clickAddMode = false;
-    if (this.clickAddToggle) this.clickAddToggle.checked = false;
+    this.mapInsertMode = false;
+    if (this.mapInsertToggle) this.mapInsertToggle.checked = false;
     if (this.onEditFormVisibilityChange) this.onEditFormVisibilityChange(true);
   }
 
   hideForm() {
     this.formEl.classList.add('hidden');
-    this.clickAddMode = false;
-    if (this.clickAddToggle) this.clickAddToggle.checked = false;
+    this.mapInsertMode = false;
+    this.selectedWaypointIndex = -1;
+    if (this.mapInsertToggle) this.mapInsertToggle.checked = false;
     if (this.onEditFormVisibilityChange) this.onEditFormVisibilityChange(false);
   }
 
@@ -635,6 +657,13 @@ class RouteEditor {
 
   focusWaypointName(name) {
     if (this.onWaypointFocus) this.onWaypointFocus(name || '');
+  }
+
+  selectWaypoint(index) {
+    if (index < 0 || index >= this.editingWaypoints.length) return;
+    this.selectedWaypointIndex = index;
+    this._updateWaypointSelectionClasses();
+    this.focusWaypointName(this.editingWaypoints[index]);
   }
 
   focusLandmarkName(name) {
@@ -677,6 +706,51 @@ class RouteEditor {
     });
   }
 
+  _normalizeSelectedWaypointIndex() {
+    if (!this.editingWaypoints || this.editingWaypoints.length === 0) {
+      this.selectedWaypointIndex = -1;
+      return;
+    }
+    if (!Number.isInteger(this.selectedWaypointIndex)
+        || this.selectedWaypointIndex < 0
+        || this.selectedWaypointIndex >= this.editingWaypoints.length) {
+      this.selectedWaypointIndex = this.editingWaypoints.length - 1;
+    }
+  }
+
+  _updateWaypointSelectionClasses() {
+    if (!this.waypointListEl) return;
+    this.waypointListEl.querySelectorAll('.wp-item').forEach((row, index) => {
+      const selected = index === this.selectedWaypointIndex;
+      row.classList.toggle('selected', selected);
+      row.setAttribute('aria-selected', selected ? 'true' : 'false');
+    });
+  }
+
+  _waypointInsertIndex() {
+    this._normalizeSelectedWaypointIndex();
+    if (this.selectedWaypointIndex < 0) return this.editingWaypoints.length;
+    return this.selectedWaypointIndex + 1;
+  }
+
+  _moveSelectedWaypointIndex(fromIndex, toIndex) {
+    if (this.selectedWaypointIndex === fromIndex) {
+      this.selectedWaypointIndex = toIndex;
+      return;
+    }
+    if (fromIndex < toIndex
+        && this.selectedWaypointIndex > fromIndex
+        && this.selectedWaypointIndex <= toIndex) {
+      this.selectedWaypointIndex -= 1;
+      return;
+    }
+    if (fromIndex > toIndex
+        && this.selectedWaypointIndex >= toIndex
+        && this.selectedWaypointIndex < fromIndex) {
+      this.selectedWaypointIndex += 1;
+    }
+  }
+
   _resetEditHistory() {
     this.undoStack = [];
     this.redoStack = [];
@@ -705,6 +779,7 @@ class RouteEditor {
       routeName: this.inputRouteName.value,
       editingWaypoints: [...this.editingWaypoints],
       editingLandmarks: [...this.editingLandmarks],
+      selectedWaypointIndex: this.selectedWaypointIndex,
     };
   }
 
@@ -712,6 +787,9 @@ class RouteEditor {
     this.inputRouteName.value = snap.routeName || '';
     this.editingWaypoints = [...(snap.editingWaypoints || [])];
     this.editingLandmarks = [...(snap.editingLandmarks || [])];
+    this.selectedWaypointIndex = Number.isInteger(snap.selectedWaypointIndex)
+      ? snap.selectedWaypointIndex
+      : -1;
     this.renderWaypointList();
     this.renderLandmarkList();
     this._updateUndoButtons();

--- a/mapoi_webui/web/js/route-editor.js
+++ b/mapoi_webui/web/js/route-editor.js
@@ -18,6 +18,7 @@ class RouteEditor {
     this.redoStack = [];
     this.HISTORY_CAP = 50;
     this.dragWaypointIndex = -1;
+    this.clickAddMode = false;
 
     this.onDirtyChange = null;
     this.onVisibilityChange = null;
@@ -44,6 +45,7 @@ class RouteEditor {
     this.waypointListEl = document.getElementById('route-waypoint-list');
     this.waypointSelect = document.getElementById('route-wp-select');
     this.btnAddWaypoint = document.getElementById('btn-add-waypoint');
+    this.clickAddToggle = document.getElementById('route-click-add-toggle');
 
     // Form inputs - landmarks (#143)
     this.landmarkListEl = document.getElementById('route-landmark-list');
@@ -57,6 +59,11 @@ class RouteEditor {
     this.btnSaveRoutes.addEventListener('click', () => this.save());
     this.btnDiscardRoutes.addEventListener('click', () => this.discard());
     this.btnAddWaypoint.addEventListener('click', () => this.addWaypointFromSelect());
+    if (this.clickAddToggle) {
+      this.clickAddToggle.addEventListener('change', () => {
+        this.clickAddMode = this.clickAddToggle.checked;
+      });
+    }
     this.waypointSelect.addEventListener('change', () => this.focusWaypointName(this.waypointSelect.value));
     this.waypointSelect.addEventListener('focus', () => this.focusWaypointName(this.waypointSelect.value));
     if (this.landmarkSelect) {
@@ -97,6 +104,10 @@ class RouteEditor {
    */
   setPoiNames(names) {
     this.poiNames = names || [];
+  }
+
+  isClickAddModeEnabled() {
+    return !!this.clickAddMode;
   }
 
   /**
@@ -601,11 +612,15 @@ class RouteEditor {
 
   showForm() {
     this.formEl.classList.remove('hidden');
+    this.clickAddMode = false;
+    if (this.clickAddToggle) this.clickAddToggle.checked = false;
     if (this.onEditFormVisibilityChange) this.onEditFormVisibilityChange(true);
   }
 
   hideForm() {
     this.formEl.classList.add('hidden');
+    this.clickAddMode = false;
+    if (this.clickAddToggle) this.clickAddToggle.checked = false;
     if (this.onEditFormVisibilityChange) this.onEditFormVisibilityChange(false);
   }
 


### PR DESCRIPTION
## Summary

- Rename the Route edit map-click option from ambiguous `Click to add` to `Map click inserts after selected`.
- Track the selected waypoint row in the Route editor and show it visually.
- When the map insert option is enabled, clicking a waypoint POI inserts it immediately after the selected waypoint instead of appending blindly.
- Keep default map-click behavior as candidate selection only, and keep landmark POIs syncing only to the Landmark select.
- Preserve insertion target behavior across reorder/remove operations, with undo/redo snapshots carrying the selected waypoint index.

Closes #317

## Validation

- `node --check mapoi_webui/web/js/app.js`
- `node --check mapoi_webui/web/js/route-editor.js`
- `node --check mapoi_webui/tests/web/e2e/route-edit-poi-select.e2e.js`
- `git diff --check`
- `npm test` in `mapoi_webui/tests/web` (54 passed)
- `npm run test:e2e` in `mapoi_webui/tests/web` (17 passed)