### PR TITLE
ci: ros-test.yml の EXPECTED_TARGETS を 12 に更新

### DIFF
--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -92,12 +92,12 @@ jobs:
           # 「テスト 0 件でも colcon が green」を塞ぐ hardening (#193)。
           # gtest binary の build 漏れ / BUILD_TESTING off / ctest label 全除外などで test
           # target が静かに消えても colcon test 自体は exit 0 になる。実際に結果を出した test
-          # target 数 (gtest 5 + pytest 6 = 11; humble/jazzy 両 distro で実測) を数え、下限を割れば
+          # target 数 (gtest 6 + pytest 6 = 12; humble/jazzy 両 distro で実測) を数え、下限を割れば
           # fail。個々の case 数 (~150) ではなく target 数を不変量にして case 増減での誤検知を避ける。
           # target を意図的に増減した時は EXPECTED_TARGETS も更新する (silent drop を強制的に可視化)。
           # NOTE: package を絞らず全 package を test 対象にしておくことで、新規 package の test が
-          # 静かに除外される穴を避ける (PR #289 review high-1)。下限 11 は build 漏れ等の損失を捕える。
-          EXPECTED_TARGETS=11
+          # 静かに除外される穴を避ける (PR #289 review high-1)。下限 12 は build 漏れ等の損失を捕える。
+          EXPECTED_TARGETS=12
           ran=$(find build -path '*test_results*' -name '*.xml' | wc -l)
           echo "ran ${ran} test target result file(s); expected >= ${EXPECTED_TARGETS}"
           if [ "${ran}" -lt "${EXPECTED_TARGETS}" ]; then


### PR DESCRIPTION
## 概要

テスト silent drop 検知の下限 `EXPECTED_TARGETS=11` が実テストターゲット数 12 とドリフトしていたのを修正する (#297 の `test_map_state_store` 追加時の更新漏れ)。

## 変更

- `EXPECTED_TARGETS` を 11 → 12 に更新
- 根拠コメントの内訳を「gtest 6 + pytest 6 = 12」に追従

## 裏取り

CMakeLists の非 launch_test 登録数: mapoi_server gtest 4 + mapoi_rviz_plugins gtest 2 + mapoi_webui pytest 5 + mapoi_turtlebot3_example pytest 1 = 12。本 PR の CI (humble/jazzy) が 12 target の実測検証を兼ねる。

恒久対策 (期待値の自動算出で手動同期を無くす) は別 issue に切り出す。

Closes #344