### PR TITLE
feat(webui): モバイルでパネルを開かずPOI drag誤操作を取り消せるフローティングUndoを追加

### DIFF
--- a/mapoi_webui/tests/web/e2e/poi-drag.e2e.js
+++ b/mapoi_webui/tests/web/e2e/poi-drag.e2e.js
@@ -3,7 +3,7 @@
 // 流した結果を実ブラウザで検証する。Leaflet は draggable な marker の icon に
 // 'leaflet-marker-draggable' class を付けるので、これで「掴める/掴めない」を観測する。
 const { test, expect } = require('@playwright/test');
-const { loadApp, selectPoi, unlockPoiPosition } = require('./helpers');
+const { loadApp, selectPoi, unlockPoiPosition, poiCard } = require('./helpers');
 
 // 選択中 (highlighted) の POI arrow marker = draggable。yaw ハンドル (.poi-yaw-handle) も
 // draggable だが class が異なるので、.poi-arrow-icon に限定すれば arrow だけ数えられる。
@@ -49,5 +49,169 @@ test.describe('B. POI ドラッグ enable/disable の実適用', () => {
     // Cancel → setPoiDraggingAllowed(true) で再び draggable。
     await page.locator('#btn-route-form-cancel').click();
     await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
+  });
+});
+
+test.describe('モバイルの誤ドラッグ即取り消し (#332)', () => {
+  test('#poi-body が畳まれたままでもフローティング Undo で drag を取り消せる', async ({ page }) => {
+    // compactMediaQuery の初期判定は script 実行時の一発読みなので、navigation 前に
+    // viewport を設定する (nav-controls.js initialSectionOpenStates)。
+    await page.setViewportSize({ width: 390, height: 844 });
+    await loadApp(page);
+
+    // 前提: モバイルでは POI panel はデフォルト畳み (地図領域確保)。
+    await expect(page.locator('#poi-body')).toBeHidden();
+    const floatUndo = page.locator('#btn-poi-undo-float');
+    await expect(floatUndo).toBeHidden();
+
+    // 位置ロックは既定 ON (#333)。#ui-controls はパネル開閉と無関係に常時見えるので
+    // モバイルでもパネルを開かず解除できる。
+    await unlockPoiPosition(page);
+
+    // パネルを開かず、地図上の marker を直接タップして選択 (#poi-list の click には依らない)。
+    const marker = page.locator('.poi-arrow-icon').first();
+    await marker.click();
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
+
+    const box = await marker.boundingBox();
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 40, cy + 30, { steps: 8 });
+    await page.mouse.up();
+
+    await expect(page.locator('#btn-save')).toBeEnabled();
+    await expect(floatUndo).toBeVisible();
+    // パネルはドラッグだけでは開かない。
+    await expect(page.locator('#poi-body')).toBeHidden();
+
+    await floatUndo.click();
+
+    // undo で working copy が originalPois と一致 = dirty 解消、フローティング Undo も消える。
+    await expect(page.locator('#btn-save')).toBeDisabled();
+    await expect(floatUndo).toBeHidden();
+    await expect(page.locator('#poi-body')).toBeHidden();
+  });
+
+  // POI undo/redo/discard/save はいずれも route 編集と無関係にいつでも実行できてよい
+  // (route 側の状態でブロックする必要は無い)。危険なのは副作用として走る loadRoutes()
+  // (サーバ最新状態で route working copy を丸ごと上書きする) の方なので、
+  // poiEditor.onDirtyChange 側の呼び出しを route 編集フォームが開いている間・
+  // OK 後 Save 前の未保存 route 変更が残っている間だけ skip する (Codex review #334
+  // round 1-4: フローティング Undo・通常 Undo/Redo/Discard ボタン・Ctrl+Z・POI Save の
+  // 全経路が同じ問題を踏むと判明したため、個々の入口ではなく発火元 1 箇所で一元的に守る)。
+  test('route 編集フォームが開いている間の POI undo は即座に効くが、route working copy は守られる', async ({ page }) => {
+    await loadApp(page);
+    const floatUndo = page.locator('#btn-poi-undo-float');
+
+    await unlockPoiPosition(page); // 位置ロックは既定 ON (#333)
+    await selectPoi(page, 'poi_wedge');
+    const marker = page.locator(DRAGGABLE_ARROW);
+    const box = await marker.boundingBox();
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 40, cy + 30, { steps: 8 });
+    await page.mouse.up();
+    await expect(floatUndo).toBeVisible();
+
+    // route 編集を開始 (未保存の name 入力あり、フォームは開いたまま)。
+    await page.locator('#btn-add-route').click();
+    await page.locator('#route-name').fill('未保存ルート');
+
+    // ブロックはしない。フローティング Undo は route 編集中も見えて即座に効く。
+    await expect(floatUndo).toBeVisible();
+    await floatUndo.click();
+    await expect(page.locator('#btn-save')).toBeDisabled();
+
+    // だが route フォームはリセットされず (loadRoutes() が skip された)、未保存入力が残る。
+    await expect(page.locator('#route-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await expect(page.locator('#route-name')).toHaveValue('未保存ルート');
+  });
+
+  test('route を OK して Save routes 前の間も、通常Undo/Ctrl+Z/POI Save が route working copy を守る (Codex #334 round 2-4 review)', async ({ page }) => {
+    await loadApp(page);
+
+    await unlockPoiPosition(page); // 位置ロックは既定 ON (#333)
+    await selectPoi(page, 'poi_wedge');
+    const marker = page.locator(DRAGGABLE_ARROW);
+    const box = await marker.boundingBox();
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 40, cy + 30, { steps: 8 });
+    await page.mouse.up();
+
+    // route を新規作成して OK (フォームは閉じるが Save routes はまだ = routeEditor.dirty)。
+    await page.locator('#btn-add-route').click();
+    await page.locator('#route-name').fill('未保存ルート2');
+    await page.locator('#route-wp-select').selectOption('poi_wedge');
+    await page.locator('#btn-add-waypoint').click();
+    await page.locator('#btn-route-form-ok').click();
+    await expect(page.locator('#route-edit-form')).toHaveClass(/(^|\s)hidden(\s|$)/);
+    await expect(page.locator('#btn-save-routes')).toBeEnabled();
+
+    // 通常の Undo ボタンは route.dirty 中でも即座に効く。
+    await page.locator('#btn-undo').click();
+    await expect(page.locator('#btn-save')).toBeDisabled();
+    // だが route の未保存変更は消えない (loadRoutes() が skip された)。
+    await expect(page.locator('#btn-save-routes')).toBeEnabled();
+
+    // 再度 POI を dirty にして、今度は Ctrl+Z 経路も同様に確認。
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 40, cy + 30, { steps: 8 });
+    await page.mouse.up();
+    await expect(page.locator('#btn-save')).toBeEnabled();
+    await page.keyboard.press('Control+z');
+    await expect(page.locator('#btn-save')).toBeDisabled();
+    await expect(page.locator('#btn-save-routes')).toBeEnabled(); // route 未保存変更は健在
+
+    // さらに POI Save 経路 (round 4 で発覚): dirty にしてから実際に Save しても、
+    // 未保存 route が上書きされない。
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 40, cy + 30, { steps: 8 });
+    await page.mouse.up();
+    await expect(page.locator('#btn-save')).toBeEnabled();
+    await page.locator('#btn-save').click();
+    await expect(page.locator('#btn-save')).toBeDisabled();
+    await expect(page.locator('#btn-save-routes')).toBeEnabled();
+
+    // route 側を Save すれば dirty が解消され、以後の POI undo/save でも通常どおり
+    // loadRoutes() が走る (壊すものが無いので実害は無い)。
+    await page.locator('#btn-save-routes').click();
+    await expect(page.locator('#btn-save-routes')).toBeDisabled();
+  });
+
+  test('loadRoutes() を skip した間も route フォームの waypoint select は POI 最新名に追従する (Codex #334 round 5 review)', async ({ page }) => {
+    await loadApp(page);
+
+    // POI 名を変更 (formOk が _pushUndo → dirty)。
+    await selectPoi(page, 'poi_wedge');
+    await poiCard(page, 'poi_wedge').locator('.btn-edit').click();
+    await page.locator('#poi-name').fill('poi_renamed');
+    await page.locator('#btn-form-ok').click();
+    await expect(page.locator('#btn-save')).toBeEnabled();
+
+    // route フォームを開く (loadRoutes() は route.dirty 監視外だが editingIndex !== -1
+    // なので、この後の POI undo で skip される)。select は開いた時点の名前 (poi_renamed)。
+    await page.locator('#btn-add-route').click();
+    await expect(page.locator('#route-wp-select')).toContainText('poi_renamed');
+
+    // POI undo で名前を poi_wedge に戻す。loadRoutes() は skip されるが、waypoint
+    // select は poiEditor.pois の最新名に repopulate されるべき (route working copy
+    // 保護のための skip が stale UI を生んではいけない)。
+    const floatUndo = page.locator('#btn-poi-undo-float');
+    await expect(floatUndo).toBeVisible();
+    await floatUndo.click();
+    await expect(page.locator('#btn-save')).toBeDisabled();
+
+    const options = await page.locator('#route-wp-select option').allTextContents();
+    expect(options).toContain('poi_wedge');
+    expect(options).not.toContain('poi_renamed');
   });
 });

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -1502,6 +1502,11 @@ main {
   display: block;
 }
 
