### PR TITLE
feat(webui): 地図ズームボタン削除とPOI位置編集の既定ロックを追加

### DIFF
--- a/mapoi_webui/tests/web/e2e/helpers.js
+++ b/mapoi_webui/tests/web/e2e/helpers.js
@@ -38,4 +38,13 @@ async function setSectionOpen(page, toggleId, bodyId, wantOpen) {
   }
 }
 
-module.exports = { loadApp, poiCard, selectPoi, displayOf, setSectionOpen };
+// POI 位置編集ロックは既定 ON (#333)。drag / yaw ハンドルを実際に動かすテストは
+// 事前にこれで解除する (route 編集中の抑止とは独立な条件なので個別に外す必要がある)。
+async function unlockPoiPosition(page) {
+  const btn = page.locator('#btn-poi-lock-toggle');
+  if ((await btn.getAttribute('aria-pressed')) === 'true') {
+    await btn.click();
+  }
+}
+
+module.exports = { loadApp, poiCard, selectPoi, displayOf, setSectionOpen, unlockPoiPosition };

--- a/mapoi_webui/tests/web/e2e/poi-drag.e2e.js
+++ b/mapoi_webui/tests/web/e2e/poi-drag.e2e.js
@@ -3,7 +3,7 @@
 // 流した結果を実ブラウザで検証する。Leaflet は draggable な marker の icon に
 // 'leaflet-marker-draggable' class を付けるので、これで「掴める/掴めない」を観測する。
 const { test, expect } = require('@playwright/test');
-const { loadApp, selectPoi } = require('./helpers');
+const { loadApp, selectPoi, unlockPoiPosition } = require('./helpers');
 
 // 選択中 (highlighted) の POI arrow marker = draggable。yaw ハンドル (.poi-yaw-handle) も
 // draggable だが class が異なるので、.poi-arrow-icon に限定すれば arrow だけ数えられる。
