### PR TITLE
fix(webui): モバイルで地図の高さが0になるCSSバグを修正 (#324)

### DIFF
--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -1340,7 +1340,13 @@ main {
     height: auto;
   }
 
+  /* 基底ルールの `flex: 1` (= flex-basis: 0%) が column 化した main では
+     height を無視して basis 0 のまま flex-grow するため、height:auto な
+     main では地図が高さ0に潰れる (#324)。flex を殺して height を直接
+     効かせる (overlay モードの body.ui-overlay #map-container の
+     height:calc(100vh - 44px) も同じ理由で無効化されていたため合わせて解消)。 */
   #map-container {
+    flex: none;
     height: 50vh;
   }
 
@@ -1415,6 +1421,36 @@ main {
 
   .form-row label {
     width: auto;
+  }
+
+  /* タップ可能要素の最小サイズ確保 (#324, 実機監査で 19〜34px を検出)。
+     デスクトップの密な見た目は変えず mobile 限定で拡大する。 */
+  .btn-section-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 40px;
+    min-height: 40px;
+  }
+
+  .btn-check-all {
+    min-height: 40px;
+    min-width: 40px;
+    padding: 4px 10px;
+  }
+
+  .editor-toolbar button {
+    min-height: 40px;
+    min-width: 40px;
+  }
+
+  .btn-add-wp {
+    min-height: 40px;
+    min-width: 40px;
+  }
+
+  .route-wp-select {
+    min-height: 40px;
   }
 }
 


### PR DESCRIPTION
## Summary
- #324 の残タスク (モバイルレスポンシブ再設計・フレームワーク導入検討) に対応。
- 実機相当の Playwright スクリーンショット監査で、モバイル幅 (375/390/360/768px) では
  `#map-container` が常に高さ0に潰れ地図が完全に非表示になる重大バグを発見・修正。
  原因は base CSS の `flex:1` (flex-basis:0%) が mobile media query の `height:50vh` と
  競合し、`main{height:auto}` 下で flex-grow の計算基準が無くなること。`flex: none` で解消。
  同じ理由で `ui-overlay` モードのパネルも 17px に潰れていたが同一修正で解消。
- 副次的に未達タッチターゲット (section-toggle chevron・check-all/none・toolbar button等、
  20〜34px) をモバイル限定で40px以上に調整。
- フレームワーク導入 (React/Vue3/Svelte) は不要と判断。GitHub一次情報で確認した結果、
  react-leaflet以外は生態系が停滞/未成熟な上、ビルドレス運用と168箇所のe2eセレクタ依存を
  破壊するコストに見合わないため、既存の vanilla CSS+JS パターンの延長で対応。

## Test plan
- [x] vitest 62件 pass
- [x] playwright e2e 25件 pass
- [x] Playwright スクリーンショットで修正前後の #map-container / ui-overlay 高さを実測検証
- [x] 実機 (docker compose demo, LAN経由) でスマホから動作確認済み