+.ui-control-glyph {
+  font-size: 20px;
+  line-height: 1;
+}
+
 /* Display section (パネル内の表示設定 #323/#324)。他 section と同じ
    section-header イディオムで、body だけ専用の縦並び。 */
 .display-body {

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -49,6 +49,15 @@
             <path d="M7 11V7a5 5 0 0 1 9.9-1"/>
           </svg>
         </button>
+        <!-- POI ドラッグの誤操作をパネルを開かずに取り消せるよう、undo 履歴がある間だけ
+             出現するフローティング Undo (#332)。パネルの開閉状態と無関係に地図上で
+             marker を選択・ドラッグできるため、モバイルで #poi-body が畳まれていても
+             即座に取り消せる場所に置く。POI 専用 (route の drag はフォームを開いている
+             時にしか発生せず、その時点でパネルは既に展開済みなので同じ問題が無い)。 -->
+        <button id="btn-poi-undo-float" type="button" class="ui-control-btn hidden"
+                title="Undo POI edit (Ctrl+Z)" aria-label="Undo last POI edit">
+          <span class="ui-control-glyph" aria-hidden="true">&#8630;</span>
+        </button>
         <button id="btn-ui-toggle" type="button" class="ui-control-btn"
                 aria-pressed="false" title="Hide UI" aria-label="Toggle UI visibility">
           <svg id="ui-toggle-icon-hide" class="ui-control-icon-svg" viewBox="0 0 24 24"

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -444,13 +444,46 @@
     }
   };
 