@@ -16,6 +16,7 @@ test.describe('B. POI ドラッグ enable/disable の実適用', () => {
     await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(0);
     await expect(page.locator('#btn-save')).toBeDisabled();
 
+    await unlockPoiPosition(page); // 位置ロックは既定 ON (#333)
     await selectPoi(page, 'poi_wedge');
     // 選択中 1 個だけ draggable。
     await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
@@ -37,6 +38,7 @@ test.describe('B. POI ドラッグ enable/disable の実適用', () => {
 
   test('route 編集中は選択中 POI でもドラッグ不可になり、Cancel で戻る', async ({ page }) => {
     await loadApp(page);
+    await unlockPoiPosition(page); // 位置ロックは既定 ON (#333)
     await selectPoi(page, 'poi_wedge');
     await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
 

--- a/mapoi_webui/tests/web/e2e/poi-position-lock.e2e.js
+++ b/mapoi_webui/tests/web/e2e/poi-position-lock.e2e.js
@@ -49,4 +49,21 @@ test.describe('地図ズームボタン削除 (#333)', () => {
     await loadApp(page);
     await expect(page.locator('.leaflet-control-zoom')).toHaveCount(0);
   });
+
+  test('ボタンが無くてもホイールでズームできる (Codex review low 対応)', async ({ page }) => {
+    await loadApp(page);
+
+    const mapEl = page.locator('#map');
+    // 初期表示 (loadMap → fitBounds) で 'zoom' イベントが発火し zoom が反映されるのを待つ。
+    await expect(mapEl).toHaveAttribute('data-zoom', /.+/);
+    const before = await mapEl.getAttribute('data-zoom');
+
+    const box = await mapEl.boundingBox();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.wheel(0, -300); // 上スクロール = ズームイン (Leaflet 既定)
+
+    await expect
+      .poll(async () => mapEl.getAttribute('data-zoom'))
+      .not.toBe(before);
+  });
 });

--- a/mapoi_webui/tests/web/e2e/poi-position-lock.e2e.js
+++ b/mapoi_webui/tests/web/e2e/poi-position-lock.e2e.js
@@ -1,0 +1,52 @@
+// POI 位置編集ロックトグルと地図ズームボタン削除 (#333)。
+// 位置編集は「たまに行う設定変更」なので既定ロック (安全側)。対象は選択中 POI の
+// drag + yaw ハンドルのみ (Add POI 配置クリック等、事前に明示ボタンが要るフローは対象外)。
+const { test, expect } = require('@playwright/test');
+const { loadApp, selectPoi } = require('./helpers');
+
+const DRAGGABLE_ARROW = '.poi-arrow-icon.leaflet-marker-draggable';
+
+test.describe('POI 位置ロック (#333)', () => {
+  test('既定はロックで選択してもドラッグ不可、トグルで解除・再ロックできる', async ({ page }) => {
+    await loadApp(page);
+
+    const lockBtn = page.locator('#btn-poi-lock-toggle');
+    await expect(lockBtn).toHaveAttribute('aria-pressed', 'true');
+
+    await selectPoi(page, 'poi_wedge');
+    // ロック中は選択しても draggable にならない。
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(0);
+    await expect(page.locator('.poi-yaw-handle')).toHaveCount(0);
+
+    await lockBtn.click();
+    await expect(lockBtn).toHaveAttribute('aria-pressed', 'false');
+    // 解除後は選択中 marker が draggable になる (再選択不要、その場で反映)。
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
+    await expect(page.locator('.poi-yaw-handle')).toHaveCount(1);
+
+    await lockBtn.click();
+    await expect(lockBtn).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(0);
+    await expect(page.locator('.poi-yaw-handle')).toHaveCount(0);
+  });
+
+  test('route 編集中はロック解除していてもドラッグ不可 (既存の抑止と AND)', async ({ page }) => {
+    await loadApp(page);
+    await page.locator('#btn-poi-lock-toggle').click(); // unlock
+    await selectPoi(page, 'poi_wedge');
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
+
+    await page.locator('#btn-add-route').click();
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(0);
+
+    await page.locator('#btn-route-form-cancel').click();
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
+  });
+});
+
+test.describe('地図ズームボタン削除 (#333)', () => {
+  test('Leaflet 既定の +/- ズームコントロールが存在しない', async ({ page }) => {
+    await loadApp(page);
+    await expect(page.locator('.leaflet-control-zoom')).toHaveCount(0);
+  });
+});

--- a/mapoi_webui/tests/web/e2e/yaw-handle.e2e.js
+++ b/mapoi_webui/tests/web/e2e/yaw-handle.e2e.js
@@ -2,13 +2,14 @@
 // 選択中 wedge POI のときだけ弧先端に .poi-yaw-handle marker が 1 個生成され、disc POI や
 // 未選択では出ない。ハンドルを掴んで回すと矢印が追従し dragend で yaw が dirty 化する。
 const { test, expect } = require('@playwright/test');
-const { loadApp, selectPoi } = require('./helpers');
+const { loadApp, selectPoi, unlockPoiPosition } = require('./helpers');
 
 const DRAGGABLE_ARROW = '.poi-arrow-icon.leaflet-marker-draggable';
 
 test.describe('C. yaw 回転ハンドルの DOM 生成と drag 追従', () => {
   test('wedge 選択でハンドル 1 個、disc 選択ではハンドル無し', async ({ page }) => {
     await loadApp(page);
+    await unlockPoiPosition(page); // 位置ロックは既定 ON (#333)。yaw ハンドルも対象。
     await expect(page.locator('.poi-yaw-handle')).toHaveCount(0);
 
     await selectPoi(page, 'poi_wedge'); // 0 < yawTol < pi → wedge
@@ -20,6 +21,7 @@ test.describe('C. yaw 回転ハンドルの DOM 生成と drag 追従', () => {
 
   test('yaw ハンドルをドラッグすると矢印 rotation が変化し dirty 化する', async ({ page }) => {
     await loadApp(page);
+    await unlockPoiPosition(page); // 位置ロックは既定 ON (#333)
     await selectPoi(page, 'poi_wedge');
 
     const handle = page.locator('.poi-yaw-handle');

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -27,6 +27,28 @@
            誤読されるため不採用。overlay / 不透明度の設定はパネル内 Display section
            (#323)。配線は ui-settings.js。 -->
       <div id="ui-controls">
+        <!-- 選択中 POI の位置編集 (drag + yaw ハンドル) を明示的にロック/アンロックする
+             (#333)。位置編集はロボット運用の主作業 (ナビゲーション/監視) に対して「たまに
+             行う設定変更」なので、既定はロック (安全側)。ページ再読み込みで再度ロックに
+             戻り、解除状態は永続化しない。対象は選択→即ドラッグできてしまう経路のみ。
+             Add POI 配置クリックや Route waypoint 追加は事前に明示ボタン操作が要るため
+             対象外 (誤操作リスクが無い)。配線は app.js、実体制御は
+             MapViewer.setPoiDraggingAllowed (route 編集中の抑止と AND)。 -->
+        <button id="btn-poi-lock-toggle" type="button" class="ui-control-btn"
+                aria-pressed="true" title="Unlock POI position editing" aria-label="Toggle POI position lock">
+          <svg id="poi-lock-icon-locked" class="ui-control-icon-svg" viewBox="0 0 24 24"
+               fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+               stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+          </svg>
+          <svg id="poi-lock-icon-unlocked" class="ui-control-icon-svg hidden" viewBox="0 0 24 24"
+               fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+               stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+            <path d="M7 11V7a5 5 0 0 1 9.9-1"/>
+          </svg>
+        </button>
         <button id="btn-ui-toggle" type="button" class="ui-control-btn"
                 aria-pressed="false" title="Hide UI" aria-label="Toggle UI visibility">
           <svg id="ui-toggle-icon-hide" class="ui-control-icon-svg" viewBox="0 0 24 24"

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -20,6 +20,10 @@
   let currentMap = '';
   let currentNavigationCapabilities = null;
   let currentNavStatus = 'idle';
+  // 選択中 POI の位置編集 (drag + yaw ハンドル) のロック状態 (#333)。位置編集は
+  // ナビゲーション/監視に対して「たまに行う設定変更」なので既定はロック (安全側)。
+  // リロードで再度ロックへ戻り、解除状態は永続化しない。
+  let poiPositionLocked = true;
 
   // --- Tag editor state ---
   let tagDirty = false;
@@ -457,6 +461,33 @@
     await loadRoutes();
   };
 
+  // 選択中 POI の位置編集ロック (#333)。route 編集中の抑止 (#239) と AND して
+  // MapViewer.setPoiDraggingAllowed に渡す単一の同期点。
+  function refreshPoiDraggingAllowed() {
+    mapViewer.setPoiDraggingAllowed(!poiPositionLocked && routeEditor.editingIndex === -1);
+  }
+
+  const btnPoiLockToggle = document.getElementById('btn-poi-lock-toggle');
+  const poiLockIconLocked = document.getElementById('poi-lock-icon-locked');
+  const poiLockIconUnlocked = document.getElementById('poi-lock-icon-unlocked');
+  function applyPoiLockUi() {
+    if (btnPoiLockToggle) {
+      btnPoiLockToggle.setAttribute('aria-pressed', String(poiPositionLocked));
+      btnPoiLockToggle.title = poiPositionLocked ? 'Unlock POI position editing' : 'Lock POI position editing';
+    }
+    if (poiLockIconLocked) poiLockIconLocked.classList.toggle('hidden', !poiPositionLocked);
+    if (poiLockIconUnlocked) poiLockIconUnlocked.classList.toggle('hidden', poiPositionLocked);
+  }
+  if (btnPoiLockToggle) {
+    btnPoiLockToggle.addEventListener('click', () => {
+      poiPositionLocked = !poiPositionLocked;
+      applyPoiLockUi();
+      refreshPoiDraggingAllowed();
+    });
+  }
+  applyPoiLockUi();
+  refreshPoiDraggingAllowed();
+
   // Route click on map
   mapViewer.onRouteClick = (routeIdx) => {
     // Ignore during editing
@@ -472,8 +503,7 @@
 
   // Route editing state change — redraw routes with editing preview
   routeEditor.onEditingChange = () => {
-    // route 編集中は POI ドラッグを無効化し、waypoint 追加クリックと競合させない (#239)。
-    mapViewer.setPoiDraggingAllowed(routeEditor.editingIndex === -1);
+    refreshPoiDraggingAllowed();
     redrawRoutes();
     // editRoute / copyRoute は selectedIndex を直接変えるが onSelectionChange を
     // 発火しないため、ここで highlightRoute を再適用して MapViewer 側の

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -15,6 +15,13 @@ class MapViewer {
       zoomControl: false,
     });
 
+    // ボタン削除後もホイール/ピンチでズームできることを e2e から検証できるよう、現在
+    // zoom を DOM に反映する (#333 Codex review low 対応)。アプリの挙動には影響しない
+    // test hook。
+    this.map.on('zoom', () => {
+      this.map.getContainer().dataset.zoom = String(this.map.getZoom());
+    });
+
     this.imageOverlay = null;
     this.poiMarkers = [];  // { marker, poi, index }
     this.sectorLayers = []; // POI tolerance を扇形描画した Leaflet layer (#136)

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -10,6 +10,9 @@ class MapViewer {
       maxZoom: 5,
       zoomSnap: 0.25,
       attributionControl: false,
+      // +/- ズームボタン (Leaflet 既定) は不要。マウスホイール/ドラッグ・タッチのピンチで
+      // 直感的にズームでき、地図上の余計なコントロールを減らす (#333)。
+      zoomControl: false,
     });
 
     this.imageOverlay = null;


### PR DESCRIPTION
## Summary
- #333 対応。
- Leaflet 既定の +/- ズームボタンを削除 (`zoomControl: false`)。マウスホイール/ドラッグやタッチのピンチで直感的にズームでき、地図上の余計なコントロールを減らす。
- 地図右上のフローティングクラスタ (`#ui-controls`) に POI 位置編集 (drag + yaw ハンドル) のロックトグル (`#btn-poi-lock-toggle`) を追加。
  - 対象は選択→即ドラッグできてしまう経路のみ (Add POI 配置クリックや Route waypoint 追加は事前に明示ボタン操作が要るため対象外)
  - 既定はロック有り (安全側)。ページ再読み込みで再度ロックへ戻り、解除状態は永続化しない
  - 既存の `MapViewer.setPoiDraggingAllowed()` (route 編集中の抑止用) に位置ロック条件を AND する形で配線

## 実装
- `map-viewer.js`: `L.map()` に `zoomControl: false`
- `app.js`: `poiPositionLocked` state + `refreshPoiDraggingAllowed()` (route 編集中の抑止と AND)、ロックボタンのクリック/表示配線
- `index.html`: ロックトグルのマークアップ (施錠/解錠 SVG アイコン)

## Test plan
- [x] vitest 62件 pass (回帰なし)
- [x] 既存 e2e (poi-drag.e2e.js / yaw-handle.e2e.js) が既定ロックの影響を受けるため、テスト冒頭で明示的にロック解除するよう修正
- [x] playwright e2e 新規追加: 既定ロックでドラッグ不可 → 解除で可能 → 再ロックで不可、route 編集中は解除していてもドラッグ不可 (既存抑止との AND)、ズームコントロール不在
- [x] playwright e2e 全体 28件 pass

## 注意
`#332` (フローティング Undo) も同じ `#ui-controls` 周りを触っている。両方 main にマージする場合、後からマージする側でリベースが必要。