### PR TITLE
feat(webui): REST エラー code 統一と排他制御拡張 (#343)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,23 @@ Added
   completed call as success (an empty ``map_name`` is passed through
   unvalidated for requesters that do not know the current map).
 
+* ``mapoi_webui`` REST API consistency improvements (#343, second half; first
+  half in #363): every JSON error response (4xx/5xx) now carries a
+  machine-readable ``code`` field alongside the existing human-readable
+  ``error`` message — ``invalid_request`` (400), ``not_found`` (404),
+  ``version_mismatch`` (409, unchanged from #241), ``service_unavailable``
+  (503), ``internal_error`` (500). This is purely additive; existing
+  ``error`` consumers are unaffected. Also, the optimistic-concurrency
+  ``expected_version`` check introduced for ``POST /api/pois`` (#241) is now
+  available on ``POST /api/routes`` and ``POST /api/custom_tags`` as well,
+  since all three write the same ``mapoi_config.yaml``: ``GET /api/routes``
+  and ``GET /api/tag_definitions`` now return ``config_version``, and the
+  corresponding ``POST`` endpoints accept ``expected_version`` and return
+  ``409`` + ``code: version_mismatch`` on a stale write (``expected_version``
+  omission still skips the check, matching the pre-existing ``/api/pois``
+  contract). The WebUI frontend (route editor, tag editor) handles the
+  conflict the same way the POI editor already does.
+
 Breaking changes
 ----------------
 

--- a/mapoi_webui/README.md
+++ b/mapoi_webui/README.md
@@ -76,7 +76,9 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 | GET | `/api/pois` | POI 一覧 |
 | POST | `/api/pois` | POI の保存 |
 | GET | `/api/routes` | ルート一覧 |
+| POST | `/api/routes` | ルートの保存 |
 | GET | `/api/tag_definitions` | タグ定義一覧 |
+| POST | `/api/custom_tags` | カスタムタグの保存 |
 | GET | `/api/nav/status` | ナビゲーション状態・ロボット位置・`robot_radius` (m) |
 | POST | `/api/nav/goal` | POI へのゴール走行 |
 | POST | `/api/nav/route` | ルート走行の開始 |
@@ -89,7 +91,23 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 
 > **注意 (`POST /api/nav/*` 呼び出し側は必読)**: `mapoi/nav/*` 系 topic への publish はローカルで成功したかどうかしか分からず、navigation backend (`mapoi_nav2_bridge` 等) が実際にコマンドを受理・実行したかまでは保証できません。そのため `POST /api/nav/goal` `/route` `/pause` `/resume` `/cancel` `/initialpose` `/switch-map` は subscriber 不在等の失敗時でも HTTP `200 OK` を返し、代わりに response body の `warning` フィールドに理由を入れます (詳細は下記「REST API と server 依存」参照)。**HTTP ステータスコードだけでは失敗を検知できません** — 外部 client は必ず response body に `warning` フィールドが含まれていないか確認してください。
 
-`POST /api/pois` は楽観的競合検出 (`expected_version` フィールド) に対応 (#241)。WebUI 経由は frontend が自動でハンドリング、外部 POST (curl / 別 client) で `expected_version` 省略時は check skip のため、競合上書きを避けたい場合は呼び出し側が `GET /api/pois` の `config_version` を送り返す責任を負う。詳細仕様は実装コメント (`api_save_pois`) / test (`test_api_save_pois_version_conflict.py`) を参照。
+### エラーレスポンス
+
+4xx/5xx を返す endpoint は、人間可読な `error` フィールドに加えて機械可読な `code` フィールドを返します (#343)。`error` の文言は変更されることがあるため、client 側の分岐は `code` を使ってください（200 + `warning` はエラーではないため `code` を持ちません、上記の注意を参照）。
+
+| `code` | HTTP status | 意味 |
+| --- | --- | --- |
+| `invalid_request` | 400 | request body 不正・必須フィールド欠如・値不正 |
+| `not_found` | 404 | 指定した map / config (yaml) が存在しない |
+| `version_mismatch` | 409 | 楽観的競合検出 (`expected_version` 不一致、下記参照) |
+| `service_unavailable` | 503 | 依存する ROS 2 service が unavailable / timeout |
+| `internal_error` | 500 | サーバ側の予期しない例外 (YAML 書き込み失敗等) |
+
+### 楽観的競合検出 (`expected_version`)
+
+`POST /api/pois` `/api/routes` `/api/custom_tags` はいずれも同じ yaml (`mapoi_config.yaml`) への書き込みのため、共通の楽観的競合検出に対応しています (`expected_version` フィールド、`/api/pois` は #241、`/api/routes` `/api/custom_tags` への展開は #343)。対応する GET (`/api/pois` `/api/routes` `/api/tag_definitions`) が返す `config_version` (yaml 内容の sha256 ハッシュ) を POST 時に `expected_version` として送り返すと、backend が現在の yaml と比較し、不一致なら `409` + `code: version_mismatch` を返します。WebUI 経由は frontend が自動でハンドリング（確認ダイアログの上でリロード）、外部 POST (curl / 別 client) で `expected_version` 省略時は check skip のため、競合上書きを避けたい場合は呼び出し側が対応する GET の `config_version` を送り返す責任を負う。
+
+`config_version` は yaml ファイル全体の内容ハッシュのため、POI/Route/CustomTags のいずれかを保存すると、他 2 つの GET が返す `config_version` も変わります（同じ yaml を共有しているため意図した挙動です）。詳細仕様は実装コメント (`api_save_pois` / `api_save_routes` / `api_save_custom_tags`) / test (`test_api_save_pois_version_conflict.py`) を参照。
 
 ## 起動方法 (3 つのシナリオ)
 

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -34,6 +34,30 @@ from mapoi_webui.yaml_handler import (
 from mapoi_webui.map_image import get_map_metadata, get_map_png
 
 
+def _version_conflict_response(data, config_path):
+    """楽観的競合検出 (#241、routes / custom_tags への展開は #343)。
+
+    frontend が GET 時に受け取った version を `expected_version` として送り返す。
+    current version と不一致なら (jsonify, 409) タプルを返し、呼び出し側はそれを
+    そのまま return する。一致、または `expected_version` 不在 (旧クライアント /
+    curl 後方互換で check skip) なら None。pois / routes / custom_tags の 3 つの
+    save endpoint は同一 yaml へ書き込むため、この契約を共有する。
+    空文字列など存在するが不一致な値は 409 になる (None のみが skip)。
+    """
+    expected_version = data.get('expected_version')
+    if expected_version is None:
+        return None
+    current_version = compute_config_version(config_path)
+    if current_version is not None and current_version != expected_version:
+        return jsonify({
+            'error': 'yaml file has been modified externally; '
+                     'please reload to fetch the latest state before saving',
+            'code': 'version_mismatch',
+            'current_version': current_version,
+        }), 409
+    return None
+
+
 def _validate_unique_names(items, label):
     """POI / route の name list が空 / 重複を含まないか検査する (#109)。
 
@@ -738,19 +762,9 @@ class MapoiWebNode(Node):
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
                 return jsonify({'error': 'Config not found', 'code': 'not_found'}), 404
-            # 楽観的競合検出 (#241): frontend が GET 時に受け取った version を `expected_version`
-            # として送り返す。current version と不一致なら 409 を返し、frontend に reload を促す。
-            # `expected_version` 不在 (旧クライアント / curl) の場合は check をスキップ。
-            expected_version = data.get('expected_version')
-            if expected_version is not None:
-                current_version = compute_config_version(config_path)
-                if current_version is not None and current_version != expected_version:
-                    return jsonify({
-                        'error': 'yaml file has been modified externally; '
-                                 'please reload to fetch the latest state before saving',
-                        'code': 'version_mismatch',
-                        'current_version': current_version,
-                    }), 409
+            conflict = _version_conflict_response(data, config_path)
+            if conflict is not None:
+                return conflict
             try:
                 save_pois(config_path, data['pois'])
                 new_version = compute_config_version(config_path)
@@ -797,18 +811,9 @@ class MapoiWebNode(Node):
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
                 return jsonify({'error': 'Config not found', 'code': 'not_found'}), 404
-            # 楽観的競合検出 (#241 の展開, #343): pois と同一契約。expected_version 不在なら
-            # check skip (旧クライアント / curl 後方互換)。
-            expected_version = data.get('expected_version')
-            if expected_version is not None:
-                current_version = compute_config_version(config_path)
-                if current_version is not None and current_version != expected_version:
-                    return jsonify({
-                        'error': 'yaml file has been modified externally; '
-                                 'please reload to fetch the latest state before saving',
-                        'code': 'version_mismatch',
-                        'current_version': current_version,
-                    }), 409
+            conflict = _version_conflict_response(data, config_path)
+            if conflict is not None:
+                return conflict
             try:
                 save_custom_tags(config_path, data['custom_tags'])
                 new_version = compute_config_version(config_path)
@@ -849,18 +854,9 @@ class MapoiWebNode(Node):
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
                 return jsonify({'error': 'Config not found', 'code': 'not_found'}), 404
-            # 楽観的競合検出 (#241 の展開, #343): pois と同一契約。expected_version 不在なら
-            # check skip (旧クライアント / curl 後方互換)。
-            expected_version = data.get('expected_version')
-            if expected_version is not None:
-                current_version = compute_config_version(config_path)
-                if current_version is not None and current_version != expected_version:
-                    return jsonify({
-                        'error': 'yaml file has been modified externally; '
-                                 'please reload to fetch the latest state before saving',
-                        'code': 'version_mismatch',
-                        'current_version': current_version,
-                    }), 409
+            conflict = _version_conflict_response(data, config_path)
+            if conflict is not None:
+                return conflict
             try:
                 save_routes(config_path, data['routes'])
                 new_version = compute_config_version(config_path)

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -628,7 +628,7 @@ class MapoiWebNode(Node):
             map_dir = node.get_map_dir(name)
             png_bytes, content_type = get_map_png(map_dir)
             if png_bytes is None:
-                return jsonify({'error': 'Map image not found'}), 404
+                return jsonify({'error': 'Map image not found', 'code': 'not_found'}), 404
             return Response(png_bytes, mimetype=content_type)
 
         @app.route('/api/maps/<name>/metadata')
@@ -636,7 +636,7 @@ class MapoiWebNode(Node):
             map_dir = node.get_map_dir(name)
             meta = get_map_metadata(map_dir)
             if meta is None:
-                return jsonify({'error': 'Map metadata not found'}), 404
+                return jsonify({'error': 'Map metadata not found', 'code': 'not_found'}), 404
             return jsonify({
                 'resolution': meta['resolution'],
                 'origin': meta['origin'],
@@ -648,18 +648,24 @@ class MapoiWebNode(Node):
         def api_select_map():
             data = request.get_json()
             if not data or 'map_name' not in data:
-                return jsonify({'error': 'map_name required'}), 400
+                return jsonify({'error': 'map_name required', 'code': 'invalid_request'}), 400
             map_name = str(data['map_name']).strip()
             if not map_name:
-                return jsonify({'error': 'map_name required'}), 400
+                return jsonify({'error': 'map_name required', 'code': 'invalid_request'}), 400
             req = SelectMap.Request()
             req.map_name = map_name
             response = node._call_service_sync(
                 node.select_map_client_, req, 'mapoi/select_map', timeout_sec=3.0)
             if response is None:
-                return jsonify({'error': 'mapoi/select_map service unavailable or timed out'}), 503
+                return jsonify({
+                    'error': 'mapoi/select_map service unavailable or timed out',
+                    'code': 'service_unavailable',
+                }), 503
             if not response.success:
-                return jsonify({'error': response.error_message or 'mapoi/select_map failed'}), 400
+                return jsonify({
+                    'error': response.error_message or 'mapoi/select_map failed',
+                    'code': 'invalid_request',
+                }), 400
             node.map_name_ = map_name
             return jsonify({
                 'success': True,
@@ -676,13 +682,13 @@ class MapoiWebNode(Node):
             # membership skip 経路でそのまま publish される潜在バグになる。別 client
             # からの POST 保険として、型不正は coerce せず 400 で弾く (#199 follow-up)。
             if not isinstance(data, dict) or not isinstance(data.get('map_name'), str):
-                return jsonify({'error': 'map_name required'}), 400
+                return jsonify({'error': 'map_name required', 'code': 'invalid_request'}), 400
             map_name = data['map_name'].strip()
             if not map_name:
-                return jsonify({'error': 'map_name required'}), 400
+                return jsonify({'error': 'map_name required', 'code': 'invalid_request'}), 400
             maps = node.get_maps_list()
             if maps and map_name not in maps:
-                return jsonify({'error': f'unknown map: {map_name}'}), 404
+                return jsonify({'error': f'unknown map: {map_name}', 'code': 'not_found'}), 404
             msg = String()
             msg.data = map_name
             _, warning = node.publish_with_subscriber_check(
@@ -703,7 +709,7 @@ class MapoiWebNode(Node):
         def api_get_pois():
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
-                return jsonify({'error': 'Config not found'}), 404
+                return jsonify({'error': 'Config not found', 'code': 'not_found'}), 404
             pois = get_pois(config_path)
             return jsonify({
                 'pois': pois,
@@ -716,22 +722,22 @@ class MapoiWebNode(Node):
         def api_save_pois():
             data = request.get_json()
             if data is None or 'pois' not in data:
-                return jsonify({'error': 'Invalid request body'}), 400
+                return jsonify({'error': 'Invalid request body', 'code': 'invalid_request'}), 400
             # name の uniqueness / 空 を backend でも validate (#109)。
             # frontend 経由なら poi-editor が reject 済みだが、yaml 直編集や
             # 別 client からの POST に対する保険として 400 で reject する。
             err = _validate_unique_names(data['pois'], 'POI')
             if err:
-                return jsonify({'error': err}), 400
+                return jsonify({'error': err, 'code': 'invalid_request'}), 400
             err = _validate_pois_tag_exclusivity(data['pois'])
             if err:
-                return jsonify({'error': err}), 400
+                return jsonify({'error': err, 'code': 'invalid_request'}), 400
             err = _validate_pois_tolerance(data['pois'])
             if err:
-                return jsonify({'error': err}), 400
+                return jsonify({'error': err, 'code': 'invalid_request'}), 400
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
-                return jsonify({'error': 'Config not found'}), 404
+                return jsonify({'error': 'Config not found', 'code': 'not_found'}), 404
             # 楽観的競合検出 (#241): frontend が GET 時に受け取った version を `expected_version`
             # として送り返す。current version と不一致なら 409 を返し、frontend に reload を促す。
             # `expected_version` 不在 (旧クライアント / curl) の場合は check をスキップ。
@@ -759,80 +765,123 @@ class MapoiWebNode(Node):
                 return jsonify({'success': True, 'config_version': new_version})
             except Exception as e:
                 node.get_logger().error(f'Failed to save POIs: {e}')
-                return jsonify({'error': str(e)}), 500
+                return jsonify({'error': str(e), 'code': 'internal_error'}), 500
 
         @app.route('/api/tag_definitions')
         def api_tag_definitions():
             response = node._call_service_sync(
                 node.tag_defs_client_, GetTagDefinitions.Request(), 'mapoi/get_tag_definitions')
             if response is None:
-                return jsonify({'error': 'mapoi/get_tag_definitions service unavailable or timed out'}), 503
+                return jsonify({
+                    'error': 'mapoi/get_tag_definitions service unavailable or timed out',
+                    'code': 'service_unavailable',
+                }), 503
             tags = [
                 {'name': d.name, 'description': d.description, 'is_system': d.is_system}
                 for d in response.definitions
             ]
-            return jsonify({'tags': tags})
+            # custom_tags は pois/routes と同じ yaml に書き込むため、POST /api/custom_tags の
+            # 楽観的競合検出 (#241 の展開, #343) 用に config_version を同梱する。config 不在
+            # (maps_path 未設定等) では compute_config_version が None を返し、POST 側は
+            # None を expected_version 一致対象から外して check skip 相当に倒す。
+            return jsonify({
+                'tags': tags,
+                'config_version': compute_config_version(node.get_config_path()),
+            })
 
         @app.route('/api/custom_tags', methods=['POST'])
         def api_save_custom_tags():
             data = request.get_json()
             if data is None or 'custom_tags' not in data:
-                return jsonify({'error': 'Invalid request body'}), 400
+                return jsonify({'error': 'Invalid request body', 'code': 'invalid_request'}), 400
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
-                return jsonify({'error': 'Config not found'}), 404
+                return jsonify({'error': 'Config not found', 'code': 'not_found'}), 404
+            # 楽観的競合検出 (#241 の展開, #343): pois と同一契約。expected_version 不在なら
+            # check skip (旧クライアント / curl 後方互換)。
+            expected_version = data.get('expected_version')
+            if expected_version is not None:
+                current_version = compute_config_version(config_path)
+                if current_version is not None and current_version != expected_version:
+                    return jsonify({
+                        'error': 'yaml file has been modified externally; '
+                                 'please reload to fetch the latest state before saving',
+                        'code': 'version_mismatch',
+                        'current_version': current_version,
+                    }), 409
             try:
                 save_custom_tags(config_path, data['custom_tags'])
+                new_version = compute_config_version(config_path)
                 reloaded = node.call_reload_map_info()
                 if not reloaded:
                     return jsonify({
                         'success': True,
+                        'config_version': new_version,
                         'warning': 'The YAML file was saved, but mapoi_server mapoi/reload_map_info '
                                    'did not respond or failed. Check the logs for details.'
                     })
-                return jsonify({'success': True})
+                return jsonify({'success': True, 'config_version': new_version})
             except Exception as e:
                 node.get_logger().error(f'Failed to save custom tags: {e}')
-                return jsonify({'error': str(e)}), 500
+                return jsonify({'error': str(e), 'code': 'internal_error'}), 500
 
         @app.route('/api/routes')
         def api_get_routes():
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
-                return jsonify({'error': 'Config not found'}), 404
+                return jsonify({'error': 'Config not found', 'code': 'not_found'}), 404
             routes = get_routes(config_path)
-            return jsonify({'routes': routes, 'map_name': node.map_name_})
+            return jsonify({
+                'routes': routes,
+                'map_name': node.map_name_,
+                # 楽観的競合検出 (#241 の展開, #343) のため frontend に渡す yaml 内容ハッシュ。
+                'config_version': compute_config_version(config_path),
+            })
 
         @app.route('/api/routes', methods=['POST'])
         def api_save_routes():
             data = request.get_json()
             if data is None or 'routes' not in data:
-                return jsonify({'error': 'Invalid request body'}), 400
+                return jsonify({'error': 'Invalid request body', 'code': 'invalid_request'}), 400
             err = _validate_unique_names(data['routes'], 'Route')
             if err:
-                return jsonify({'error': err}), 400
+                return jsonify({'error': err, 'code': 'invalid_request'}), 400
             config_path = node.get_config_path()
             if not os.path.exists(config_path):
-                return jsonify({'error': 'Config not found'}), 404
+                return jsonify({'error': 'Config not found', 'code': 'not_found'}), 404
+            # 楽観的競合検出 (#241 の展開, #343): pois と同一契約。expected_version 不在なら
+            # check skip (旧クライアント / curl 後方互換)。
+            expected_version = data.get('expected_version')
+            if expected_version is not None:
+                current_version = compute_config_version(config_path)
+                if current_version is not None and current_version != expected_version:
+                    return jsonify({
+                        'error': 'yaml file has been modified externally; '
+                                 'please reload to fetch the latest state before saving',
+                        'code': 'version_mismatch',
+                        'current_version': current_version,
+                    }), 409
             try:
                 save_routes(config_path, data['routes'])
+                new_version = compute_config_version(config_path)
                 reloaded = node.call_reload_map_info()
                 if not reloaded:
                     return jsonify({
                         'success': True,
+                        'config_version': new_version,
                         'warning': 'The YAML file was saved, but mapoi_server mapoi/reload_map_info '
                                    'did not respond or failed. Check the logs for details.'
                     })
-                return jsonify({'success': True})
+                return jsonify({'success': True, 'config_version': new_version})
             except Exception as e:
                 node.get_logger().error(f'Failed to save routes: {e}')
-                return jsonify({'error': str(e)}), 500
+                return jsonify({'error': str(e), 'code': 'internal_error'}), 500
 
         @app.route('/api/nav/goal', methods=['POST'])
         def api_nav_goal():
             data = request.get_json()
             if not data or 'poi_name' not in data:
-                return jsonify({'error': 'poi_name required'}), 400
+                return jsonify({'error': 'poi_name required', 'code': 'invalid_request'}), 400
             msg = String()
             msg.data = data['poi_name']
             _, warning = node.publish_with_subscriber_check(
@@ -846,7 +895,7 @@ class MapoiWebNode(Node):
         def api_nav_route():
             data = request.get_json()
             if not data or 'route_name' not in data:
-                return jsonify({'error': 'route_name required'}), 400
+                return jsonify({'error': 'route_name required', 'code': 'invalid_request'}), 400
             msg = String()
             msg.data = data['route_name']
             _, warning = node.publish_with_subscriber_check(
@@ -901,7 +950,7 @@ class MapoiWebNode(Node):
         def api_nav_initialpose():
             data = request.get_json()
             if not data or 'poi_name' not in data:
-                return jsonify({'error': 'poi_name required'}), 400
+                return jsonify({'error': 'poi_name required', 'code': 'invalid_request'}), 400
             # #211: initialpose_poi を直接 publish せず、唯一の writer である mapoi_server に
             # request_initial_pose service 経由で publish を依頼する。
             req = RequestInitialPose.Request()
@@ -910,11 +959,15 @@ class MapoiWebNode(Node):
             response = node._call_service_sync(
                 node.request_initial_pose_client_, req, 'mapoi/request_initial_pose', timeout_sec=3.0)
             if response is None:
-                return jsonify(
-                    {'error': 'mapoi/request_initial_pose service unavailable or timed out'}), 503
+                return jsonify({
+                    'error': 'mapoi/request_initial_pose service unavailable or timed out',
+                    'code': 'service_unavailable',
+                }), 503
             if not response.success:
-                return jsonify(
-                    {'error': response.error_message or 'mapoi/request_initial_pose failed'}), 400
+                return jsonify({
+                    'error': response.error_message or 'mapoi/request_initial_pose failed',
+                    'code': 'invalid_request',
+                }), 400
             node.get_logger().info(f'Initial pose: {data["poi_name"]}')
             # #211 review fix: 旧 publish_with_subscriber_check 相当の「無人 publish」警告を復元。
             # service は mapoi_server に届くが、その先の mapoi/initialpose_poi に subscriber

--- a/mapoi_webui/test/test_api_nav_endpoints.py
+++ b/mapoi_webui/test/test_api_nav_endpoints.py
@@ -78,21 +78,28 @@ class TestApiNavSwitchMap(unittest.TestCase):
         node = _FakeNode(maps=['mapA'])
         resp = _client(node).post('/api/nav/switch-map', json=[1, 2])
         self.assertEqual(resp.status_code, 400, resp.get_data(as_text=True))
-        self.assertIn('map_name', resp.get_json().get('error', ''))
+        body = resp.get_json()
+        self.assertIn('map_name', body.get('error', ''))
+        # 機械可読 code フィールド (#343): 400 系は invalid_request で統一。
+        self.assertEqual(body.get('code'), 'invalid_request')
         self.assertEqual(node.published, [])  # publish されていない
 
     def test_missing_map_name_returns_400(self):
         node = _FakeNode(maps=['mapA'])
         resp = _client(node).post('/api/nav/switch-map', json={})
         self.assertEqual(resp.status_code, 400, resp.get_data(as_text=True))
-        self.assertIn('map_name', resp.get_json().get('error', ''))
+        body = resp.get_json()
+        self.assertIn('map_name', body.get('error', ''))
+        self.assertEqual(body.get('code'), 'invalid_request')
         self.assertEqual(node.published, [])
 
     def test_whitespace_map_name_returns_400(self):
         node = _FakeNode(maps=['mapA'])
         resp = _client(node).post('/api/nav/switch-map', json={'map_name': '   '})
         self.assertEqual(resp.status_code, 400, resp.get_data(as_text=True))
-        self.assertIn('map_name', resp.get_json().get('error', ''))
+        body = resp.get_json()
+        self.assertIn('map_name', body.get('error', ''))
+        self.assertEqual(body.get('code'), 'invalid_request')
         self.assertEqual(node.published, [])
 
     def test_non_string_map_name_returns_400(self):
@@ -108,14 +115,19 @@ class TestApiNavSwitchMap(unittest.TestCase):
             self.assertEqual(
                 resp.status_code, 400,
                 f'map_name={bad!r}: {resp.get_data(as_text=True)}')
-            self.assertIn('map_name', resp.get_json().get('error', ''))
+            body = resp.get_json()
+            self.assertIn('map_name', body.get('error', ''))
+            self.assertEqual(body.get('code'), 'invalid_request')
             self.assertEqual(node.published, [], f'map_name={bad!r} を publish した')
 
     def test_unknown_map_returns_404(self):
         node = _FakeNode(maps=['mapA', 'mapB'])
         resp = _client(node).post('/api/nav/switch-map', json={'map_name': 'mapX'})
         self.assertEqual(resp.status_code, 404, resp.get_data(as_text=True))
-        self.assertIn('mapX', resp.get_json().get('error', ''))
+        body = resp.get_json()
+        self.assertIn('mapX', body.get('error', ''))
+        # 機械可読 code フィールド (#343): 404 系は not_found で統一。
+        self.assertEqual(body.get('code'), 'not_found')
         self.assertEqual(node.published, [])
 
     def test_valid_map_publishes_and_returns_200(self):

--- a/mapoi_webui/test/test_api_save_pois_version_conflict.py
+++ b/mapoi_webui/test/test_api_save_pois_version_conflict.py
@@ -1,7 +1,8 @@
-"""Flask endpoint level test for `/api/pois` POST 楽観的競合検出 (#241 / #246).
+"""Flask endpoint level test for POST /api/pois `/api/routes` `/api/custom_tags` の
+楽観的競合検出 (#241 / #246、routes・custom_tags への展開は #343)。
 
 `test_yaml_handler_version.py` は `compute_config_version` 単体の決定性しか pin して
-いないため、Flask endpoint レベルで以下の `api_save_pois` 仕様契約を独立に固定する:
+いないため、Flask endpoint レベルで以下の仕様契約を独立に固定する (3 endpoint 共通):
 
 - `expected_version` 不一致 → 409 + `code: 'version_mismatch'` + `current_version`
 - `expected_version` 省略 → 200 OK (旧クライアント / curl 後方互換)
@@ -9,10 +10,11 @@
 
 ROS 2 Node を本物で起動すると DDS / service / publisher が絡んで test 重量級になるため、
 `create_flask_app` を duck-typed `FakeNode` に bind して呼び出す (= `MapoiWebNode.create_flask_app`
-は `self` を `node = self` で local capture するだけで、`/api/pois` 経路は
-`node.get_config_path()` / `node.call_reload_map_info()` / `node.get_logger()` の 3 メソッドだけに
-依存する)。他 endpoint の closures は登録時に評価されないため `FakeNode` に該当 attr が無くても
-本 test は影響を受けない。
+は `self` を `node = self` で local capture するだけで、`/api/pois` `/api/routes`
+`/api/custom_tags` の経路はいずれも `node.get_config_path()` / `node.call_reload_map_info()` /
+`node.get_logger()` の 3 メソッドだけに依存する、pois/routes/custom_tags で fixture 構成が
+共通なため `docs/testing-policy.md` 3 節に従い同一ファイルにクラスを追加している)。他 endpoint
+の closures は登録時に評価されないため `FakeNode` に該当 attr が無くても本 test は影響を受けない。
 """
 import os
 import tempfile
@@ -201,6 +203,154 @@ class TestApiSavePoisVersionConflict(unittest.TestCase):
         「明示送信は常に check」契約を test で固定する。
         """
         self._assert_409_version_mismatch_without_writing('')
+
+
+def _valid_routes_payload():
+    """`_validate_unique_names` の check を通る最小 1 route body."""
+    return [{'name': 'route1', 'waypoints': ['p1'], 'landmarks': []}]
+
+
+class TestApiSaveRoutesVersionConflict(unittest.TestCase):
+    """`POST /api/routes` の楽観的競合検出 (#241 の展開, #343)。
+
+    `api_save_pois` と同じ `compute_config_version` / `expected_version` 契約を
+    `api_save_routes` にも適用したことを pin する。`_FakeNode` は
+    `TestApiSavePoisVersionConflict` と共通 (get_config_path / call_reload_map_info /
+    get_logger の 3 メソッドだけに依存)。
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.config_path = os.path.join(self._tmp.name, 'cfg.yaml')
+        _seed_config(self.config_path)
+        self.fake_node = _FakeNode(self.config_path)
+        self.app = MapoiWebNode.create_flask_app(self.fake_node)
+        self.client = self.app.test_client()
+
+    def _current_version(self):
+        from mapoi_webui.yaml_handler import compute_config_version
+        return compute_config_version(self.config_path)
+
+    def test_save_with_matching_expected_version_returns_200_with_new_version(self):
+        v_before = self._current_version()
+        resp = self.client.post('/api/routes', json={
+            'routes': _valid_routes_payload(),
+            'expected_version': v_before,
+        })
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertTrue(body.get('success'))
+        self.assertIn('config_version', body)
+        self.assertNotEqual(body['config_version'], v_before)
+        self.assertEqual(body['config_version'], self._current_version())
+        with open(self.config_path, 'r') as f:
+            saved = yaml.safe_load(f)
+        self.assertEqual((saved.get('route') or [])[0]['name'], 'route1')
+
+    def test_save_with_mismatched_expected_version_returns_409_without_writing(self):
+        v_before = self._current_version()
+        with open(self.config_path, 'rb') as f:
+            content_before = f.read()
+        stale_version = 'b' * 64
+        self.assertNotEqual(stale_version, v_before)
+
+        resp = self.client.post('/api/routes', json={
+            'routes': _valid_routes_payload(),
+            'expected_version': stale_version,
+        })
+        self.assertEqual(resp.status_code, 409, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertEqual(body.get('code'), 'version_mismatch')
+        self.assertEqual(body.get('current_version'), v_before)
+        self.assertIn('reload', str(body.get('error', '')).lower())
+        # 競合時に save_routes が呼ばれていないこと (byte 単位で content 不変)。
+        with open(self.config_path, 'rb') as f:
+            self.assertEqual(f.read(), content_before)
+
+    def test_save_without_expected_version_returns_200(self):
+        """`expected_version` 省略時は旧クライアント / curl 後方互換で check skip する。"""
+        v_before = self._current_version()
+        resp = self.client.post('/api/routes', json={'routes': _valid_routes_payload()})
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertTrue(body.get('success'))
+        self.assertNotEqual(body.get('config_version'), v_before)
+        self.assertEqual(body['config_version'], self._current_version())
+
+
+def _valid_custom_tags_payload():
+    """`api_save_custom_tags` は name uniqueness 等の validation を持たないため、
+    素朴な 1 tag body で十分。"""
+    return [{'name': 'zone_a', 'description': 'Zone A'}]
+
+
+class TestApiSaveCustomTagsVersionConflict(unittest.TestCase):
+    """`POST /api/custom_tags` の楽観的競合検出 (#241 の展開, #343)。
+
+    `api_save_pois` と同じ `compute_config_version` / `expected_version` 契約を
+    `api_save_custom_tags` にも適用したことを pin する。`_FakeNode` は
+    `TestApiSavePoisVersionConflict` と共通。
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.config_path = os.path.join(self._tmp.name, 'cfg.yaml')
+        _seed_config(self.config_path)
+        self.fake_node = _FakeNode(self.config_path)
+        self.app = MapoiWebNode.create_flask_app(self.fake_node)
+        self.client = self.app.test_client()
+
+    def _current_version(self):
+        from mapoi_webui.yaml_handler import compute_config_version
+        return compute_config_version(self.config_path)
+
+    def test_save_with_matching_expected_version_returns_200_with_new_version(self):
+        v_before = self._current_version()
+        resp = self.client.post('/api/custom_tags', json={
+            'custom_tags': _valid_custom_tags_payload(),
+            'expected_version': v_before,
+        })
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertTrue(body.get('success'))
+        self.assertIn('config_version', body)
+        self.assertNotEqual(body['config_version'], v_before)
+        self.assertEqual(body['config_version'], self._current_version())
+        with open(self.config_path, 'r') as f:
+            saved = yaml.safe_load(f)
+        self.assertEqual((saved.get('custom_tags') or [])[0]['name'], 'zone_a')
+
+    def test_save_with_mismatched_expected_version_returns_409_without_writing(self):
+        v_before = self._current_version()
+        with open(self.config_path, 'rb') as f:
+            content_before = f.read()
+        stale_version = 'c' * 64
+        self.assertNotEqual(stale_version, v_before)
+
+        resp = self.client.post('/api/custom_tags', json={
+            'custom_tags': _valid_custom_tags_payload(),
+            'expected_version': stale_version,
+        })
+        self.assertEqual(resp.status_code, 409, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertEqual(body.get('code'), 'version_mismatch')
+        self.assertEqual(body.get('current_version'), v_before)
+        self.assertIn('reload', str(body.get('error', '')).lower())
+        with open(self.config_path, 'rb') as f:
+            self.assertEqual(f.read(), content_before)
+
+    def test_save_without_expected_version_returns_200(self):
+        """`expected_version` 省略時は旧クライアント / curl 後方互換で check skip する。"""
+        v_before = self._current_version()
+        resp = self.client.post(
+            '/api/custom_tags', json={'custom_tags': _valid_custom_tags_payload()})
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        body = resp.get_json()
+        self.assertTrue(body.get('success'))
+        self.assertNotEqual(body.get('config_version'), v_before)
+        self.assertEqual(body['config_version'], self._current_version())
 
 
 if __name__ == '__main__':

--- a/mapoi_webui/test/test_api_save_pois_version_conflict.py
+++ b/mapoi_webui/test/test_api_save_pois_version_conflict.py
@@ -232,6 +232,17 @@ class TestApiSaveRoutesVersionConflict(unittest.TestCase):
         from mapoi_webui.yaml_handler import compute_config_version
         return compute_config_version(self.config_path)
 
+    def test_get_routes_returns_config_version(self):
+        """GET /api/routes が expected_version の種になる config_version を返す (#343)。
+
+        frontend (route-editor.js) はこの key を Save 時に送り返す。key 名が変わる /
+        消えると楽観ロックがサイレントに無効化されるため backend 側で pin する。
+        """
+        self.fake_node.map_name_ = 'test_map'
+        resp = self.client.get('/api/routes')
+        self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+        self.assertEqual(resp.get_json()['config_version'], self._current_version())
+
     def test_save_with_matching_expected_version_returns_200_with_new_version(self):
         v_before = self._current_version()
         resp = self.client.post('/api/routes', json={

--- a/mapoi_webui/test/test_api_select_map.py
+++ b/mapoi_webui/test/test_api_select_map.py
@@ -65,18 +65,23 @@ class TestApiSelectMap(unittest.TestCase):
             resolved_initial_poi_name=''))
         resp = _client(node).post('/api/maps/select', json={'map_name': 'm'})
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual(resp.get_json()['error'], 'boom')
+        body = resp.get_json()
+        self.assertEqual(body['error'], 'boom')
+        # 機械可読 code フィールド (#343): 400 系は invalid_request で統一。
+        self.assertEqual(body.get('code'), 'invalid_request')
         self.assertEqual(node.map_name_, 'old_map', '失敗時に map_name_ が更新されている')
 
     def test_service_unavailable_returns_503(self):
         node = _FakeNode(service_response=None)
         resp = _client(node).post('/api/maps/select', json={'map_name': 'm'})
         self.assertEqual(resp.status_code, 503)
+        self.assertEqual(resp.get_json().get('code'), 'service_unavailable')
 
     def test_missing_map_name_returns_400(self):
         node = _FakeNode(service_response=None)
         resp = _client(node).post('/api/maps/select', json={})
         self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json().get('code'), 'invalid_request')
 
 
 if __name__ == '__main__':

--- a/mapoi_webui/tests/web/api-nav.test.js
+++ b/mapoi_webui/tests/web/api-nav.test.js
@@ -3,6 +3,12 @@
 // stub して固定する。DOM 非依存なので default (node) 環境で回す。
 // backend 側の validation は test_api_nav_endpoints.py (#279) が pin 済で、ここは
 // client が「正しい URL に正しい payload を投げ、JSON をそのまま返す」ことだけを見る。
+//
+// saveRoutes / saveCustomTags の楽観的競合検出 (#241 の展開, #343) も同じファイルで
+// pin する: backend 側の version check 自体は test_api_save_pois_version_conflict.py
+// (TestApiSaveRoutesVersionConflict / TestApiSaveCustomTagsVersionConflict) が持つので、
+// ここでは client が expected_version を送り、{ ok, status, conflict } を正しく組み立てる
+// ことだけを見る。
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as MapoiApi from '../../web/js/api.js';
@@ -12,8 +18,10 @@ afterEach(() => {
   delete globalThis.fetch;
 });
 
-function mockFetch(payload) {
+function mockFetch(payload, { status = 200, ok = status < 400 } = {}) {
   const fetchMock = vi.fn().mockResolvedValue({
+    ok,
+    status,
     json: vi.fn().mockResolvedValue(payload),
   });
   globalThis.fetch = fetchMock;
@@ -50,5 +58,66 @@ describe('MapoiApi.mode', () => {
     expect(url).toBe('/api/mode');
     expect(opts).toBeUndefined(); // GET は options なし
     expect(res).toEqual({ mode: 'navigation' });
+  });
+});
+
+describe('MapoiApi.saveRoutes', () => {
+  it('POST /api/routes に routes と expected_version を JSON body で送る', async () => {
+    const fetchMock = mockFetch({ success: true, config_version: 'v2' });
+    const routes = [{ name: 'r1', waypoints: [] }];
+    const res = await MapoiApi.saveRoutes(routes, 'v1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/routes');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ routes, expected_version: 'v1' });
+    // ok/status/conflict を savePois と同じ形で付加しつつ backend body を透過する (#343)。
+    expect(res).toEqual({
+      ok: true, status: 200, conflict: false, success: true, config_version: 'v2',
+    });
+  });
+
+  it('409 (version_mismatch) を conflict: true として組み立てる', async () => {
+    mockFetch(
+      { error: 'reload required', code: 'version_mismatch', current_version: 'v2' },
+      { status: 409 },
+    );
+    const res = await MapoiApi.saveRoutes([{ name: 'r1' }], 'stale');
+
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(409);
+    expect(res.conflict).toBe(true);
+    expect(res.code).toBe('version_mismatch');
+  });
+});
+
+describe('MapoiApi.saveCustomTags', () => {
+  it('POST /api/custom_tags に custom_tags と expected_version を JSON body で送る', async () => {
+    const fetchMock = mockFetch({ success: true, config_version: 'v2' });
+    const customTags = [{ name: 'zone_a', description: 'Zone A' }];
+    const res = await MapoiApi.saveCustomTags(customTags, 'v1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/custom_tags');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ custom_tags: customTags, expected_version: 'v1' });
+    expect(res).toEqual({
+      ok: true, status: 200, conflict: false, success: true, config_version: 'v2',
+    });
+  });
+
+  it('409 (version_mismatch) を conflict: true として組み立てる', async () => {
+    mockFetch(
+      { error: 'reload required', code: 'version_mismatch', current_version: 'v2' },
+      { status: 409 },
+    );
+    const res = await MapoiApi.saveCustomTags([{ name: 'zone_a' }], 'stale');
+
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(409);
+    expect(res.conflict).toBe(true);
+    expect(res.code).toBe('version_mismatch');
   });
 });

--- a/mapoi_webui/web/js/api.js
+++ b/mapoi_webui/web/js/api.js
@@ -68,13 +68,23 @@ const MapoiApi = {
     return res.json();
   },
 
-  async saveCustomTags(customTags) {
+  /**
+   * POST /api/custom_tags (#343: #241 の楽観的競合検出を custom_tags にも展開)。
+   * 返値の形は savePois と同じ { ok, status, conflict, ...body } (#343)。
+   */
+  async saveCustomTags(customTags, expectedVersion) {
     const res = await fetch('/api/custom_tags', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ custom_tags: customTags }),
+      body: JSON.stringify({ custom_tags: customTags, expected_version: expectedVersion }),
     });
-    return res.json();
+    const body = await res.json().catch(() => ({}));
+    return {
+      ok: res.ok,
+      status: res.status,
+      conflict: res.status === 409,
+      ...body,
+    };
   },
 
   async getRoutes() {
@@ -82,13 +92,23 @@ const MapoiApi = {
     return res.json();
   },
 
-  async saveRoutes(routes) {
+  /**
+   * POST /api/routes (#343: #241 の楽観的競合検出を routes にも展開)。
+   * 返値の形は savePois と同じ { ok, status, conflict, ...body } (#343)。
+   */
+  async saveRoutes(routes, expectedVersion) {
     const res = await fetch('/api/routes', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ routes }),
+      body: JSON.stringify({ routes, expected_version: expectedVersion }),
     });
-    return res.json();
+    const body = await res.json().catch(() => ({}));
+    return {
+      ok: res.ok,
+      status: res.status,
+      conflict: res.status === 409,
+      ...body,
+    };
   },
 
   async navGoal(poiName) {

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -28,6 +28,9 @@
   // --- Tag editor state ---
   let tagDirty = false;
   let editingTags = []; // working copy of tags (both system + custom)
+  // 楽観的競合検出用 yaml ハッシュ (#241 の展開, #343)。loadTagDefinitions() で受け取り、
+  // btnSaveTags の POST 時に送り返す。
+  let tagConfigVersion = null;
   const expandedTagDescriptions = new Set();
   const tagList = document.getElementById('tag-list');
   const tagAddName = document.getElementById('tag-add-name');
@@ -139,12 +142,31 @@
     const customTags = editingTags
       .filter((t) => !t.is_system)
       .map((t) => ({ name: t.name, description: t.description }));
-    const result = await MapoiApi.saveCustomTags(customTags);
+    const result = await MapoiApi.saveCustomTags(customTags, tagConfigVersion);
+    // 409 (version_mismatch): yaml が外部で変わった (#241 の展開, #343)。
+    // poi-editor.js / route-editor.js の save() と同じ確認ダイアログ経路。
+    if (result.conflict) {
+      const shouldReload = window.confirm(
+        'The YAML file was changed outside this page.'
+        + '\nSaving now may overwrite newer changes.'
+        + '\n\n[OK] Reload the latest file. Unsaved edits will be lost.'
+        + '\n[Cancel] Keep editing. You will see this warning again on Save.'
+      );
+      if (shouldReload) {
+        setTagDirty(false);
+        await loadTagDefinitions();
+        await loadPois();
+        await loadRoutes();
+      }
+      return;
+    }
     if (result.error) {
       alert('Failed to save tags: ' + result.error);
       return;
     }
     setTagDirty(false);
+    // loadTagDefinitions() が最新 config_version も取り直すため、tagConfigVersion を
+    // ここで個別更新する必要は無い (#343)。
     await loadTagDefinitions();
   });
 
@@ -205,6 +227,8 @@
     mapViewer.setTagDefinitions(tags);
     // Update tag editor working copy
     editingTags = tags.map((t) => ({ ...t }));
+    // 楽観的競合検出 token (#241 の展開, #343)。後続の btnSaveTags で backend に送り返す。
+    tagConfigVersion = data.config_version || null;
     renderTagList();
   }
 
@@ -231,7 +255,8 @@
   // --- Load routes ---
   async function loadRoutes() {
     const data = await MapoiApi.getRoutes();
-    routeEditor.loadRoutes(data.routes || []);
+    // config_version は楽観的競合検出 token (#241 の展開, #343): backend から受け取り、save() で送り返す。
+    routeEditor.loadRoutes(data.routes || [], data.config_version);
     redrawRoutes();
     populateNavRouteSelect(routeEditor.routes);
   }
@@ -489,6 +514,15 @@
   // 409 version_mismatch 受信時の全体 reload (#241)。POI だけ再 load しても route 側
   // の参照が壊れる可能性があるため、loadTagDefinitions → loadPois → loadRoutes を一括で。
   poiEditor.onConflictReload = async () => {
+    await loadTagDefinitions();
+    await loadPois();
+    await loadRoutes();
+  };
+
+  // 409 version_mismatch 受信時の全体 reload (#241 の展開, #343)。route save 経路でも
+  // poiEditor.onConflictReload と同じ理由 (loadTagDefinitions → loadPois → loadRoutes を
+  // 一括で行い、全 working copy の参照を揃える) で同じ順序にする。
+  routeEditor.onConflictReload = async () => {
     await loadTagDefinitions();
     await loadPois();
     await loadRoutes();

--- a/mapoi_webui/web/js/route-editor.js
+++ b/mapoi_webui/web/js/route-editor.js
@@ -7,6 +7,9 @@ class RouteEditor {
     this.routes = [];
     this.originalRoutes = [];
     this.dirty = false;
+    // 楽観的競合検出用 yaml ハッシュ (#241 の展開, #343)。GET 時に backend から受け取り、
+    // Save 時に送り返す。poi-editor.js の configVersion と同じ役割。
+    this.configVersion = null;
     this.editingIndex = -1; // -1 = closed, >=0 = editing, -2 = new route
     this.selectedIndex = -1; // -1 = none selected
     this.visibleRoutes = new Set();
@@ -29,6 +32,9 @@ class RouteEditor {
     this.onLandmarkFocus = null; // callback(poiName) - fired when landmark UI previews a POI
     this.onEditFormVisibilityChange = null; // callback(isOpen)
     this.onBeforeEditStart = null; // callback(action) -> false blocks route edit/add/copy/delete
+    // 409 受信時に app.js 側で全体 reload を発火させるためのフック (#343)。
+    // poi-editor.js の onConflictReload と同じ役割。
+    this.onConflictReload = null;  // async callback() — full reload on version_mismatch
 
     // DOM references
     this.listEl = document.getElementById('route-list');
@@ -88,12 +94,14 @@ class RouteEditor {
   /**
    * Load routes from server response and reset state.
    */
-  loadRoutes(routes) {
+  loadRoutes(routes, configVersion) {
     this.routes = JSON.parse(JSON.stringify(routes));
     this.originalRoutes = JSON.parse(JSON.stringify(routes));
     this.editingIndex = -1;
     this.selectedIndex = -1;
     this.visibleRoutes = new Set(routes.map((r) => r.name));
+    // 楽観的競合検出 token (#241 の展開, #343)。後続の save() で backend に送り返す。
+    this.configVersion = configVersion || null;
     this._resetEditHistory();
     this.setDirty(false);
     this.hideForm();
@@ -837,9 +845,25 @@ class RouteEditor {
     if (!this.dirty) return;
     this.btnSaveRoutes.textContent = 'Saving...';
     try {
-      const result = await MapoiApi.saveRoutes(this.routes);
-      if (result.success) {
+      const result = await MapoiApi.saveRoutes(this.routes, this.configVersion);
+      // 409 (version_mismatch): yaml が外部 (yaml 直編集 / 他クライアント) で変わった
+      // (#241 の展開, #343)。poi-editor.js の save() と同じ確認ダイアログ経路。
+      if (result.conflict) {
+        this.btnSaveRoutes.textContent = 'Save';
+        const shouldReload = window.confirm(
+          'The YAML file was changed outside this page.'
+          + '\nSaving now may overwrite newer changes.'
+          + '\n\n[OK] Reload the latest file. Unsaved edits will be lost.'
+          + '\n[Cancel] Keep editing. You will see this warning again on Save.'
+        );
+        if (shouldReload && this.onConflictReload) {
+          await this.onConflictReload();
+        }
+        return;
+      }
+      if (result.ok && result.success) {
         this.originalRoutes = JSON.parse(JSON.stringify(this.routes));
+        if (result.config_version) this.configVersion = result.config_version;
         this.setDirty(false);
         this.btnSaveRoutes.textContent = 'Saved!';
         setTimeout(() => { this.btnSaveRoutes.textContent = 'Save'; }, 1500);


### PR DESCRIPTION
## 概要

issue #343 (公開 API 周りの小粒一貫性改善チェックリスト) の残り 2 項目を対応する。前半 5 項目は #363 で対応済み。URL separator 統一 (#340) は本 PR では触らない。

## 対応内容

1. **エラーレスポンスの機械可読 `code` フィールドを全エラーに統一**: `mapoi_webui_node.py` の全 JSON エラーレスポンス (4xx/5xx) に `code` を追加。`invalid_request` (400) / `not_found` (404) / `version_mismatch` (409, 既存不変) / `service_unavailable` (503) / `internal_error` (500)。既存の `error` (人間可読メッセージ) は維持したままの追加のみで非破壊。200+warning の `warning` フィールドは対象外。README に code 一覧表を追加。
2. **楽観的排他制御 (`expected_version`) を routes / custom_tags にも展開**: `POST /api/pois` のみ対応 (#241) だった `expected_version` 競合検出を、同じ yaml への書き込みである `POST /api/routes` `/api/custom_tags` にも展開。`GET /api/routes` `/api/tag_definitions` が `config_version` を返すようにし、対応する POST が `expected_version` を受けて不一致なら 409 + `code: version_mismatch` を返す (pois と同一契約、省略時は check skip)。frontend (route editor / tag editor) にも pois と同じ conflict 確認ダイアログ + 全体 reload ハンドリングを展開。

## 検証

- jazzy docker で `colcon build` + `colcon test` 実行、213 tests 全 green (0 errors, 0 failures, 0 skipped)
- vitest ローカル実行、80 tests 全 green (saveRoutes / saveCustomTags の conflict ハンドリングを新規 pin)
- `scripts/check_docs_consistency.py` / `check_robot_radius_drift.py` / `check_sample_yaml_consistency.py` ローカル実行、全て OK
- humble は CI 任せ、Playwright e2e も CI 任せ

Closes #343