### PR TITLE
[codex] Use English for remaining Web UI warnings

### DIFF
--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -78,11 +78,11 @@ def _validate_pois_tag_exclusivity(pois):
         has_pause = 'pause' in tags
         name = (poi.get('name', '?') if isinstance(poi, dict) else '?')
         if has_waypoint and has_landmark:
-            return (f'POI #{i} ({name}): "waypoint" と "landmark" は併用できません '
-                    '(landmark は Nav2 navigation 不可な reference 専用)')
+            return (f'POI #{i} ({name}): "waypoint" and "landmark" cannot be used together. '
+                    'A landmark is only a reference POI and is not sent to Nav2.')
         if has_pause and has_landmark:
-            return (f'POI #{i} ({name}): "pause" と "landmark" は併用できません '
-                    '(landmark は到達不可な reference のため pause 動作が成立しません)')
+            return (f'POI #{i} ({name}): "pause" and "landmark" cannot be used together. '
+                    'A landmark is not a navigation target, so the robot cannot pause there.')
         # (initial_pose × landmark 排他は #144 で initial_pose system tag を廃止したため不要に。)
     return None
 
@@ -147,8 +147,8 @@ class MapoiWebNode(Node):
             self.get_parameter('robot_radius').get_parameter_value().double_value)
         if not math.isfinite(raw_radius) or raw_radius <= 0.0:
             self.get_logger().warn(
-                f'robot_radius={raw_radius!r} は不正値です。default 0.15m を使います。'
-                ' (連動する Nav2 robot_radius と一致するように launch param を見直してください)')
+                f'robot_radius={raw_radius!r} is invalid. Using the default 0.15 m. '
+                'Please check the launch parameter so it matches the Nav2 robot_radius.')
             self.robot_radius_ = 0.15
         else:
             self.robot_radius_ = raw_radius
@@ -433,8 +433,8 @@ class MapoiWebNode(Node):
         sub_count = pub.get_subscription_count()
         pub.publish(msg)
         if sub_count == 0:
-            warning = (f"{topic_name} に subscriber が見つかりません "
-                       "(mapoi_nav2_bridge などの listener が起動していない可能性)")
+            warning = (f'No subscribers found for {topic_name}. '
+                       'The listener, such as mapoi_nav2_bridge, may not be running.')
             self.get_logger().warn(warning)
             return True, warning
         return True, None
@@ -751,8 +751,8 @@ class MapoiWebNode(Node):
                     return jsonify({
                         'success': True,
                         'config_version': new_version,
-                        'warning': 'YAML は保存しましたが、mapoi_server の reload_map_info '
-                                   'service が応答しなかったか失敗しました。詳細はログを確認してください'
+                        'warning': 'The YAML file was saved, but mapoi_server reload_map_info '
+                                   'did not respond or failed. Check the logs for details.'
                     })
                 return jsonify({'success': True, 'config_version': new_version})
             except Exception as e:
@@ -785,8 +785,8 @@ class MapoiWebNode(Node):
                 if not reloaded:
                     return jsonify({
                         'success': True,
-                        'warning': 'YAML は保存しましたが、mapoi_server の reload_map_info '
-                                   'service が応答しなかったか失敗しました。詳細はログを確認してください'
+                        'warning': 'The YAML file was saved, but mapoi_server reload_map_info '
+                                   'did not respond or failed. Check the logs for details.'
                     })
                 return jsonify({'success': True})
             except Exception as e:
@@ -818,8 +818,8 @@ class MapoiWebNode(Node):
                 if not reloaded:
                     return jsonify({
                         'success': True,
-                        'warning': 'YAML は保存しましたが、mapoi_server の reload_map_info '
-                                   'service が応答しなかったか失敗しました。詳細はログを確認してください'
+                        'warning': 'The YAML file was saved, but mapoi_server reload_map_info '
+                                   'did not respond or failed. Check the logs for details.'
                     })
                 return jsonify({'success': True})
             except Exception as e:
@@ -921,8 +921,8 @@ class MapoiWebNode(Node):
             if node.count_subscribers('mapoi/initialpose_poi') == 0:
                 return jsonify({
                     'success': True,
-                    'warning': 'mapoi/initialpose_poi に subscriber がいません '
-                               '(localization bridge 未起動?)。initial pose は配信されません。',
+                    'warning': 'No subscribers found for mapoi/initialpose_poi. '
+                               'The localization bridge may not be running, so the initial pose was not sent.',
                 })
             return jsonify({'success': True})
 

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -217,7 +217,7 @@
                 </select>
                 <button type="button" id="btn-add-landmark" class="btn-add-wp">+</button>
               </div>
