### PR TITLE
chore(api)!: 公開API周りの一貫性改善 前半5項目 (#343)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -91,6 +91,16 @@ Breaking changes
   switch to keying on ``name`` instead. See ``docs/migration/v0.5.0.md``
   (#338).
 
+* ``mapoi_interfaces/srv/SelectMap`` response field ``initial_poi_name`` is
+  renamed to ``resolved_initial_poi_name``. Request and response previously
+  reused the same field name (``initial_poi_name``) for the *requested* POI
+  and the *resolved* POI, which read ambiguously at a glance; the request
+  field is unchanged. The ``mapoi_webui`` REST endpoint ``POST
+  /api/maps/select`` mirrors the rename in its JSON response body.
+  Recompile all clients against the updated ``.srv``; ``mapoi_server`` and
+  ``mapoi_nav2_bridge`` are updated in this change. See
+  ``docs/migration/v0.5.0.md`` (#343).
+
 Fixed
 -----
 

--- a/docs/migration/v0.5.0.md
+++ b/docs/migration/v0.5.0.md
@@ -87,3 +87,19 @@ sed -E -i \
 ### `name` の一意性について
 
 `id` 削除により `name` が唯一の識別子になります。一意性は編集経路で強制されます: RViz POI editor (`ValidatePois`) と WebUI の保存 API (#109) はどちらも重複 name を reject します。YAML を手編集して重複させた場合の name 解決 (route の waypoint 参照等) は**最初に一致した POI** を使うため、手編集時は name の一意性を保ってください。
+
+## `SelectMap.srv` の response フィールド `initial_poi_name` を `resolved_initial_poi_name` に rename ([#343](https://github.com/shimz-robotics/mapoi/issues/343))
+
+`SelectMap.srv` は request / response の両方に `initial_poi_name` という同名フィールドを持っており、「呼び出し側が指定した POI 名」(request) と「実際に採用された POI 名」(response) の区別が一読で付きにくいという問題がありました。response 側のみを `resolved_initial_poi_name` に rename しました。request 側の `initial_poi_name` は不変です。
+
+| フィールド | 旧名 | 新名 |
+|---|---|---|
+| Response | `initial_poi_name` | `resolved_initial_poi_name` |
+
+### 影響を受けるユーザー
+
+- `.srv` 定義の変更のため、`mapoi_interfaces` に依存する全パッケージは **再ビルドが必須** です
+- `mapoi/select_map` を `ros2 service call` / 独自 client から直接叩き、response の `initial_poi_name` を読んでいる場合
+- `mapoi_webui` の REST API `POST /api/maps/select` を叩く外部 client: JSON response body のキーも `initial_poi_name` から `resolved_initial_poi_name` に変わります (WebUI 本体の frontend はこのキーを参照していないため追従不要でしたが、外部 client は更新が必要です)
+
+本リポジトリに含まれる `mapoi_server` (response の生成元) と `mapoi_nav2_bridge` (response の読み手) は本リリースで新フィールド名に追従済みです。

--- a/mapoi_interfaces/README.md
+++ b/mapoi_interfaces/README.md
@@ -125,7 +125,7 @@ QoS contract (TRANSIENT_LOCAL / RELIABLE / MANUAL_BY_TOPIC publisher / AUTOMATIC
 | Response | `success` | `bool` | context 選択成功の有無 |
 | Response | `error_message` | `string` | 失敗時の理由 |
 | Response | `config_path` | `string` | 選択後の設定ファイル path |
-| Response | `initial_poi_name` | `string` | 解決済み初期姿勢 POI 名 |
+| Response | `resolved_initial_poi_name` | `string` | 解決済み初期姿勢 POI 名 |
 | Response | `nav2_node_names` | `string[]` | Nav2 map server node 名 |
 | Response | `nav2_map_urls` | `string[]` | 対応する map YAML path |
 

--- a/mapoi_interfaces/msg/NavigationBackendStatus.msg
+++ b/mapoi_interfaces/msg/NavigationBackendStatus.msg
@@ -1,6 +1,6 @@
 # Minimal navigation backend readiness, published 1 Hz on
 # `mapoi/nav/backend_status` by navigation bridges such as
-# `mapoi_nav_server` (Nav2 bridge) or any custom bridge.
+# `mapoi_nav2_bridge` (Nav2 bridge) or any custom bridge.
 #
 # Custom bridges only need to populate these three fields. UI consumers
 # (mapoi_webui, mapoi_rviz_plugins) gate navigation operations on
@@ -9,7 +9,7 @@
 #
 # How to populate `backend_ready` (custom bridge implementers — issue #207):
 #   AND only the capabilities your bridge actually exposes. Do NOT copy
-#   `mapoi_nav_server`'s `goal_ready && route_ready && switch_map_ready`
+#   `mapoi_nav2_bridge`'s `goal_ready && route_ready && switch_map_ready`
 #   verbatim — that AND is correct only for a bridge that exposes all three
 #   (NavigateToPose + FollowWaypoints + map switch). For a single-capability
 #   bridge, ANDing in capabilities you don't expose pins `backend_ready` to
@@ -20,7 +20,7 @@
 #     - Goal + map switch: backend_ready = goal_ready && switch_map_ready
 #   Convention for `reason` (recommended for operator UX consistency):
 #   when `backend_ready` is false, list missing capabilities joined by ", "
-#   prefixed with "not ready: " (see mapoi_nav_server::publish_backend_status
+#   prefixed with "not ready: " (see mapoi_nav2_bridge::publish_backend_status
 #   for the canonical format).
 #   Privacy: `reason` is surfaced in the operator UI and may be logged by
 #   bag recorders or remote dashboards. Bridges MUST NOT include sensitive
@@ -58,7 +58,7 @@
 # regardless of the latched payload (see `_resolve_backend_status_for_ui` in mapoi_webui).
 #
 # NOTE (issue #213): the lease must exceed any blocking call inside the publisher
-# node's executor. mapoi_nav_server's `select_map` flow can block the
+# node's executor. mapoi_nav2_bridge's `select_map` flow can block the
 # SingleThreadedExecutor for up to ~11 s per Nav2 map node during `send_load_map_request`,
 # which can trigger false-positive liveliness lost events even at 5 s lease.
 # Issue #213 tracks splitting backend_status_timer into a Reentrant callback group

--- a/mapoi_interfaces/srv/SelectMap.srv
+++ b/mapoi_interfaces/srv/SelectMap.srv
@@ -1,7 +1,7 @@
 # Select the active map context and reload all associated configuration.
 #
 # This service is intentionally Nav2-free. Operator-mode map switching is driven
-# by publishing the map name to /mapoi/nav/switch_map; mapoi_nav_server then calls
+# by publishing the map name to /mapoi/nav/switch_map; mapoi_nav2_bridge then calls
 # this service, executes Nav2 LoadMap using the returned map URLs, and publishes
 # the initial pose request after Nav2 accepts the new map.
 string map_name              # Name of the map directory to select
@@ -12,6 +12,6 @@ string initial_poi_name      # (optional) POI name whose pose should be used as 
 bool success                 # True if the map context was selected successfully
 string error_message         # Non-empty on failure with description of the error
 string config_path           # Full path to the selected mapoi config file
-string initial_poi_name      # Resolved initial POI name. Empty means no valid candidate.
+string resolved_initial_poi_name  # Resolved initial POI name. Empty means no valid candidate.
 string[] nav2_node_names     # Nav2 map server node names from the selected config's map entries
 string[] nav2_map_urls       # Absolute map YAML paths for the corresponding Nav2 map servers

--- a/mapoi_server/src/mapoi_nav2_bridge.cpp
+++ b/mapoi_server/src/mapoi_nav2_bridge.cpp
@@ -427,7 +427,7 @@ void MapoiNav2Bridge::on_select_map_received(
       map_url.c_str(), node_name.c_str());
   }
 
-  request_initial_pose(map_name, result->initial_poi_name);
+  request_initial_pose(map_name, result->resolved_initial_poi_name);
   publish_nav_status("map_switch_succeeded", map_name);
   RCLCPP_INFO(this->get_logger(), "Map switch completed: %s", map_name.c_str());
 }

--- a/mapoi_server/src/mapoi_server.cpp
+++ b/mapoi_server/src/mapoi_server.cpp
@@ -486,7 +486,7 @@ void MapoiServer::select_map_service(const std::shared_ptr<mapoi_interfaces::srv
   // #297: operator の map 選択を永続化 (crash/再起動時の context 復元用)。
   persist_last_selected_map();
   response->config_path = config_path_;
-  response->initial_poi_name = resolve_initial_poi_name(request->initial_poi_name);
+  response->resolved_initial_poi_name = resolve_initial_poi_name(request->initial_poi_name);
 
   if (nav2_map_list_ && nav2_map_list_.IsSequence()) {
     for (const auto & map : nav2_map_list_) {
@@ -513,7 +513,7 @@ void MapoiServer::select_map_service(const std::shared_ptr<mapoi_interfaces::srv
 
   // select_map は Nav2-free の context 更新入口。ここでは AMCL に initial pose を流さず、
   // stale な latched initial pose だけを clear する。operator mode では mapoi_nav2_bridge が
-  // Nav2 LoadMap 成功後に response->initial_poi_name を mapoi/initialpose_poi へ publish する。
+  // Nav2 LoadMap 成功後に response->resolved_initial_poi_name を mapoi/initialpose_poi へ publish する。
   publish_initialpose_clear();
 
   RCLCPP_INFO(this->get_logger(), "Selected map context: %s", map_name_.c_str());

--- a/mapoi_server/test/test_server_restart_initialpose_relatch.py
+++ b/mapoi_server/test/test_server_restart_initialpose_relatch.py
@@ -188,7 +188,7 @@ class TestServerRestartInitialposeRelatch(unittest.TestCase):
         select_result = self._call(
             select_map_client, SelectMap.Request(map_name='test_map_b'))
         self.assertTrue(select_result.success)
-        self.assertEqual(select_result.initial_poi_name, 'map_b_start')
+        self.assertEqual(select_result.resolved_initial_poi_name, 'map_b_start')
         request = RequestInitialPose.Request(
             map_name='test_map_b', poi_name='map_b_start')
         self.assertTrue(self._call(request_initialpose_client, request).success)

--- a/mapoi_webui/CMakeLists.txt
+++ b/mapoi_webui/CMakeLists.txt
@@ -50,6 +50,12 @@ if(BUILD_TESTING)
     test/test_api_sse_config_events.py
     TIMEOUT 15
   )
+  # /api/maps/select の REST 契約 (#343): resolved_initial_poi_name key (srv rename の
+  # REST 側 mirror) と 400/503 経路を Flask test_client で固定。
+  ament_add_pytest_test(test_api_select_map
+    test/test_api_select_map.py
+    TIMEOUT 10
+  )
 endif()
 
 ament_package()

--- a/mapoi_webui/README.md
+++ b/mapoi_webui/README.md
@@ -87,6 +87,8 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 | POST | `/api/nav/switch-map` | Navigation map switch。`mapoi/nav/switch_map` に map 名を publish |
 | GET | `/api/mode` | navigation 機能の検出結果 (`navigation_available`, topic subscriber 数) |
 
+> **注意 (`POST /api/nav/*` 呼び出し側は必読)**: `mapoi/nav/*` 系 topic への publish はローカルで成功したかどうかしか分からず、navigation backend (`mapoi_nav2_bridge` 等) が実際にコマンドを受理・実行したかまでは保証できません。そのため `POST /api/nav/goal` `/route` `/pause` `/resume` `/cancel` `/initialpose` `/switch-map` は subscriber 不在等の失敗時でも HTTP `200 OK` を返し、代わりに response body の `warning` フィールドに理由を入れます (詳細は下記「REST API と server 依存」参照)。**HTTP ステータスコードだけでは失敗を検知できません** — 外部 client は必ず response body に `warning` フィールドが含まれていないか確認してください。
+
 `POST /api/pois` は楽観的競合検出 (`expected_version` フィールド) に対応 (#241)。WebUI 経由は frontend が自動でハンドリング、外部 POST (curl / 別 client) で `expected_version` 省略時は check skip のため、競合上書きを避けたい場合は呼び出し側が `GET /api/pois` の `config_version` を送り返す責任を負う。詳細仕様は実装コメント (`api_save_pois`) / test (`test_api_save_pois_version_conflict.py`) を参照。
 
 ## 起動方法 (3 つのシナリオ)
@@ -112,6 +114,18 @@ ros2 launch mapoi_webui mapoi_editor.launch.yaml maps_path:=/path/to/maps map_na
 ### C. 統合運用 / デモ (Nav2 + sim + webui を全部)
 
 `mapoi_turtlebot3_example` の `turtlebot3_navigation.launch.yaml` のような bringup + webui 統合 launch を使う。詳細はそのパッケージの README を参照。
+
+## maps_path 未設定時の縮退
+
+`maps_path` パラメータは `""` (未設定) でも `mapoi_webui_node` は起動します。`mapoi_server` が `maps_path` 空で FATAL ログを出して即 throw する (起動しない) のとは非対称ですが、これは意図的な設計です — webui は「ロボットが既に稼働中の環境に、RViz の代替としてオペレーター用 nav UI を後付けする」用途 (起動方法 A) が正当に存在し、その用途では地図ディレクトリへのアクセスを必要としないため、fail-fast にはしていません。
+
+`maps_path` 未設定時の挙動は以下の通りです:
+
+- 起動時に `maps_path parameter not set. Set it to use the web editor.` を `WARN` ログ出力し、そのまま起動を継続する
+- **editor 機能 (地図一覧・地図画像・POI/Route/CustomTags の閲覧・編集) は無効になる**: `get_maps_list()` は `maps_path` が空 (または存在しないディレクトリ) の場合に空リストを返すため、`GET /api/maps` は `maps: []` を返し、`GET /api/maps/<name>/image` `/metadata` や POI/Route/CustomTags 系の endpoint (`GET`/`POST /api/pois` `/api/routes` `/api/custom_tags`) は対象 YAML/PNG が見つからず `404 Not Found` を返す
+- **nav 操作系 (`/api/nav/*`, `/api/mode`, `GET /api/nav/status`) は `maps_path` に依存せず動作する**: これらは `mapoi/nav/*` topic の publish / subscribe や `mapoi_server` の service 呼び出しのみで完結するため、`maps_path` 未設定でも通常通り使える
+
+したがって、`maps_path` を設定せずに起動した webui は「ナビゲーション操作専用の後付け UI」として機能し、地図編集機能だけが無効になります。
 
 ## REST API と server 依存
 

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -20,7 +20,7 @@ except ImportError:  # Humble fallback
 from std_msgs.msg import String
 from std_srvs.srv import Trigger
 from mapoi_interfaces.srv import (
-    GetMapsInfo, GetTagDefinitions, RequestInitialPose, SelectMap)
+    GetTagDefinitions, RequestInitialPose, SelectMap)
 from mapoi_interfaces.msg import (
     LocalizationBackendStatus, NavigationBackendStatus)
 import tf2_ros
@@ -155,7 +155,6 @@ class MapoiWebNode(Node):
 
         # ROS2 service clients
         self.reload_client_ = self.create_client(Trigger, 'mapoi/reload_map_info')
-        self.get_maps_client_ = self.create_client(GetMapsInfo, 'mapoi/get_maps_info')
         self.tag_defs_client_ = self.create_client(GetTagDefinitions, 'mapoi/get_tag_definitions')
         self.select_map_client_ = self.create_client(SelectMap, 'mapoi/select_map')
         # #211: initialpose POI は直接 publish せず mapoi_server (唯一の writer) へ
@@ -241,7 +240,10 @@ class MapoiWebNode(Node):
         self._sse_clients = set()
         self._sse_lock = threading.Lock()
 
-        # If maps_path not set, try to get it from get_maps_info service or use default
+        # maps_path 未設定時は fail-fast せず WARN のみで起動継続する (#343)。map 一覧は
+        # maps_path 配下を listdir で直読みするため (`get_maps_list`)、この場合は空リストに
+        # なり editor 系 (地図一覧・POI/route 編集) は使えないが、nav 操作系 API は引き続き動く
+        # (詳細は mapoi_webui/README.md の「maps_path 未設定時の縮退」を参照)。
         if not self.maps_path_:
             self.get_logger().warn('maps_path parameter not set. Set it to use the web editor.')
 
@@ -663,7 +665,7 @@ class MapoiWebNode(Node):
                 'success': True,
                 'map_name': map_name,
                 'config_path': response.config_path,
-                'initial_poi_name': response.initial_poi_name,
+                'resolved_initial_poi_name': response.resolved_initial_poi_name,
             })
 
         @app.route('/api/nav/switch-map', methods=['POST'])

--- a/mapoi_webui/test/test_api_select_map.py
+++ b/mapoi_webui/test/test_api_select_map.py
@@ -1,0 +1,83 @@
+"""Flask endpoint level test for `POST /api/maps/select` (#343).
+
+SelectMap.srv の response フィールド rename (`initial_poi_name` →
+`resolved_initial_poi_name`, #343) を REST JSON key レベルでも pin する。
+srv 側の rename は C++ の再コンパイルで検知されるが、REST key は文字列なので
+リファクタで旧名に戻っても CI で気づけない — この test がその regression を塞ぐ。
+
+`test_api_nav_endpoints.py` と同じく `create_flask_app` を duck-typed
+`_FakeNode` に bind し、`_call_service_sync` を差し替えて service 応答を偽装する。
+"""
+import unittest
+from types import SimpleNamespace
+
+from mapoi_webui.mapoi_webui_node import MapoiWebNode
+
+
+class _NullLogger:
+    def info(self, *_a, **_k):
+        pass
+
+    def warn(self, *_a, **_k):
+        pass
+
+    def error(self, *_a, **_k):
+        pass
+
+
+class _FakeNode:
+    """select_map endpoint 経路で参照される最小限の attr / method を持つ duck-typed node."""
+
+    def __init__(self, *, service_response):
+        self._service_response = service_response
+        self.select_map_client_ = object()
+        self.map_name_ = 'old_map'
+
+    def _call_service_sync(self, _client, _req, _name, timeout_sec):
+        return self._service_response
+
+    def get_logger(self):
+        return _NullLogger()
+
+
+def _client(node):
+    app = MapoiWebNode.create_flask_app(node)
+    return app.test_client()
+
+
+class TestApiSelectMap(unittest.TestCase):
+
+    def test_success_returns_resolved_initial_poi_name_key(self):
+        """成功時の JSON key は resolved_initial_poi_name (#343 rename の REST 側 pin)。"""
+        node = _FakeNode(service_response=SimpleNamespace(
+            success=True, error_message='', config_path='/maps/m/mapoi_config.yaml',
+            resolved_initial_poi_name='poi_start'))
+        resp = _client(node).post('/api/maps/select', json={'map_name': 'm'})
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        payload = resp.get_json()
+        self.assertEqual(payload['resolved_initial_poi_name'], 'poi_start')
+        self.assertNotIn('initial_poi_name', payload, '旧 key が復活している (#343 regression)')
+        self.assertEqual(node.map_name_, 'm')
+
+    def test_service_failure_returns_400_with_error_message(self):
+        node = _FakeNode(service_response=SimpleNamespace(
+            success=False, error_message='boom', config_path='',
+            resolved_initial_poi_name=''))
+        resp = _client(node).post('/api/maps/select', json={'map_name': 'm'})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()['error'], 'boom')
+        self.assertEqual(node.map_name_, 'old_map', '失敗時に map_name_ が更新されている')
+
+    def test_service_unavailable_returns_503(self):
+        node = _FakeNode(service_response=None)
+        resp = _client(node).post('/api/maps/select', json={'map_name': 'm'})
+        self.assertEqual(resp.status_code, 503)
+
+    def test_missing_map_name_returns_400(self):
+        node = _FakeNode(service_response=None)
+        resp = _client(node).post('/api/maps/select', json={})
+        self.assertEqual(resp.status_code, 400)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 概要

issue #343 (公開 API 周りの小粒一貫性改善チェックリスト) の前半 5 項目を対応する。残り (エラーレスポンス `code` 統一 / `expected_version` の routes・custom_tags 展開) は別 PR で対応する。URL separator 統一は #340 で別途対応する。

## 対応内容

1. **msg/srv コメントの旧名修正**: `NavigationBackendStatus.msg` / `SelectMap.srv` に rename 注記なしで残っていた旧名 `mapoi_nav_server` を `mapoi_nav2_bridge` に更新
2. **webui の maps_path 空時の縮退を README に明記**: `mapoi_webui` は `maps_path` 空でも fail-fast せず起動継続する設計を維持しつつ、`mapoi_webui/README.md` に「editor 機能が無効になり nav 操作系のみ動く」旨を新設セクションとして明記
3. **未使用 client の削除**: `mapoi_webui_node.py` の未使用 `get_maps_client_` (`GetMapsInfo`) と不要になった import を削除、古い将来案コメントも実態に合わせて整理
4. **SelectMap.srv の response フィールド rename (breaking)**: request/response で同名だった `initial_poi_name` のうち response 側を `resolved_initial_poi_name` に rename。`mapoi_server` / `mapoi_nav2_bridge` / `mapoi_webui` REST API / test / README / CHANGELOG / migration doc を追従
5. **200+warning 設計の README 明示**: `POST /api/nav/*` の 200+warning 設計について「HTTP ステータスだけでは失敗を検知できない、response body の `warning` を必ず確認」という注意書きを REST API 仕様の目立つ位置に追加

## 検証

- jazzy docker で `colcon build` + `colcon test` 実行、202 tests 全 green (main baseline と一致)
- `scripts/check_docs_consistency.py` / `check_robot_radius_drift.py` / `check_sample_yaml_consistency.py` ローカル実行、全て OK
- JS は変更していないため vitest は未実行
- humble は CI 任せ

Refs #343