-  // Dirty state change — refresh map markers and routes after save/discard
+  // Dirty state change — refresh map markers and routes after save/discard/undo/redo。
+  // isDirty=false になる経路は save 成功・discard・undo・redo と複数あり (Codex review
+  // #334 round 1-4 で全経路が同じ問題を踏むと判明)、loadRoutes() はサーバ最新状態で
+  // route working copy を丸ごと上書きするため、route 編集フォームが開いている間、または
+  // OK 後 Save 前の未保存 route 変更が残っている間に走ると route 側の作業を黙って失う。
+  // POI 側の操作自体 (undo/redo/discard/save) は route 編集と無関係にいつでも行えて
+  // よく、危険なのは loadRoutes() という副作用の方なので、個々の POI 操作ではなく
+  // ここ (route working copy を触る唯一の呼び出し元) で一元的にガードする。
   poiEditor.onDirtyChange = (isDirty) => {
     updateRouteEditorPoiNames();
     if (!isDirty) {
       mapViewer.showPois(poiEditor.pois, poiEditor.visiblePois);
-      loadRoutes();
+      if (routeEditor.editingIndex === -1 && !routeEditor.dirty) {
+        loadRoutes();
+      } else {
+        // loadRoutes() (サーバ最新化 + フォーム閉じ) は route working copy 保護のため
+        // skip したが、クライアント側の表示は最新の poiEditor.pois に合わせて更新して
+        // おかないと、開いている route フォームの waypoint/landmark select が古い POI
+        // 名を出し続けたり、route polyline が undo 前の POI 座標のまま残ったりする
+        // (Codex review #334 round 5)。どちらも poiEditor.pois の再取得済みデータだけで
+        // 完結する再描画で、サーバ最新化 (route working copy 上書き) は伴わない。
+        redrawRoutes();
+        if (routeEditor.editingIndex !== -1) {
+          // updateRouteEditorPoiNames() は関数先頭で呼び済み (routeEditor.poiNames は
+          // 最新)。select の DOM 再構築だけここで行う。
+          routeEditor.populateWaypointSelect();
+          routeEditor.populateLandmarkSelect();
+        }
+      }
     }
+  };
+
+  // モバイルで #poi-body が畳まれていても POI のドラッグ誤操作をすぐ取り消せるよう、
+  // undo 履歴がある間だけ地図上のフローティング Undo を出す (#332)。
+  const btnPoiUndoFloat = document.getElementById('btn-poi-undo-float');
+  if (btnPoiUndoFloat) {
+    btnPoiUndoFloat.addEventListener('click', () => poiEditor.undo());
+  }
+  poiEditor.onHistoryChange = (canUndo) => {
+    if (btnPoiUndoFloat) btnPoiUndoFloat.classList.toggle('hidden', !canUndo);
   };
 
   // 409 version_mismatch 受信時の全体 reload (#241)。POI だけ再 load しても route 側

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -33,6 +33,9 @@ class PoiEditor {
     // 409 受信時に app.js 側で全体 reload (loadMaps → loadPois/Routes) を発火させるためのフック。
     // poi-editor 単独では route-editor の state を巻き戻せないため、解決は呼び出し側に委ねる (#241)。
     this.onConflictReload = null;  // async callback() — full reload on version_mismatch
+    // undo スタックの有無が変わるたびに発火 (#332)。モバイルでパネルが畳まれていても
+    // 押せるフローティング Undo ボタンの表示/非表示を app.js 側で切り替えるためのフック。
+    this.onHistoryChange = null;  // callback(canUndo)
 
     // DOM references
     this.listEl = document.getElementById('poi-list');
@@ -582,6 +585,7 @@ class PoiEditor {
   _updateUndoButtons() {
     if (this.btnUndo) this.btnUndo.disabled = this.undoStack.length === 0;
     if (this.btnRedo) this.btnRedo.disabled = this.redoStack.length === 0;
+    if (this.onHistoryChange) this.onHistoryChange(this.undoStack.length > 0);
   }
 
   /**

--- a/mapoi_webui/web/js/route-editor.js
+++ b/mapoi_webui/web/js/route-editor.js
@@ -298,6 +298,10 @@ class RouteEditor {
    * Populate the waypoint POI dropdown.
    */
   populateWaypointSelect() {
+    // POI undo 等で候補が変わった後の再構築 (#334 round5) でも、ユーザーが選択中
+    // だった値が新しい候補集合にまだ含まれるなら保持する (#334 round6: innerHTML
+    // 入れ替えで無条件に空へ戻ると、選択済みの候補が黙って別物に変わってしまう)。
+    const prevValue = this.waypointSelect.value;
     this.waypointSelect.innerHTML = '<option value="">-- Select POI --</option>';
     this.poiNames.forEach((name) => {
       const opt = document.createElement('option');
@@ -305,6 +309,9 @@ class RouteEditor {
       opt.textContent = name;
       this.waypointSelect.appendChild(opt);
     });
+    if (prevValue && this.poiNames.includes(prevValue)) {
+      this.waypointSelect.value = prevValue;
+    }
   }
 
   /**
@@ -476,6 +483,8 @@ class RouteEditor {
 
   populateLandmarkSelect() {
     if (!this.landmarkSelect) return;
+    // populateWaypointSelect と同じ理由で選択中の値を保持する (#334 round6)。
+    const prevValue = this.landmarkSelect.value;
     this.landmarkSelect.innerHTML = '<option value="">-- Select landmark POI --</option>';
     this.landmarkNames.forEach((name) => {
       const opt = document.createElement('option');
@@ -483,6 +492,9 @@ class RouteEditor {
       opt.textContent = name;
       this.landmarkSelect.appendChild(opt);
     });
+    if (prevValue && this.landmarkNames.includes(prevValue)) {
+      this.landmarkSelect.value = prevValue;
+    }
   }
 
   renderLandmarkList() {


### PR DESCRIPTION
## Summary
- #332 対応。モバイル (viewport ≤768px) では POI セクション (`#poi-body`) が既定で折りたたまれているが、地図上の POI マーカーはパネルの開閉状態と無関係に選択・ドラッグできる。誤ってドラッグしても Undo (`#btn-undo`) は畳まれたパネルの中にあり押せない。
- 地図右上の常時表示フローティングクラスタ (`#ui-controls`) に、undo スタックが空でない時だけ出現する Undo アイコン (`#btn-poi-undo-float`) を追加。既存の `poiEditor.undo()` をそのまま叩く。
- Route 側は対象外 (waypoint 並べ替えは編集フォームを開いている時にしか発生せず、その時点でパネルは既に展開済みなので同じ問題が無い。共通化は非対称な問題への過剰設計と判断)。

## 実装
- `poi-editor.js`: `onHistoryChange(canUndo)` コールバックを追加 (`_updateUndoButtons()` の単一同期点から発火、既存パターンを踏襲)
- `app.js`: 新ボタンを `poiEditor.undo()` に配線、`canUndo` に応じて表示/非表示
- `index.html` / `style.css`: フローティングボタンのマークアップ・スタイル

## Test plan
- [x] vitest 62件 pass (回帰なし)
- [x] playwright e2e 追加: モバイル viewport で `#poi-body` が畳まれたまま drag → フローティング Undo 出現 → タップで dirty 解消・ボタン消滅
- [x] playwright e2e 全体 26件 pass
- [x] 実機相当の headless browser 検証 (別セッションでの事前調査): ドラッグ→undo で座標が完全復元することをスクリーンショット付きで確認済み

## 注意
`#333` (ズームボタン削除 + POI位置ロック) も同じ `#ui-controls` 周りを触っている。両方 main にマージする場合、後からマージする側でリベースが必要。