-              <div class="route-wp-map-hint">Landmark POI は radius 監視対象として認識されますが Nav2 へは送られません</div>
+              <div class="route-wp-map-hint">Landmark POIs are watched by radius. They are not sent to Nav2.</div>
             </div>
             <div class="form-actions">
               <button id="btn-route-form-ok">OK</button>

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -655,10 +655,10 @@ class PoiEditor {
       if (result.conflict) {
         this.btnSave.textContent = 'Save';
         const shouldReload = window.confirm(
-          'YAML ファイルが外部で変更されています (例: 手動編集 + git pull / 他端末からの保存)。'
-          + '\n上書き保存すると最新の変更が失われます。'
-          + '\n\n[OK] 最新を再 load する (未保存の編集は破棄されます)'
-          + '\n[キャンセル] そのまま編集を続ける (再度 Save 時に同じ警告)'
+          'The YAML file was changed outside this page.'
+          + '\nSaving now may overwrite newer changes.'
+          + '\n\n[OK] Reload the latest file. Unsaved edits will be lost.'
+          + '\n[Cancel] Keep editing. You will see this warning again on Save.'
         );
         if (shouldReload && this.onConflictReload) {
           await this.onConflictReload();

--- a/mapoi_webui/web/js/poi-filter.js
+++ b/mapoi_webui/web/js/poi-filter.js
@@ -134,14 +134,14 @@
     if (has(SYSTEM_TAGS.WAYPOINT) && has(SYSTEM_TAGS.LANDMARK)) {
       return {
         ok: false,
-        error: '"waypoint" と "landmark" は併用できません (landmark は Nav2 navigation 不可な reference 専用)。',
+        error: '"waypoint" and "landmark" cannot be used together. A landmark is only a reference POI and is not sent to Nav2.',
       };
     }
     // landmark × pause 排他 (#143): landmark は到達不可なので pause 動作が成立しない。
     if (has(SYSTEM_TAGS.PAUSE) && has(SYSTEM_TAGS.LANDMARK)) {
       return {
         ok: false,
-        error: '"pause" と "landmark" は併用できません (landmark は到達不可な reference のため pause 動作が成立しません)。',
+        error: '"pause" and "landmark" cannot be used together. A landmark is not a navigation target, so the robot cannot pause there.',
       };
     }
     // (initial_pose × landmark 排他は #144 で initial_pose system tag を廃止したため不要に。)

--- a/mapoi_webui/web/js/route-editor.js
+++ b/mapoi_webui/web/js/route-editor.js
@@ -514,7 +514,7 @@ class RouteEditor {
       name.textContent = lm;
       if (this.landmarkNames.length > 0 && !this.landmarkNames.includes(lm)) {
         name.classList.add('wp-missing');
-        name.title = 'Landmark POI not found (existing landmark POI と紐付かない名前)';
+        name.title = 'Landmark POI not found. This name is not linked to an existing landmark POI.';
       }
 
       const btns = document.createElement('span');


### PR DESCRIPTION
## Summary

- Replace the Route edit Landmark hint with simple English: `Landmark POIs are watched by radius. They are not sent to Nav2.`
- Convert remaining user-visible Japanese messages in Web UI flows to English:
  - route landmark missing tooltip
  - frontend landmark tag validation errors
  - POI save conflict confirmation
  - backend API warnings/errors that can surface in the Web UI
- Set the page language hint from `ja` to `en`.

Closes #319

## Japanese UI scan

- Searched `mapoi_webui/web` and `mapoi_webui/mapoi_webui` for Japanese string literals.
- Remaining Japanese hits are comments/docstrings only, not user-visible UI copy.

## Validation

- `node --check mapoi_webui/web/js/poi-editor.js`
- `node --check mapoi_webui/web/js/poi-filter.js`
- `node --check mapoi_webui/web/js/route-editor.js`
- `python3 -m py_compile mapoi_webui/mapoi_webui/mapoi_webui_node.py`
- `git diff --check`
- `npm test` in `mapoi_webui/tests/web` (54 passed)
- `npm run test:e2e` in `mapoi_webui/tests/web` (17 passed)

Note: direct `pytest mapoi_webui/test/test_api_save_pois_version_conflict.py` was attempted, but this unsourced local shell cannot import `rclpy`. ROS CI should cover that path.