### PR TITLE
feat(webui): UI オン/オフトグルと半透明化 (#323, #324)

### DIFF
--- a/mapoi_webui/tests/web/e2e/map-edit-polish.e2e.js
+++ b/mapoi_webui/tests/web/e2e/map-edit-polish.e2e.js
@@ -28,13 +28,13 @@ function distance(a, b) {
 }
 
 test.describe('Map edit polish', () => {
-  test('sidebar sections are ordered Navigation, Tags, POIs, Routes', async ({ page }) => {
+  test('sidebar sections are ordered Navigation, Tags, POIs, Routes, Display', async ({ page }) => {
     await loadApp(page);
 
     const ids = await page.locator('#poi-panel > .panel-section').evaluateAll((els) =>
       els.map((el) => el.id));
 
-    expect(ids).toEqual(['nav-section', 'tag-section', 'poi-section', 'route-section']);
+    expect(ids).toEqual(['nav-section', 'tag-section', 'poi-section', 'route-section', 'display-section']);
   });
 
   test('Escape clears POI and route selection without opening edit forms', async ({ page }) => {

--- a/mapoi_webui/tests/web/e2e/ui-settings.e2e.js
+++ b/mapoi_webui/tests/web/e2e/ui-settings.e2e.js
@@ -30,17 +30,22 @@ async function setAlphaPercent(page, percent) {
 }
 
 test.describe('UI 表示コントロール (#323 / #324)', () => {
-  test('トグルで header/panel を隠し、再クリックで戻す。#ui-controls は残す', async ({ page }) => {
+  test('トグルで header/panel を隠し、再クリックで戻す。#ui-controls は残り icon が swap する', async ({ page }) => {
     await loadApp(page);
     expect(await displayOf(page, 'header')).not.toBe('none');
     expect(await displayOf(page, '#poi-panel')).not.toBe('none');
+    // 表示中は「隠す」action の eye-off icon
+    expect(await displayOf(page, '#ui-toggle-icon-hide')).not.toBe('none');
+    expect(await displayOf(page, '#ui-toggle-icon-show')).toBe('none');
 
     await page.locator('#btn-ui-toggle').click();
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(true);
     expect(await displayOf(page, 'header')).toBe('none');
     expect(await displayOf(page, '#poi-panel')).toBe('none');
-    // UI を復帰できるようコントロール自身は残す。
+    // UI を復帰できるようコントロール自身は残し、icon は「戻す」action の eye に swap
     expect(await displayOf(page, '#ui-controls')).not.toBe('none');
+    expect(await displayOf(page, '#ui-toggle-icon-hide')).toBe('none');
+    expect(await displayOf(page, '#ui-toggle-icon-show')).not.toBe('none');
 
     await page.locator('#btn-ui-toggle').click();
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
@@ -48,11 +53,14 @@ test.describe('UI 表示コントロール (#323 / #324)', () => {
     expect(await displayOf(page, '#poi-panel')).not.toBe('none');
   });
 
-  test('overlay チェックで panel が地図上に絶対配置される', async ({ page }) => {
+  test('Display section は既定折畳で、開くと overlay チェックで panel が地図上に絶対配置される', async ({ page }) => {
     await loadApp(page);
     expect(await positionOf(page, '#poi-panel')).not.toBe('absolute');
+    // 既定は折畳 (地図上でなくパネル内に置いた表示設定)
+    expect(await displayOf(page, '#display-body')).toBe('none');
 
-    await page.locator('#btn-ui-settings').click();
+    await page.locator('#btn-display-toggle').click();
+    expect(await displayOf(page, '#display-body')).not.toBe('none');
     await page.locator('#ui-overlay-toggle').check();
 
     expect(await bodyHasClass(page, 'ui-overlay')).toBe(true);
@@ -63,7 +71,7 @@ test.describe('UI 表示コントロール (#323 / #324)', () => {
     await loadApp(page);
     expect(await cssVar(page, '--ui-panel-alpha')).toBe('1');
 
-    await page.locator('#btn-ui-settings').click();
+    await page.locator('#btn-display-toggle').click();
     await setAlphaPercent(page, 50);
 
     expect(await cssVar(page, '--ui-panel-alpha')).toBe('0.5');
@@ -72,9 +80,9 @@ test.describe('UI 表示コントロール (#323 / #324)', () => {
 
   test('設定が reload をまたいで localStorage に永続化される', async ({ page }) => {
     await loadApp(page);
-    await page.locator('#btn-ui-toggle').click(); // hidden = true
-    await page.locator('#btn-ui-settings').click();
+    await page.locator('#btn-display-toggle').click();
     await setAlphaPercent(page, 40);
+    await page.locator('#btn-ui-toggle').click(); // hidden = true
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(true);
 
     await loadApp(page); // reload (同一 context で localStorage は保持)

--- a/mapoi_webui/tests/web/e2e/ui-settings.e2e.js
+++ b/mapoi_webui/tests/web/e2e/ui-settings.e2e.js
@@ -1,0 +1,84 @@
+// UI 表示コントロールの実ブラウザ配線 (#323 半透明化 / #324 UI オン/オフトグル)。
+// ui-settings.js の pure helper は unit test で pin 済み。ここでは index.html /
+// style.css / ui-settings.js を通した DOM 配線 (class toggle・CSS 変数・localStorage
+// 永続) を実ブラウザでのみ通せる経路として検証する。
+const { test, expect } = require('@playwright/test');
+const { loadApp, displayOf } = require('./helpers');
+
+function bodyHasClass(page, cls) {
+  return page.locator('body').evaluate((el, c) => el.classList.contains(c), cls);
+}
+
+function cssVar(page, name) {
+  return page.evaluate(
+    (n) => getComputedStyle(document.body).getPropertyValue(n).trim(),
+    name,
+  );
+}
+
+function positionOf(page, selector) {
+  return page.locator(selector).evaluate((el) => getComputedStyle(el).position);
+}
+
+// range input は fill() 非対応なので value 直接設定 + input/change を明示 dispatch。
+async function setAlphaPercent(page, percent) {
+  await page.locator('#ui-alpha-slider').evaluate((el, p) => {
+    el.value = String(p);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  }, percent);
+}
+
+test.describe('UI 表示コントロール (#323 / #324)', () => {
+  test('トグルで header/panel を隠し、再クリックで戻す。#ui-controls は残す', async ({ page }) => {
+    await loadApp(page);
+    expect(await displayOf(page, 'header')).not.toBe('none');
+    expect(await displayOf(page, '#poi-panel')).not.toBe('none');
+
+    await page.locator('#btn-ui-toggle').click();
+    expect(await bodyHasClass(page, 'ui-hidden')).toBe(true);
+    expect(await displayOf(page, 'header')).toBe('none');
+    expect(await displayOf(page, '#poi-panel')).toBe('none');
+    // UI を復帰できるようコントロール自身は残す。
+    expect(await displayOf(page, '#ui-controls')).not.toBe('none');
+
+    await page.locator('#btn-ui-toggle').click();
+    expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
+    expect(await displayOf(page, 'header')).not.toBe('none');
+    expect(await displayOf(page, '#poi-panel')).not.toBe('none');
+  });
+
+  test('overlay チェックで panel が地図上に絶対配置される', async ({ page }) => {
+    await loadApp(page);
+    expect(await positionOf(page, '#poi-panel')).not.toBe('absolute');
+
+    await page.locator('#btn-ui-settings').click();
+    await page.locator('#ui-overlay-toggle').check();
+
+    expect(await bodyHasClass(page, 'ui-overlay')).toBe(true);
+    expect(await positionOf(page, '#poi-panel')).toBe('absolute');
+  });
+
+  test('不透明度スライダーが --ui-panel-alpha と表示ラベルを更新する', async ({ page }) => {
+    await loadApp(page);
+    expect(await cssVar(page, '--ui-panel-alpha')).toBe('1');
+
+    await page.locator('#btn-ui-settings').click();
+    await setAlphaPercent(page, 50);
+
+    expect(await cssVar(page, '--ui-panel-alpha')).toBe('0.5');
+    expect(await page.locator('#ui-alpha-value').textContent()).toBe('50%');
+  });
+
+  test('設定が reload をまたいで localStorage に永続化される', async ({ page }) => {
+    await loadApp(page);
+    await page.locator('#btn-ui-toggle').click(); // hidden = true
+    await page.locator('#btn-ui-settings').click();
+    await setAlphaPercent(page, 40);
+    expect(await bodyHasClass(page, 'ui-hidden')).toBe(true);
+
+    await loadApp(page); // reload (同一 context で localStorage は保持)
+    expect(await bodyHasClass(page, 'ui-hidden')).toBe(true);
+    expect(await cssVar(page, '--ui-panel-alpha')).toBe('0.4');
+  });
+});

--- a/mapoi_webui/tests/web/ui-settings.test.js
+++ b/mapoi_webui/tests/web/ui-settings.test.js
@@ -1,0 +1,197 @@
+// vitest unit tests for the pure UI 表示設定 helpers in
+// mapoi_webui/web/js/ui-settings.js (#323 半透明化 / #324 UI オン/オフトグル)。
+//
+// 対象: MapoiUiSettings.{clampAlpha, alphaToPercent, percentToAlpha,
+//   normalizeSettings, readSettings, writeSettings, applySettings}
+//
+// テスト方針: localStorage 永続 (read/write) と body への反映 (applySettings) は
+//   「設定が壊れる / 既定が現行の見た目からずれる」に直結する核なので pin する。
+//   alpha の clamp / % 往復は slider 値契約。private mode 等の storage 例外を
+//   握り潰して既定に落ちることも確認する。DOM は fake object で表現し jsdom 非依存。
+import { describe, it, expect } from 'vitest';
+import * as ui from '../../web/js/ui-settings.js';
+
+const {
+  ALPHA_MIN,
+  ALPHA_MAX,
+  ALPHA_DEFAULT,
+  STORAGE_KEYS,
+  clampAlpha,
+  alphaToPercent,
+  percentToAlpha,
+  normalizeSettings,
+  readSettings,
+  writeSettings,
+  applySettings,
+} = ui;
+
+/** localStorage 互換の in-memory fake。throwing=true で全操作を投げる。 */
+function makeStorage(initial, throwing) {
+  const m = new Map(Object.entries(initial || {}));
+  return {
+    getItem(k) {
+      if (throwing) throw new Error('blocked');
+      return m.has(k) ? m.get(k) : null;
+    },
+    setItem(k, v) {
+      if (throwing) throw new Error('blocked');
+      m.set(k, String(v));
+    },
+    _map: m,
+  };
+}
+
+/** body 要素の最小 fake (classList.toggle/contains + style.setProperty)。 */
+function makeBody() {
+  const classes = new Set();
+  const props = {};
+  return {
+    classList: {
+      toggle(name, on) {
+        if (on) classes.add(name);
+        else classes.delete(name);
+        return classes.has(name);
+      },
+      contains: (n) => classes.has(n),
+    },
+    style: {
+      setProperty(k, v) {
+        props[k] = v;
+      },
+    },
+    _classes: classes,
+    _props: props,
+  };
+}
+
+describe('clampAlpha', () => {
+  it('範囲内はそのまま', () => {
+    expect(clampAlpha(0.5)).toBe(0.5);
+    expect(clampAlpha(ALPHA_MIN)).toBe(ALPHA_MIN);
+    expect(clampAlpha(ALPHA_MAX)).toBe(ALPHA_MAX);
+  });
+  it('範囲外は clamp', () => {
+    expect(clampAlpha(0)).toBe(ALPHA_MIN);
+    expect(clampAlpha(-1)).toBe(ALPHA_MIN);
+    expect(clampAlpha(2)).toBe(ALPHA_MAX);
+  });
+  it('数値化できない値は既定 1.0', () => {
+    expect(clampAlpha('x')).toBe(ALPHA_DEFAULT);
+    expect(clampAlpha(NaN)).toBe(ALPHA_DEFAULT);
+    expect(clampAlpha(undefined)).toBe(ALPHA_DEFAULT);
+  });
+  it('数値文字列は解釈する', () => {
+    expect(clampAlpha('0.6')).toBeCloseTo(0.6, 6);
+  });
+});
+
+describe('alpha ⇔ percent', () => {
+  it('alphaToPercent は 0-100 の整数', () => {
+    expect(alphaToPercent(1)).toBe(100);
+    expect(alphaToPercent(0.3)).toBe(30);
+    expect(alphaToPercent(0.555)).toBe(56);
+  });
+  it('percentToAlpha は clamp 付きで割り戻す', () => {
+    expect(percentToAlpha(100)).toBe(1);
+    expect(percentToAlpha(30)).toBeCloseTo(0.3, 6);
+    expect(percentToAlpha(0)).toBe(ALPHA_MIN); // 30% 未満は clamp
+    expect(percentToAlpha('x')).toBe(ALPHA_DEFAULT);
+  });
+  it('slider 刻み (5%) の往復で値が保たれる', () => {
+    for (let p = 30; p <= 100; p += 5) {
+      expect(alphaToPercent(percentToAlpha(p))).toBe(p);
+    }
+  });
+});
+
+describe('normalizeSettings', () => {
+  it('未指定は既定 (全 false / alpha=1)', () => {
+    expect(normalizeSettings(undefined)).toEqual({ hidden: false, overlay: false, alpha: 1 });
+    expect(normalizeSettings({})).toEqual({ hidden: false, overlay: false, alpha: 1 });
+  });
+  it('真偽は文字列/真値の両方を解釈', () => {
+    expect(normalizeSettings({ hidden: 'true', overlay: '1' })).toMatchObject({ hidden: true, overlay: true });
+    expect(normalizeSettings({ hidden: true, overlay: false })).toMatchObject({ hidden: true, overlay: false });
+    expect(normalizeSettings({ hidden: 'false' })).toMatchObject({ hidden: false });
+  });
+  it('alpha は clamp される', () => {
+    expect(normalizeSettings({ alpha: 5 }).alpha).toBe(ALPHA_MAX);
+    expect(normalizeSettings({ alpha: 0 }).alpha).toBe(ALPHA_MIN);
+  });
+});
+
+describe('readSettings', () => {
+  it('storage=null は既定', () => {
+    expect(readSettings(null)).toEqual({ hidden: false, overlay: false, alpha: ALPHA_DEFAULT });
+  });
+  it('保存値を読み出す', () => {
+    const s = makeStorage({
+      [STORAGE_KEYS.hidden]: 'true',
+      [STORAGE_KEYS.overlay]: 'false',
+      [STORAGE_KEYS.alpha]: '0.5',
+    });
+    expect(readSettings(s)).toEqual({ hidden: true, overlay: false, alpha: 0.5 });
+  });
+  it('欠損キーは既定で補完', () => {
+    const s = makeStorage({ [STORAGE_KEYS.alpha]: '0.7' });
+    expect(readSettings(s)).toEqual({ hidden: false, overlay: false, alpha: 0.7 });
+  });
+  it('壊れた alpha は clamp/既定に落ちる', () => {
+    expect(readSettings(makeStorage({ [STORAGE_KEYS.alpha]: 'garbage' })).alpha).toBe(ALPHA_DEFAULT);
+    expect(readSettings(makeStorage({ [STORAGE_KEYS.alpha]: '0.01' })).alpha).toBe(ALPHA_MIN);
+  });
+  it('storage が例外を投げても既定で握り潰す', () => {
+    expect(readSettings(makeStorage({}, true))).toEqual({
+      hidden: false,
+      overlay: false,
+      alpha: ALPHA_DEFAULT,
+    });
+  });
+});
+
+describe('writeSettings', () => {
+  it('正規化した文字列を書き込む', () => {
+    const s = makeStorage({});
+    writeSettings(s, { hidden: true, overlay: false, alpha: 0.6 });
+    expect(s._map.get(STORAGE_KEYS.hidden)).toBe('true');
+    expect(s._map.get(STORAGE_KEYS.overlay)).toBe('false');
+    expect(s._map.get(STORAGE_KEYS.alpha)).toBe('0.6');
+  });
+  it('storage 例外は握り潰す (throw しない)', () => {
+    expect(() => writeSettings(makeStorage({}, true), { hidden: true, alpha: 1 })).not.toThrow();
+    expect(() => writeSettings(null, { hidden: true, alpha: 1 })).not.toThrow();
+  });
+  it('read→write の往復で値が保たれる', () => {
+    const s = makeStorage({});
+    const original = { hidden: true, overlay: true, alpha: 0.45 };
+    writeSettings(s, original);
+    expect(readSettings(s)).toEqual({ hidden: true, overlay: true, alpha: 0.45 });
+  });
+});
+
+describe('applySettings', () => {
+  it('hidden/overlay class を反映し alpha を CSS 変数に設定', () => {
+    const body = makeBody();
+    applySettings(body, { hidden: true, overlay: false, alpha: 0.5 });
+    expect(body._classes.has('ui-hidden')).toBe(true);
+    expect(body._classes.has('ui-overlay')).toBe(false);
+    expect(body._props['--ui-panel-alpha']).toBe('0.5');
+  });
+  it('既定 (alpha=1, 全 false) では class 無し・変数 1', () => {
+    const body = makeBody();
+    applySettings(body, {});
+    expect(body._classes.size).toBe(0);
+    expect(body._props['--ui-panel-alpha']).toBe('1');
+  });
+  it('再適用で class が正しく off に戻る', () => {
+    const body = makeBody();
+    applySettings(body, { hidden: true, overlay: true, alpha: 0.4 });
+    applySettings(body, { hidden: false, overlay: false, alpha: 1 });
+    expect(body._classes.has('ui-hidden')).toBe(false);
+    expect(body._classes.has('ui-overlay')).toBe(false);
+    expect(body._props['--ui-panel-alpha']).toBe('1');
+  });
+  it('body=null は no-op (throw しない)', () => {
+    expect(() => applySettings(null, { hidden: true })).not.toThrow();
+  });
+});

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -1460,50 +1460,39 @@ main {
   background: rgba(52, 152, 219, 0.9);
 }
 
-.ui-control-icon {
-  font-size: 1.2rem;
-  line-height: 1;
+.ui-control-icon-svg {
+  width: 20px;
+  height: 20px;
+  display: block;
 }
 
-.ui-settings-wrap {
-  position: relative;
-}
-
-.ui-settings-popover {
-  position: absolute;
-  top: 48px;
-  right: 0;
-  width: 220px;
-  padding: 12px;
-  background: rgba(255, 255, 255, 0.96);
-  color: #333;
-  border-radius: 8px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
+/* Display section (パネル内の表示設定 #323/#324)。他 section と同じ
+   section-header イディオムで、body だけ専用の縦並び。 */
+.display-body {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  padding: 8px 16px 12px;
   font-size: 0.85rem;
 }
 
-.ui-settings-row {
+.display-check {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.ui-settings-check {
-  flex-direction: row;
   align-items: center;
   gap: 8px;
   cursor: pointer;
 }
 
-.ui-settings-check input {
+.display-check input {
   width: 18px;
   height: 18px;
   cursor: pointer;
+}
+
+.display-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .ui-alpha-row {

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -6,6 +6,12 @@
   padding: 0;
 }
 
+/* UI 半透明化 (#323) の基準。既定 1 = 不透明 = 現行の見た目。
+   ui-settings.js が body の inline style で上書きする。 */
+:root {
+  --ui-panel-alpha: 1;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #f5f5f5;
@@ -17,7 +23,7 @@ header {
   align-items: center;
   justify-content: space-between;
   padding: 8px 16px;
-  background: #2c3e50;
+  background: rgba(44, 62, 80, var(--ui-panel-alpha));
   color: #fff;
 }
 
@@ -51,6 +57,8 @@ main {
   display: flex;
   flex-direction: row;
   height: calc(100vh - 44px);
+  /* overlay モード (#323) で #poi-panel を絶対配置する際のアンカー。 */
+  position: relative;
 }
 
 /* Map */
@@ -104,6 +112,11 @@ main {
   display: flex;
   flex-direction: column;
   border-left: 1px solid #ddd;
+  /* 半透明化 (#323): 既定 alpha=1 では body と同じ #f5f5f5 で現行と一致。
+     backdrop-filter は overlay モードで背後の地図を frosted glass にする。 */
+  background: rgba(245, 245, 245, var(--ui-panel-alpha));
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
 }
 
 .editor-toolbar {
@@ -113,7 +126,7 @@ main {
   padding: 6px 12px;
   flex-wrap: wrap;
   border-top: 1px solid #ddd;
-  background: #f5f5f5;
+  background: rgba(245, 245, 245, var(--ui-panel-alpha));
   flex-shrink: 0;
 }
 
@@ -455,7 +468,7 @@ main {
   align-items: center;
   justify-content: space-between;
   padding: 6px 16px;
-  background: #ecf0f1;
+  background: rgba(236, 240, 241, var(--ui-panel-alpha));
   font-size: 0.9rem;
   font-weight: 600;
   color: #555;
@@ -1402,5 +1415,158 @@ main {
 
   .form-row label {
     width: auto;
+  }
+}
+
+/* ============================================================
+   表示コントロール: UI オン/オフトグル (#324) と半透明化 (#323)
+   #ui-controls は #map-container 内に絶対配置し ui-hidden でも残す。
+   ============================================================ */
+#ui-controls {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 1200;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.ui-control-btn {
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: rgba(44, 62, 80, 0.82);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.ui-control-btn:hover {
+  background: rgba(44, 62, 80, 0.95);
+}
+
+.ui-control-btn[aria-pressed="true"] {
+  background: rgba(52, 152, 219, 0.9);
+}
+
+.ui-control-icon {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.ui-settings-wrap {
+  position: relative;
+}
+
+.ui-settings-popover {
+  position: absolute;
+  top: 48px;
+  right: 0;
+  width: 220px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.96);
+  color: #333;
+  border-radius: 8px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 0.85rem;
+}
+
+.ui-settings-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ui-settings-check {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.ui-settings-check input {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.ui-alpha-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ui-alpha-row input[type="range"] {
+  flex: 1;
+  min-width: 0;
+}
+
+.ui-alpha-value {
+  min-width: 40px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: #555;
+}
+
+/* --- UI オン/オフ (#324): header / resizer / panel を隠し地図を全画面に --- */
+body.ui-hidden header,
+body.ui-hidden #sidebar-resizer,
+body.ui-hidden #poi-panel {
+  display: none;
+}
+
+body.ui-hidden main {
+  height: 100vh;
+}
+
+body.ui-hidden #map-container {
+  height: 100vh;
+}
+
+/* --- overlay モード (#323): パネルを地図の上にフロートさせ半透明を活かす --- */
+body.ui-overlay #sidebar-resizer {
+  display: none;
+}
+
+body.ui-overlay #map-container {
+  height: calc(100vh - 44px);
+}
+
+body.ui-overlay #poi-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(360px, 92vw);
+  z-index: 1100;
+  border-left: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: -3px 0 16px rgba(0, 0, 0, 0.22);
+  overflow-y: auto;
+}
+
+@media (max-width: 768px) {
+  /* タップしやすいよう mobile ではボタンを拡大 (top-right 維持で Leaflet
+     attribution / zoom と衝突しない)。 */
+  .ui-control-btn {
+    width: 48px;
+    height: 48px;
+    min-width: 48px;
+    min-height: 48px;
   }
 }

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -20,6 +20,35 @@
     <div id="map-container">
       <div id="map"></div>
       <div id="map-status"></div>
+
+      <!-- 地図上にフロートする表示コントロール (#323 半透明化 / #324 UI トグル)。
+           ui-hidden 時も残るので UI を復帰できる。ui-settings.js が配線する。 -->
+      <div id="ui-controls">
+        <button id="btn-ui-toggle" type="button" class="ui-control-btn"
+                aria-pressed="false" title="UI を隠す" aria-label="UI 表示切替">
+          <span class="ui-control-icon" aria-hidden="true">&#9681;</span>
+        </button>
+        <div class="ui-settings-wrap">
+          <button id="btn-ui-settings" type="button" class="ui-control-btn"
+                  aria-haspopup="true" aria-expanded="false" title="表示設定" aria-label="表示設定">
+            <span class="ui-control-icon" aria-hidden="true">&#9881;</span>
+          </button>
+          <div id="ui-settings-popover" class="ui-settings-popover hidden" role="dialog" aria-label="表示設定">
+            <label class="ui-settings-row ui-settings-check">
+              <input type="checkbox" id="ui-overlay-toggle" />
+              <span>地図の上に重ねて表示</span>
+            </label>
+            <div class="ui-settings-row">
+              <label for="ui-alpha-slider">UI の不透明度</label>
+              <div class="ui-alpha-row">
+                <input type="range" id="ui-alpha-slider" min="30" max="100" step="5" value="100"
+                       aria-label="UI の不透明度 (%)" />
+                <span id="ui-alpha-value" class="ui-alpha-value">100%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div id="sidebar-resizer" role="separator" aria-orientation="vertical" title="Drag to resize sidebar"></div>
@@ -259,6 +288,9 @@
   <script src="/js/poi-editor.js"></script>
   <script src="/js/route-editor.js"></script>
   <script src="/js/sidebar-resizer.js"></script>
+  <!-- ui-settings.js は #ui-controls を配線し UI オン/オフトグル (#324) と
+       半透明化 (#323) を localStorage 永続で提供する pure/DOM helper。他モジュール非依存。 -->
+  <script src="/js/ui-settings.js"></script>
   <!-- nav-controls.js は MapoiNavControls を window に attach する pure/DOM helper 群 (#199)。
        app.js より前に読み込む (updateNavControlsAvailability / map switch / 初期 section で参照)。 -->
   <script src="/js/nav-controls.js"></script>

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -21,33 +21,29 @@
       <div id="map"></div>
       <div id="map-status"></div>
 
-      <!-- 地図上にフロートする表示コントロール (#323 半透明化 / #324 UI トグル)。
-           ui-hidden 時も残るので UI を復帰できる。ui-settings.js が配線する。 -->
+      <!-- 地図上にフロートする UI 一括表示/非表示トグル (#324)。ui-hidden 時も残る
+           ので UI を復帰できる。アイコンは action-based の eye SVG (表示中 = eye-off
+           「隠す」、非表示中 = eye「戻す」)。◑/⚙ グリフはダークモード/アプリ設定と
+           誤読されるため不採用。overlay / 不透明度の設定はパネル内 Display section
+           (#323)。配線は ui-settings.js。 -->
       <div id="ui-controls">
         <button id="btn-ui-toggle" type="button" class="ui-control-btn"
-                aria-pressed="false" title="UI を隠す" aria-label="UI 表示切替">
-          <span class="ui-control-icon" aria-hidden="true">&#9681;</span>
+                aria-pressed="false" title="Hide UI" aria-label="Toggle UI visibility">
+          <svg id="ui-toggle-icon-hide" class="ui-control-icon-svg" viewBox="0 0 24 24"
+               fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+               stroke-linejoin="round" aria-hidden="true">
+            <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/>
+            <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/>
+            <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24"/>
+            <line x1="1" y1="1" x2="23" y2="23"/>
+          </svg>
+          <svg id="ui-toggle-icon-show" class="ui-control-icon-svg hidden" viewBox="0 0 24 24"
+               fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+               stroke-linejoin="round" aria-hidden="true">
+            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+            <circle cx="12" cy="12" r="3"/>
+          </svg>
         </button>
-        <div class="ui-settings-wrap">
-          <button id="btn-ui-settings" type="button" class="ui-control-btn"
-                  aria-haspopup="true" aria-expanded="false" title="表示設定" aria-label="表示設定">
-            <span class="ui-control-icon" aria-hidden="true">&#9881;</span>
-          </button>
-          <div id="ui-settings-popover" class="ui-settings-popover hidden" role="dialog" aria-label="表示設定">
-            <label class="ui-settings-row ui-settings-check">
-              <input type="checkbox" id="ui-overlay-toggle" />
-              <span>地図の上に重ねて表示</span>
-            </label>
-            <div class="ui-settings-row">
-              <label for="ui-alpha-slider">UI の不透明度</label>
-              <div class="ui-alpha-row">
-                <input type="range" id="ui-alpha-slider" min="30" max="100" step="5" value="100"
-                       aria-label="UI の不透明度 (%)" />
-                <span id="ui-alpha-value" class="ui-alpha-value">100%</span>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
 
@@ -264,6 +260,32 @@
               <button id="btn-route-redo" class="btn-icon-command" title="Redo route edit (Ctrl+Shift+Z)" aria-label="Redo route edit" disabled>&#8631;</button>
             </span>
             <span id="route-dirty-indicator"></span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Display section (#323 / #324): overlay / 不透明度の表示設定。UI が見えている
+           時にしか意味がないため地図上のフローティングでなくパネル内に置く。既定折畳。
+           開閉・配線は ui-settings.js (app.js setupSectionToggle とは独立、glyph は同じ)。 -->
+      <div id="display-section" class="panel-section">
+        <div class="section-header">
+          <span>Display</span>
+          <div class="section-header-actions">
+            <button id="btn-display-toggle" class="btn-section-toggle" title="Toggle">&#9654;</button>
+          </div>
+        </div>
+        <div id="display-body" class="display-body" style="display: none;">
+          <label class="display-check">
+            <input type="checkbox" id="ui-overlay-toggle" />
+            <span>Overlay on map</span>
+          </label>
+          <div class="display-row">
+            <label for="ui-alpha-slider">UI opacity</label>
+            <div class="ui-alpha-row">
+              <input type="range" id="ui-alpha-slider" min="30" max="100" step="5" value="100"
+                     aria-label="UI opacity (%)" />
+              <span id="ui-alpha-value" class="ui-alpha-value">100%</span>
+            </div>
           </div>
         </div>
       </div>

--- a/mapoi_webui/web/js/ui-settings.js
+++ b/mapoi_webui/web/js/ui-settings.js
@@ -10,6 +10,11 @@
  *  - alpha  : パネル/ヘッダ背景の不透明度 (0.3〜1.0)。frosted glass
  *             (backdrop-filter) と組み合わせる。既定 1.0 = 不透明 = 現行。
  *
+ * UI 配置 (PR #325 レビューで再設計): 地図上のフローティングは UI トグル
+ * (eye SVG) 1 個のみ。overlay / alpha の設定はパネル内 Display section に置く
+ * (UI が見えている時にしか意味がない設定のため)。◑/⚙ グリフはダークモード/
+ * アプリ設定と誤読されるため不採用。
+ *
  * Browser からは `MapoiUiSettings.*` のグローバルとして使い、Node (vitest)
  * からは `module.exports` 経由で import する dual export 形式。pure helper
  * (clampAlpha / read/write/applySettings 等) は DOM/window 非依存。DOM 配線
@@ -138,8 +143,10 @@
 
     const body = doc.body;
     const toggleBtn = doc.getElementById('btn-ui-toggle');
-    const gearBtn = doc.getElementById('btn-ui-settings');
-    const popover = doc.getElementById('ui-settings-popover');
+    const iconHide = doc.getElementById('ui-toggle-icon-hide');
+    const iconShow = doc.getElementById('ui-toggle-icon-show');
+    const displayToggleBtn = doc.getElementById('btn-display-toggle');
+    const displayBody = doc.getElementById('display-body');
     const overlayChk = doc.getElementById('ui-overlay-toggle');
     const alphaSlider = doc.getElementById('ui-alpha-slider');
     const alphaValue = doc.getElementById('ui-alpha-value');
@@ -166,10 +173,13 @@
       }
     }
 
+    // action-based icon: 表示中は eye-off (「隠す」)、非表示中は eye (「戻す」)。
     function syncToggleBtn() {
       if (!toggleBtn) return;
       toggleBtn.setAttribute('aria-pressed', settings.hidden ? 'true' : 'false');
-      toggleBtn.title = settings.hidden ? 'UI を表示' : 'UI を隠す';
+      toggleBtn.title = settings.hidden ? 'Show UI' : 'Hide UI';
+      if (iconHide) iconHide.classList.toggle('hidden', settings.hidden);
+      if (iconShow) iconShow.classList.toggle('hidden', !settings.hidden);
     }
 
     function syncAlphaControls() {
@@ -178,17 +188,20 @@
       if (alphaValue) alphaValue.textContent = pct + '%';
     }
 
-    function setPopoverOpen(open) {
-      if (!popover) return;
-      popover.classList.toggle('hidden', !open);
-      if (gearBtn) gearBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    // Display section の開閉 (既定折畳)。app.js setupSectionToggle と同じ
+    // display:none + ▼/▶ glyph の挙動を module 独立で再現する。開閉状態は
+    // 他 section と同様に永続しない。
+    let displayOpen = false;
+    function applyDisplayOpen() {
+      if (displayBody) displayBody.style.display = displayOpen ? '' : 'none';
+      if (displayToggleBtn) displayToggleBtn.innerHTML = displayOpen ? '▼' : '▶';
     }
 
     // 初期反映
     if (overlayChk) overlayChk.checked = settings.overlay;
     syncAlphaControls();
     syncToggleBtn();
-    setPopoverOpen(false);
+    applyDisplayOpen();
 
     if (toggleBtn) {
       toggleBtn.addEventListener('click', () => {
@@ -200,15 +213,11 @@
       });
     }
 
-    if (gearBtn && popover) {
-      gearBtn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        setPopoverOpen(popover.classList.contains('hidden'));
+    if (displayToggleBtn && displayBody) {
+      displayToggleBtn.addEventListener('click', () => {
+        displayOpen = !displayOpen;
+        applyDisplayOpen();
       });
-      // popover 内クリックで閉じないように
-      popover.addEventListener('click', (e) => e.stopPropagation());
-      // 外側クリックで閉じる
-      doc.addEventListener('click', () => setPopoverOpen(false));
     }
 
     if (overlayChk) {

--- a/mapoi_webui/web/js/ui-settings.js
+++ b/mapoi_webui/web/js/ui-settings.js
@@ -1,0 +1,250 @@
+/**
+ * UI 表示設定: 半透明化 (#323) と UI オン/オフトグル (#324)。
+ *
+ * 提供する 3 つの設定 (いずれも localStorage 永続、既定は現行の見た目を維持):
+ *  - hidden : UI (header / #poi-panel / resizer) を一括で表示/非表示。地図を
+ *             全画面で見たい / フィールドで片手で素早く隠したい時用 (#324)。
+ *  - overlay: #poi-panel を地図の上にフロート表示する opt-in モード。docked
+ *             (既定) では横に並ぶだけで地図は透けないが、overlay + 半透明で
+ *             初めて「地図が UI 越しに透けて見える」(#323) が成立する。
+ *  - alpha  : パネル/ヘッダ背景の不透明度 (0.3〜1.0)。frosted glass
+ *             (backdrop-filter) と組み合わせる。既定 1.0 = 不透明 = 現行。
+ *
+ * Browser からは `MapoiUiSettings.*` のグローバルとして使い、Node (vitest)
+ * からは `module.exports` 経由で import する dual export 形式。pure helper
+ * (clampAlpha / read/write/applySettings 等) は DOM/window 非依存。DOM 配線
+ * (initDom) は #ui-controls が存在する実ページでのみ走り、unit test 環境
+ * (jsdom, #ui-controls 無し) では no-op になる。
+ *
+ * localStorage 読み書きは private mode 等で例外を投げ得るため全て try/catch。
+ */
+(function () {
+  'use strict';
+
+  const STORAGE_KEYS = {
+    hidden: 'mapoi_ui_hidden',
+    overlay: 'mapoi_ui_overlay',
+    alpha: 'mapoi_ui_panel_alpha',
+  };
+
+  const ALPHA_MIN = 0.3;
+  const ALPHA_MAX = 1.0;
+  const ALPHA_DEFAULT = 1.0;
+
+  function clampAlpha(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return ALPHA_DEFAULT;
+    return Math.max(ALPHA_MIN, Math.min(ALPHA_MAX, n));
+  }
+
+  function alphaToPercent(alpha) {
+    return Math.round(clampAlpha(alpha) * 100);
+  }
+
+  function percentToAlpha(percent) {
+    const p = Number(percent);
+    if (!Number.isFinite(p)) return ALPHA_DEFAULT;
+    return clampAlpha(p / 100);
+  }
+
+  function toBool(raw) {
+    return raw === true || raw === 'true' || raw === '1';
+  }
+
+  /** 任意の raw オブジェクトを正規化した settings に落とす (defaults 補完)。 */
+  function normalizeSettings(raw) {
+    const src = raw || {};
+    return {
+      hidden: toBool(src.hidden),
+      overlay: toBool(src.overlay),
+      alpha: clampAlpha(src.alpha === undefined || src.alpha === null ? ALPHA_DEFAULT : src.alpha),
+    };
+  }
+
+  /** localStorage-like から設定を読む。null/失敗時は defaults。 */
+  function readSettings(storage) {
+    const out = { hidden: false, overlay: false, alpha: ALPHA_DEFAULT };
+    if (!storage) return out;
+    try {
+      const h = storage.getItem(STORAGE_KEYS.hidden);
+      if (h !== null) out.hidden = toBool(h);
+      const o = storage.getItem(STORAGE_KEYS.overlay);
+      if (o !== null) out.overlay = toBool(o);
+      const a = storage.getItem(STORAGE_KEYS.alpha);
+      if (a !== null) out.alpha = clampAlpha(parseFloat(a));
+    } catch (_) {
+      // private mode / cookies blocked: defaults のまま
+    }
+    return out;
+  }
+
+  /** settings を localStorage-like に書く。失敗は無視。 */
+  function writeSettings(storage, settings) {
+    if (!storage) return;
+    const s = normalizeSettings(settings);
+    try {
+      storage.setItem(STORAGE_KEYS.hidden, s.hidden ? 'true' : 'false');
+      storage.setItem(STORAGE_KEYS.overlay, s.overlay ? 'true' : 'false');
+      storage.setItem(STORAGE_KEYS.alpha, String(s.alpha));
+    } catch (_) {
+      // 永続化できない環境では skip
+    }
+  }
+
+  /**
+   * settings を body 要素に反映する:
+   *  - `ui-hidden` / `ui-overlay` class を toggle
+   *  - CSS 変数 `--ui-panel-alpha` を設定 (body 配下の header/panel に cascade)
+   */
+  function applySettings(bodyEl, settings) {
+    if (!bodyEl || !bodyEl.classList) return;
+    const s = normalizeSettings(settings);
+    bodyEl.classList.toggle('ui-hidden', s.hidden);
+    bodyEl.classList.toggle('ui-overlay', s.overlay);
+    if (bodyEl.style && typeof bodyEl.style.setProperty === 'function') {
+      bodyEl.style.setProperty('--ui-panel-alpha', String(s.alpha));
+    }
+  }
+
+  const api = {
+    STORAGE_KEYS,
+    ALPHA_MIN,
+    ALPHA_MAX,
+    ALPHA_DEFAULT,
+    clampAlpha,
+    alphaToPercent,
+    percentToAlpha,
+    normalizeSettings,
+    readSettings,
+    writeSettings,
+    applySettings,
+  };
+
+  // ---- DOM 配線 (実ページのみ) --------------------------------------------
+
+  function safeLocalStorage() {
+    try {
+      return typeof localStorage !== 'undefined' ? localStorage : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function initDom(doc, storage) {
+    if (!doc || !doc.body) return;
+    // #ui-controls が無い環境 (unit test の jsdom など) では何もしない。
+    const controls = doc.getElementById('ui-controls');
+    if (!controls) return;
+
+    const body = doc.body;
+    const toggleBtn = doc.getElementById('btn-ui-toggle');
+    const gearBtn = doc.getElementById('btn-ui-settings');
+    const popover = doc.getElementById('ui-settings-popover');
+    const overlayChk = doc.getElementById('ui-overlay-toggle');
+    const alphaSlider = doc.getElementById('ui-alpha-slider');
+    const alphaValue = doc.getElementById('ui-alpha-value');
+
+    const win = doc.defaultView || (typeof window !== 'undefined' ? window : null);
+
+    const settings = readSettings(storage);
+    applySettings(body, settings);
+
+    function persist() {
+      writeSettings(storage, settings);
+    }
+
+    // hidden / overlay の切替は #map-container のサイズを変える。Leaflet は
+    // window resize を listen して invalidateSize するので (sidebar-resizer と同様)、
+    // 露出した領域が gray tile のまま残らないよう resize を明示 dispatch する。
+    function notifyMapResize() {
+      if (win && typeof win.dispatchEvent === 'function' && typeof Event === 'function') {
+        try {
+          win.dispatchEvent(new Event('resize'));
+        } catch (_) {
+          // Event 構築不可な環境では skip
+        }
+      }
+    }
+
+    function syncToggleBtn() {
+      if (!toggleBtn) return;
+      toggleBtn.setAttribute('aria-pressed', settings.hidden ? 'true' : 'false');
+      toggleBtn.title = settings.hidden ? 'UI を表示' : 'UI を隠す';
+    }
+
+    function syncAlphaControls() {
+      const pct = alphaToPercent(settings.alpha);
+      if (alphaSlider) alphaSlider.value = String(pct);
+      if (alphaValue) alphaValue.textContent = pct + '%';
+    }
+
+    function setPopoverOpen(open) {
+      if (!popover) return;
+      popover.classList.toggle('hidden', !open);
+      if (gearBtn) gearBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+
+    // 初期反映
+    if (overlayChk) overlayChk.checked = settings.overlay;
+    syncAlphaControls();
+    syncToggleBtn();
+    setPopoverOpen(false);
+
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        settings.hidden = !settings.hidden;
+        applySettings(body, settings);
+        persist();
+        syncToggleBtn();
+        notifyMapResize();
+      });
+    }
+
+    if (gearBtn && popover) {
+      gearBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        setPopoverOpen(popover.classList.contains('hidden'));
+      });
+      // popover 内クリックで閉じないように
+      popover.addEventListener('click', (e) => e.stopPropagation());
+      // 外側クリックで閉じる
+      doc.addEventListener('click', () => setPopoverOpen(false));
+    }
+
+    if (overlayChk) {
+      overlayChk.addEventListener('change', () => {
+        settings.overlay = overlayChk.checked;
+        applySettings(body, settings);
+        persist();
+        notifyMapResize();
+      });
+    }
+
+    if (alphaSlider) {
+      alphaSlider.addEventListener('input', () => {
+        settings.alpha = percentToAlpha(alphaSlider.value);
+        applySettings(body, settings);
+        syncAlphaControls();
+      });
+      // input 連発中は書かず、確定 (change) で 1 回永続化
+      alphaSlider.addEventListener('change', persist);
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    window.MapoiUiSettings = window.MapoiUiSettings || {};
+    Object.assign(window.MapoiUiSettings, api);
+
+    if (typeof document !== 'undefined' && document.addEventListener) {
+      const boot = () => initDom(document, safeLocalStorage());
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', boot);
+      } else {
+        boot();
+      }
+    }
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+}());


### PR DESCRIPTION
## 概要

WebUI に **UI オン/オフトグル (#324)** と **パネル半透明化 (#323)** を追加する。地図右上のフローティングコントロールから操作でき、設定は localStorage に永続する。

`mapoi_webui` 内で完結し、C++ / Docker (humble・jazzy) build には影響しない。

## 機能 (すべて既定は現行の見た目を維持 = 回帰なし)

- **UI オン/オフトグル** (◑ ボタン, #324): 1タップで header / #poi-panel / resizer を隠して地図を全画面化 ↔ 復帰。フィールドでの片手操作を想定。Leaflet に `resize` を通知し、露出領域が gray tile のまま残らないようにする。
- **不透明度スライダー** (⚙ → popover, 30–100%, #323): `--ui-panel-alpha` CSS 変数でパネル/ヘッダ背景の alpha を制御。`backdrop-filter: blur()` で frosted glass 化。既定 100% (不透明) は現状と完全一致。
- **オーバーレイ表示** (opt-in checkbox, #323): #poi-panel を地図の上にフロート (絶対配置) させ、半透明が実際に地図を透過するようにする。既定 OFF で docked レイアウトは不変。

## 実装

| ファイル | 内容 |
|---|---|
| `web/js/ui-settings.js` (新規) | pure helper (`clampAlpha` / `read`・`write`・`applySettings` 等) + DOM 配線。dual-export (browser global + `module.exports`)。localStorage 例外は try/catch |
| `web/index.html` | `#map-container` 内にコントロール群 + `<script>` を追加 |
| `web/css/style.css` | `--ui-panel-alpha`、`.ui-hidden` / `.ui-overlay`、コントロール styles。既存背景を `rgba(…, var(--ui-panel-alpha))` 化 (alpha=1 で従来色と一致) |

## テスト

- **unit (vitest)**: `tests/web/ui-settings.test.js` 22件 — alpha clamp / % 往復 / read↔write 往復 / applySettings の class・CSS 変数反映 / storage 例外の握り潰し。全 7 ファイル **62 passed**。
- **e2e (playwright)**: `tests/web/e2e/ui-settings.e2e.js` 4件 — トグルで header/panel 非表示・復帰、overlay で絶対配置、スライダーが `--ui-panel-alpha` 更新、reload をまたいだ永続。全 **25 passed** (回帰なし)。`all-js-200` smoke が新 JS の 404 / 実行エラーゼロと HTML⇔disk 整合を確認。

## スコープ (意図的に据え置き)

- #324 の **Web フレームワーク移行** (React / Vue / Svelte 選定) と **mobile レスポンシブ再設計** は本 PR では扱わない。overlay の mobile 挙動は opt-in の best-effort。
- 本 PR で #323 は実現。#324 はトグル部分のみ対応 (フレームワークは継続検討)。close 判断は reviewer に委ねる。

Refs #323, #324
