### PR TITLE
feat(webui)!: REST URL の editor/nav 階層分離 (#340)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -118,6 +118,26 @@ Breaking changes
   ``mapoi_nav2_bridge`` are updated in this change. See
   ``docs/migration/v0.5.0.md`` (#343).
 
+* ``mapoi_webui`` REST API URL hierarchy: editor-only endpoints now live
+  under an ``/api/editor/`` prefix, separate from ``/api/nav/`` endpoints
+  that act on the running robot. ``POST /api/maps/select`` only switches
+  ``mapoi_server``'s edit-context map and does not touch Nav2 or the
+  running robot, whereas ``POST /api/nav/switch-map`` actually switches
+  the running robot's Nav2 map; the similar naming made this distinction
+  easy to miss and risked unintended map switches on a live robot (#340).
+  The remaining renames unify the URL separator convention on kebab-case
+  (#343, fifth checklist item). No compatibility alias is provided; old
+  paths now return ``404``. Rename table:
+
+  - ``POST /api/maps/select`` -> ``POST /api/editor/select-map``
+  - ``GET /api/tag_definitions`` -> ``GET /api/tag-definitions``
+  - ``POST /api/custom_tags`` -> ``POST /api/custom-tags``
+  - ``POST /api/nav/initialpose`` -> ``POST /api/nav/initial-pose``
+
+  Update any external client (curl scripts, dashboards, custom
+  frontends) pinning one of the old paths. See
+  ``docs/migration/v0.5.0.md`` for the full migration guide.
+
 Fixed
 -----
 

--- a/docs/migration/v0.5.0.md
+++ b/docs/migration/v0.5.0.md
@@ -103,3 +103,28 @@ sed -E -i \
 - `mapoi_webui` の REST API `POST /api/maps/select` を叩く外部 client: JSON response body のキーも `initial_poi_name` から `resolved_initial_poi_name` に変わります (WebUI 本体の frontend はこのキーを参照していないため追従不要でしたが、外部 client は更新が必要です)
 
 本リポジトリに含まれる `mapoi_server` (response の生成元) と `mapoi_nav2_bridge` (response の読み手) は本リリースで新フィールド名に追従済みです。
+
+## `mapoi_webui` REST API URL の editor/nav 階層分離・separator 統一 ([#340](https://github.com/shimz-robotics/mapoi/issues/340), [#343](https://github.com/shimz-robotics/mapoi/issues/343) 5項目目)
+
+`POST /api/maps/select` (`mapoi_server` の編集 context 切替、Nav2 には触れない) と `POST /api/nav/switch-map` (稼働中ロボットの Nav2 map を実際に切替える) は名称が似ているため挙動を誤推測しやすく、稼働中ロボットに対する意図しない map 切替につながりうる安全上のリスクがありました。v1.0.0 で REST API を固定する前に、editor 系の URL を `/api/editor/` 配下へ分離しました。併せて、URL の区切り文字が snake_case / 無区切りで不統一だった残り 3 件を kebab-case に統一しました (#343 の 5 項目目)。
+
+**互換 alias はありません。旧 URL は `404 Not Found` を返します。**
+
+| 旧 URL | 新 URL | 備考 |
+|---|---|---|
+| `POST /api/maps/select` | `POST /api/editor/select-map` | editor 系 (`mapoi_server` の編集 context 切替) と `POST /api/nav/switch-map` (実ロボットの map 切替) を URL 階層で峻別 |
+| `GET /api/tag_definitions` | `GET /api/tag-definitions` | separator を kebab-case に統一 |
+| `POST /api/custom_tags` | `POST /api/custom-tags` | separator を kebab-case に統一 |
+| `POST /api/nav/initialpose` | `POST /api/nav/initial-pose` | 無区切り → kebab-case |
+
+### 影響を受けるユーザー
+
+- 上記 4 endpoint のいずれかを curl / 独自 dashboard / 独自 frontend 等から直接叩いている外部 client
+- WebUI 本体 (`mapoi_webui/web/js/`) は本リリースで新 URL に追従済みのため、標準 UI の利用のみであれば影響はありません
+
+### `/api/editor/select-map` と `/api/nav/switch-map` の違い (再掲)
+
+- `/api/editor/select-map`: `mapoi_server` の編集 context (WebUI がどの地図の POI/Route/CustomTags を編集するか) を切替えるだけで、Nav2 / 実ロボットの走行地図には作用しません。単独で叩くと、server の編集 context と Nav2 の実際の走行地図が乖離した状態を作れます
+- `/api/nav/switch-map`: 稼働中ロボットの Nav2 map を実際に切替えます
+
+両者を一致させたい場合は呼び出し側が両方の endpoint を叩く必要があります。詳細は `mapoi_webui/README.md` の REST API 表 (「作用対象」列) を参照してください。

--- a/mapoi_webui/README.md
+++ b/mapoi_webui/README.md
@@ -51,7 +51,7 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 
 | サービス名 | 型 | 説明 |
 | --- | --- | --- |
-| `mapoi/request_initial_pose` | `RequestInitialPose` | `POST /api/nav/initialpose` 受信時に `mapoi_server` へ publish を依頼 (#211)。WebUI は直接 `mapoi/initialpose_poi` を publish しない |
+| `mapoi/request_initial_pose` | `RequestInitialPose` | `POST /api/nav/initial-pose` 受信時に `mapoi_server` へ publish を依頼 (#211)。WebUI は直接 `mapoi/initialpose_poi` を publish しない |
 
 #### サブスクライバー
 
@@ -68,28 +68,37 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 
 ## REST API
 
-| メソッド | エンドポイント | 説明 |
-| --- | --- | --- |
-| GET | `/api/maps` | 地図一覧と現在の地図名 |
-| GET | `/api/maps/<name>/image` | 地図画像（PNG） |
-| GET | `/api/maps/<name>/metadata` | 地図メタデータ（解像度・原点・サイズ） |
-| GET | `/api/pois` | POI 一覧 |
-| POST | `/api/pois` | POI の保存 |
-| GET | `/api/routes` | ルート一覧 |
-| POST | `/api/routes` | ルートの保存 |
-| GET | `/api/tag_definitions` | タグ定義一覧 |
-| POST | `/api/custom_tags` | カスタムタグの保存 |
-| GET | `/api/nav/status` | ナビゲーション状態・ロボット位置・`robot_radius` (m) |
-| POST | `/api/nav/goal` | POI へのゴール走行 |
-| POST | `/api/nav/route` | ルート走行の開始 |
-| POST | `/api/nav/pause` | ナビゲーションの一時停止 |
-| POST | `/api/nav/resume` | ナビゲーションの再開 |
-| POST | `/api/nav/cancel` | ナビゲーションの停止 |
-| POST | `/api/nav/initialpose` | 自己位置推定のリセット |
-| POST | `/api/nav/switch-map` | Navigation map switch。`mapoi/nav/switch_map` に map 名を publish |
-| GET | `/api/mode` | navigation 機能の検出結果 (`navigation_available`, topic subscriber 数) |
+v1.0.0 に向けて URL 階層を editor 系 (`/api/editor/*`)・nav 系 (`/api/nav/*`) に分離しています (#340)。**「作用対象」列**は各 endpoint が触れる範囲を示します:
 
-> **注意 (`POST /api/nav/*` 呼び出し側は必読)**: `mapoi/nav/*` 系 topic への publish はローカルで成功したかどうかしか分からず、navigation backend (`mapoi_nav2_bridge` 等) が実際にコマンドを受理・実行したかまでは保証できません。そのため `POST /api/nav/goal` `/route` `/pause` `/resume` `/cancel` `/initialpose` `/switch-map` は subscriber 不在等の失敗時でも HTTP `200 OK` を返し、代わりに response body の `warning` フィールドに理由を入れます (詳細は下記「REST API と server 依存」参照)。**HTTP ステータスコードだけでは失敗を検知できません** — 外部 client は必ず response body に `warning` フィールドが含まれていないか確認してください。
+- **編集 context のみ**: `mapoi_server` 内部の編集対象 (map context / YAML) を変更するだけで、稼働中の実ロボット・Nav2 には一切作用しません
+- **実ロボットに作用**: Nav2 / navigation backend (`mapoi_nav2_bridge` 等) に指示を送り、稼働中のロボットの挙動 (走行・地図切替・自己位置) を変えます
+- **読み取りのみ**: 状態取得のみで副作用はありません
+
+| メソッド | エンドポイント | 作用対象 | 説明 |
+| --- | --- | --- | --- |
+| GET | `/api/maps` | 読み取りのみ | 地図一覧と現在の地図名 |
+| GET | `/api/maps/<name>/image` | 読み取りのみ | 地図画像（PNG） |
+| GET | `/api/maps/<name>/metadata` | 読み取りのみ | 地図メタデータ（解像度・原点・サイズ） |
+| POST | `/api/editor/select-map` | 編集 context のみ (実ロボット非接触) | `mapoi_server` の編集対象地図を切替 (`select_map` service)。Nav2 / 実ロボットの走行地図には作用しない。単独で叩くと server の編集 context と Nav2 の実 map が乖離しうる (乖離を解消するのは `/api/nav/switch-map`) |
+| GET | `/api/pois` | 読み取りのみ | POI 一覧 |
+| POST | `/api/pois` | 編集 context のみ | POI の保存 |
+| GET | `/api/routes` | 読み取りのみ | ルート一覧 |
+| POST | `/api/routes` | 編集 context のみ | ルートの保存 |
+| GET | `/api/tag-definitions` | 読み取りのみ | タグ定義一覧 |
+| POST | `/api/custom-tags` | 編集 context のみ | カスタムタグの保存 |
+| GET | `/api/nav/status` | 読み取りのみ | ナビゲーション状態・ロボット位置・`robot_radius` (m) |
+| POST | `/api/nav/goal` | 実ロボットに作用 | POI へのゴール走行 |
+| POST | `/api/nav/route` | 実ロボットに作用 | ルート走行の開始 |
+| POST | `/api/nav/pause` | 実ロボットに作用 | ナビゲーションの一時停止 |
+| POST | `/api/nav/resume` | 実ロボットに作用 | ナビゲーションの再開 |
+| POST | `/api/nav/cancel` | 実ロボットに作用 | ナビゲーションの停止 |
+| POST | `/api/nav/initial-pose` | 実ロボットに作用 | 自己位置推定のリセット |
+| POST | `/api/nav/switch-map` | 実ロボットに作用 | 稼働中ロボットの Nav2 map を実際に切替える。`mapoi/nav/switch_map` に map 名を publish |
+| GET | `/api/mode` | 読み取りのみ | navigation 機能の検出結果 (`navigation_available`, topic subscriber 数) |
+
+> **`/api/editor/select-map` と `/api/nav/switch-map` の違い (必読)**: 名前が紛らわしいですが挙動は全く異なります。`/api/editor/select-map` は WebUI の編集対象 (どの地図の POI/Route/CustomTags を編集するか) を切替えるだけで、Nav2 や実ロボットの走行地図には触れません。`/api/nav/switch-map` は稼働中ロボットの Nav2 map を実際に切替えます。`/api/editor/select-map` だけを叩いた場合、server の編集 context と Nav2 の実際の走行地図が乖離した状態になり得ます — 両方を一致させたい場合は呼び出し側が両方を叩く必要があります (#340)。
+
+> **注意 (`POST /api/nav/*` 呼び出し側は必読)**: `mapoi/nav/*` 系 topic への publish はローカルで成功したかどうかしか分からず、navigation backend (`mapoi_nav2_bridge` 等) が実際にコマンドを受理・実行したかまでは保証できません。そのため `POST /api/nav/goal` `/route` `/pause` `/resume` `/cancel` `/initial-pose` `/switch-map` は subscriber 不在等の失敗時でも HTTP `200 OK` を返し、代わりに response body の `warning` フィールドに理由を入れます (詳細は下記「REST API と server 依存」参照)。**HTTP ステータスコードだけでは失敗を検知できません** — 外部 client は必ず response body に `warning` フィールドが含まれていないか確認してください。
 
 ### エラーレスポンス
 
@@ -105,7 +114,7 @@ Flask ベースの HTTP サーバーを内蔵した ROS2 ノードです。
 
 ### 楽観的競合検出 (`expected_version`)
 
-`POST /api/pois` `/api/routes` `/api/custom_tags` はいずれも同じ yaml (`mapoi_config.yaml`) への書き込みのため、共通の楽観的競合検出に対応しています (`expected_version` フィールド、`/api/pois` は #241、`/api/routes` `/api/custom_tags` への展開は #343)。対応する GET (`/api/pois` `/api/routes` `/api/tag_definitions`) が返す `config_version` (yaml 内容の sha256 ハッシュ) を POST 時に `expected_version` として送り返すと、backend が現在の yaml と比較し、不一致なら `409` + `code: version_mismatch` を返します。WebUI 経由は frontend が自動でハンドリング（確認ダイアログの上でリロード）、外部 POST (curl / 別 client) で `expected_version` 省略時は check skip のため、競合上書きを避けたい場合は呼び出し側が対応する GET の `config_version` を送り返す責任を負う。
+`POST /api/pois` `/api/routes` `/api/custom-tags` はいずれも同じ yaml (`mapoi_config.yaml`) への書き込みのため、共通の楽観的競合検出に対応しています (`expected_version` フィールド、`/api/pois` は #241、`/api/routes` `/api/custom-tags` への展開は #343)。対応する GET (`/api/pois` `/api/routes` `/api/tag-definitions`) が返す `config_version` (yaml 内容の sha256 ハッシュ) を POST 時に `expected_version` として送り返すと、backend が現在の yaml と比較し、不一致なら `409` + `code: version_mismatch` を返します。WebUI 経由は frontend が自動でハンドリング（確認ダイアログの上でリロード）、外部 POST (curl / 別 client) で `expected_version` 省略時は check skip のため、競合上書きを避けたい場合は呼び出し側が対応する GET の `config_version` を送り返す責任を負う。
 
 `config_version` は yaml ファイル全体の内容ハッシュのため、POI/Route/CustomTags のいずれかを保存すると、他 2 つの GET が返す `config_version` も変わります（同じ yaml を共有しているため意図した挙動です）。詳細仕様は実装コメント (`api_save_pois` / `api_save_routes` / `api_save_custom_tags`) / test (`test_api_save_pois_version_conflict.py`) を参照。
 
@@ -140,7 +149,7 @@ ros2 launch mapoi_webui mapoi_editor.launch.yaml maps_path:=/path/to/maps map_na
 `maps_path` 未設定時の挙動は以下の通りです:
 
 - 起動時に `maps_path parameter not set. Set it to use the web editor.` を `WARN` ログ出力し、そのまま起動を継続する
-- **editor 機能 (地図一覧・地図画像・POI/Route/CustomTags の閲覧・編集) は無効になる**: `get_maps_list()` は `maps_path` が空 (または存在しないディレクトリ) の場合に空リストを返すため、`GET /api/maps` は `maps: []` を返し、`GET /api/maps/<name>/image` `/metadata` や POI/Route/CustomTags 系の endpoint (`GET`/`POST /api/pois` `/api/routes` `/api/custom_tags`) は対象 YAML/PNG が見つからず `404 Not Found` を返す
+- **editor 機能 (地図一覧・地図画像・POI/Route/CustomTags の閲覧・編集) は無効になる**: `get_maps_list()` は `maps_path` が空 (または存在しないディレクトリ) の場合に空リストを返すため、`GET /api/maps` は `maps: []` を返し、`GET /api/maps/<name>/image` `/metadata` や POI/Route/CustomTags 系の endpoint (`GET`/`POST /api/pois` `/api/routes` `/api/custom-tags`) は対象 YAML/PNG が見つからず `404 Not Found` を返す
 - **nav 操作系 (`/api/nav/*`, `/api/mode`, `GET /api/nav/status`) は `maps_path` に依存せず動作する**: これらは `mapoi/nav/*` topic の publish / subscribe や `mapoi_server` の service 呼び出しのみで完結するため、`maps_path` 未設定でも通常通り使える
 
 したがって、`maps_path` を設定せずに起動した webui は「ナビゲーション操作専用の後付け UI」として機能し、地図編集機能だけが無効になります。
@@ -153,18 +162,20 @@ ros2 launch mapoi_webui mapoi_editor.launch.yaml maps_path:=/path/to/maps map_na
 |---|---|---|
 | `GET /api/maps` `/maps/<name>/image\|metadata` | 不要 | `maps_path` を直 ls / YAML/PNG 直読み |
 | `GET /api/pois` `/api/routes` | 不要 | YAML 直読み |
-| `POST /api/pois` `/api/routes` `/api/custom_tags` | **必要** | YAML 書き込み後に `mapoi/reload_map_info` service を呼ぶ |
-| `GET /api/tag_definitions` | **必要** | `mapoi/get_tag_definitions` service 経由 |
+| `POST /api/editor/select-map` | **必要 (`mapoi_server` の `select_map` service)** | 編集対象地図の切替のみ。Nav2 / 実ロボットには作用しない |
+| `POST /api/pois` `/api/routes` `/api/custom-tags` | **必要** | YAML 書き込み後に `mapoi/reload_map_info` service を呼ぶ |
+| `GET /api/tag-definitions` | **必要** | `mapoi/get_tag_definitions` service 経由 |
 | `POST /api/nav/{goal,route,cancel,pause,resume}` | **必要 (mapoi_nav2_bridge)** | publisher → mapoi_nav2_bridge が listener、subscriber 0 件なら warning を返す |
-| `POST /api/nav/initialpose` | **必要 (`mapoi_server` の `mapoi/request_initial_pose` service)** | `mapoi/request_initial_pose` service 経由で `mapoi_server` が `mapoi/initialpose_poi` を publish (#211)。service 不在時は 503。さらに `mapoi/initialpose_poi` に subscriber (`mapoi_amcl_localization_bridge` 等) が居ないと initial pose は配信されず warning を返す |
-| `POST /api/nav/switch-map` | **必要 (mapoi_nav2_bridge 等)** | `mapoi/nav/switch_map` publisher → navigation backend が listener、subscriber 0 件なら warning を返す |
+| `POST /api/nav/initial-pose` | **必要 (`mapoi_server` の `mapoi/request_initial_pose` service)** | `mapoi/request_initial_pose` service 経由で `mapoi_server` が `mapoi/initialpose_poi` を publish (#211)。service 不在時は 503。さらに `mapoi/initialpose_poi` に subscriber (`mapoi_amcl_localization_bridge` 等) が居ないと initial pose は配信されず warning を返す |
+| `POST /api/nav/switch-map` | **必要 (mapoi_nav2_bridge 等)** | 稼働中ロボットの Nav2 map を実際に切替える。`mapoi/nav/switch_map` publisher → navigation backend が listener、subscriber 0 件なら warning を返す |
 | `GET /api/nav/status` | 不要 (subscriber 経由で受信値返却) | mapoi_nav2_bridge がいなければ default 値 |
 | `GET /api/mode` | 不要 | command topic の subscriber 数から best-effort で検出 |
 
 server / mapoi_nav2_bridge 不在時の挙動 (endpoint カテゴリ別):
-- `GET /api/tag_definitions`: `503 Service Unavailable` (service 必須、unavailable / timeout 時)
-- `POST /api/pois` / `/api/routes` / `/api/custom_tags`: `200 OK` + `warning` フィールド (YAML 書き込み自体は成功するため、`mapoi/reload_map_info` の unavailable / timeout / failure は warning として通知)
-- `POST /api/nav/{goal,route,cancel,pause,resume}` / `/api/nav/initialpose` / `/api/nav/switch-map`: `200 OK` + `warning` フィールド (publish 自体は成功扱い、subscriber 不在を best-effort で検出して通知)
+- `POST /api/editor/select-map`: `503 Service Unavailable` (service 必須、unavailable / timeout 時)
+- `GET /api/tag-definitions`: `503 Service Unavailable` (service 必須、unavailable / timeout 時)
+- `POST /api/pois` / `/api/routes` / `/api/custom-tags`: `200 OK` + `warning` フィールド (YAML 書き込み自体は成功するため、`mapoi/reload_map_info` の unavailable / timeout / failure は warning として通知)
+- `POST /api/nav/{goal,route,cancel,pause,resume}` / `/api/nav/initial-pose` / `/api/nav/switch-map`: `200 OK` + `warning` フィールド (publish 自体は成功扱い、subscriber 不在を best-effort で検出して通知)
 
 ## 開発者規約
 

--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -668,7 +668,7 @@ class MapoiWebNode(Node):
                 'height': meta['height'],
             })
 
-        @app.route('/api/maps/select', methods=['POST'])
+        @app.route('/api/editor/select-map', methods=['POST'])
         def api_select_map():
             data = request.get_json()
             if not data or 'map_name' not in data:
@@ -781,7 +781,7 @@ class MapoiWebNode(Node):
                 node.get_logger().error(f'Failed to save POIs: {e}')
                 return jsonify({'error': str(e), 'code': 'internal_error'}), 500
 
-        @app.route('/api/tag_definitions')
+        @app.route('/api/tag-definitions')
         def api_tag_definitions():
             response = node._call_service_sync(
                 node.tag_defs_client_, GetTagDefinitions.Request(), 'mapoi/get_tag_definitions')
@@ -794,7 +794,7 @@ class MapoiWebNode(Node):
                 {'name': d.name, 'description': d.description, 'is_system': d.is_system}
                 for d in response.definitions
             ]
-            # custom_tags は pois/routes と同じ yaml に書き込むため、POST /api/custom_tags の
+            # custom_tags は pois/routes と同じ yaml に書き込むため、POST /api/custom-tags の
             # 楽観的競合検出 (#241 の展開, #343) 用に config_version を同梱する。config 不在
             # (maps_path 未設定等) では compute_config_version が None を返し、POST 側は
             # None を expected_version 一致対象から外して check skip 相当に倒す。
@@ -803,7 +803,7 @@ class MapoiWebNode(Node):
                 'config_version': compute_config_version(node.get_config_path()),
             })
 
-        @app.route('/api/custom_tags', methods=['POST'])
+        @app.route('/api/custom-tags', methods=['POST'])
         def api_save_custom_tags():
             data = request.get_json()
             if data is None or 'custom_tags' not in data:
@@ -942,7 +942,7 @@ class MapoiWebNode(Node):
                 'navigation': node.get_navigation_capabilities(),
             })
 
-        @app.route('/api/nav/initialpose', methods=['POST'])
+        @app.route('/api/nav/initial-pose', methods=['POST'])
         def api_nav_initialpose():
             data = request.get_json()
             if not data or 'poi_name' not in data:

--- a/mapoi_webui/test/test_api_save_pois_version_conflict.py
+++ b/mapoi_webui/test/test_api_save_pois_version_conflict.py
@@ -1,4 +1,4 @@
-"""Flask endpoint level test for POST /api/pois `/api/routes` `/api/custom_tags` の
+"""Flask endpoint level test for POST /api/pois `/api/routes` `/api/custom-tags` の
 楽観的競合検出 (#241 / #246、routes・custom_tags への展開は #343)。
 
 `test_yaml_handler_version.py` は `compute_config_version` 単体の決定性しか pin して
@@ -11,7 +11,7 @@
 ROS 2 Node を本物で起動すると DDS / service / publisher が絡んで test 重量級になるため、
 `create_flask_app` を duck-typed `FakeNode` に bind して呼び出す (= `MapoiWebNode.create_flask_app`
 は `self` を `node = self` で local capture するだけで、`/api/pois` `/api/routes`
-`/api/custom_tags` の経路はいずれも `node.get_config_path()` / `node.call_reload_map_info()` /
+`/api/custom-tags` の経路はいずれも `node.get_config_path()` / `node.call_reload_map_info()` /
 `node.get_logger()` の 3 メソッドだけに依存する、pois/routes/custom_tags で fixture 構成が
 共通なため `docs/testing-policy.md` 3 節に従い同一ファイルにクラスを追加している)。他 endpoint
 の closures は登録時に評価されないため `FakeNode` に該当 attr が無くても本 test は影響を受けない。
@@ -297,7 +297,7 @@ def _valid_custom_tags_payload():
 
 
 class TestApiSaveCustomTagsVersionConflict(unittest.TestCase):
-    """`POST /api/custom_tags` の楽観的競合検出 (#241 の展開, #343)。
+    """`POST /api/custom-tags` の楽観的競合検出 (#241 の展開, #343)。
 
     `api_save_pois` と同じ `compute_config_version` / `expected_version` 契約を
     `api_save_custom_tags` にも適用したことを pin する。`_FakeNode` は
@@ -319,7 +319,7 @@ class TestApiSaveCustomTagsVersionConflict(unittest.TestCase):
 
     def test_save_with_matching_expected_version_returns_200_with_new_version(self):
         v_before = self._current_version()
-        resp = self.client.post('/api/custom_tags', json={
+        resp = self.client.post('/api/custom-tags', json={
             'custom_tags': _valid_custom_tags_payload(),
             'expected_version': v_before,
         })
@@ -340,7 +340,7 @@ class TestApiSaveCustomTagsVersionConflict(unittest.TestCase):
         stale_version = 'c' * 64
         self.assertNotEqual(stale_version, v_before)
 
-        resp = self.client.post('/api/custom_tags', json={
+        resp = self.client.post('/api/custom-tags', json={
             'custom_tags': _valid_custom_tags_payload(),
             'expected_version': stale_version,
         })
@@ -356,7 +356,7 @@ class TestApiSaveCustomTagsVersionConflict(unittest.TestCase):
         """`expected_version` 省略時は旧クライアント / curl 後方互換で check skip する。"""
         v_before = self._current_version()
         resp = self.client.post(
-            '/api/custom_tags', json={'custom_tags': _valid_custom_tags_payload()})
+            '/api/custom-tags', json={'custom_tags': _valid_custom_tags_payload()})
         self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
         body = resp.get_json()
         self.assertTrue(body.get('success'))

--- a/mapoi_webui/test/test_api_select_map.py
+++ b/mapoi_webui/test/test_api_select_map.py
@@ -1,4 +1,4 @@
-"""Flask endpoint level test for `POST /api/maps/select` (#343).
+"""Flask endpoint level test for `POST /api/editor/select-map` (#343, URL rename #340).
 
 SelectMap.srv の response フィールド rename (`initial_poi_name` →
 `resolved_initial_poi_name`, #343) を REST JSON key レベルでも pin する。
@@ -52,7 +52,7 @@ class TestApiSelectMap(unittest.TestCase):
         node = _FakeNode(service_response=SimpleNamespace(
             success=True, error_message='', config_path='/maps/m/mapoi_config.yaml',
             resolved_initial_poi_name='poi_start'))
-        resp = _client(node).post('/api/maps/select', json={'map_name': 'm'})
+        resp = _client(node).post('/api/editor/select-map', json={'map_name': 'm'})
         self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
         payload = resp.get_json()
         self.assertEqual(payload['resolved_initial_poi_name'], 'poi_start')
@@ -63,7 +63,7 @@ class TestApiSelectMap(unittest.TestCase):
         node = _FakeNode(service_response=SimpleNamespace(
             success=False, error_message='boom', config_path='',
             resolved_initial_poi_name=''))
-        resp = _client(node).post('/api/maps/select', json={'map_name': 'm'})
+        resp = _client(node).post('/api/editor/select-map', json={'map_name': 'm'})
         self.assertEqual(resp.status_code, 400)
         body = resp.get_json()
         self.assertEqual(body['error'], 'boom')
@@ -73,13 +73,13 @@ class TestApiSelectMap(unittest.TestCase):
 
     def test_service_unavailable_returns_503(self):
         node = _FakeNode(service_response=None)
-        resp = _client(node).post('/api/maps/select', json={'map_name': 'm'})
+        resp = _client(node).post('/api/editor/select-map', json={'map_name': 'm'})
         self.assertEqual(resp.status_code, 503)
         self.assertEqual(resp.get_json().get('code'), 'service_unavailable')
 
     def test_missing_map_name_returns_400(self):
         node = _FakeNode(service_response=None)
-        resp = _client(node).post('/api/maps/select', json={})
+        resp = _client(node).post('/api/editor/select-map', json={})
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.get_json().get('code'), 'invalid_request')
 

--- a/mapoi_webui/test/test_api_select_map.py
+++ b/mapoi_webui/test/test_api_select_map.py
@@ -45,6 +45,29 @@ def _client(node):
     return app.test_client()
 
 
+class TestApiUrlRouting(unittest.TestCase):
+    """#340 の URL rename (editor/nav 階層分離 + kebab-case 統一) を routing 表で pin する。
+
+    url_map の検査は handler closure を評価しないため、最小 FakeNode で全 endpoint の
+    登録有無を一括確認できる。互換 alias なし (旧 URL は 404) が仕様の中心なので、
+    新 URL の存在だけでなく**旧 URL の不在**も assert する (alias の意図しない復活防止)。
+    """
+
+    _RENAMES = {
+        '/api/maps/select': '/api/editor/select-map',
+        '/api/tag_definitions': '/api/tag-definitions',
+        '/api/custom_tags': '/api/custom-tags',
+        '/api/nav/initialpose': '/api/nav/initial-pose',
+    }
+
+    def test_renamed_urls_registered_and_old_urls_gone(self):
+        app = MapoiWebNode.create_flask_app(_FakeNode(service_response=None))
+        rules = {r.rule for r in app.url_map.iter_rules()}
+        for old, new in self._RENAMES.items():
+            self.assertIn(new, rules, f'renamed URL {new} not registered')
+            self.assertNotIn(old, rules, f'old URL {old} still registered (#340 no-alias policy)')
+
+
 class TestApiSelectMap(unittest.TestCase):
 
     def test_success_returns_resolved_initial_poi_name_key(self):

--- a/mapoi_webui/tests/web/api-nav.test.js
+++ b/mapoi_webui/tests/web/api-nav.test.js
@@ -121,3 +121,28 @@ describe('MapoiApi.saveCustomTags', () => {
     expect(res.code).toBe('version_mismatch');
   });
 });
+
+// #340 で rename した URL の pin (editor/nav 階層分離 + kebab-case 統一)。
+// backend 側は test_api_select_map.py の url_map 検査が旧 URL 不在まで pin する。
+// ここでは frontend の fetch 先が誤 revert しないことだけを固定する。
+describe('MapoiApi renamed URLs (#340)', () => {
+  it('selectMap は POST /api/editor/select-map を叩く', async () => {
+    const fetchMock = mockFetch({ success: true });
+    await MapoiApi.selectMap('m');
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/editor/select-map');
+    expect(fetchMock.mock.calls[0][1].method).toBe('POST');
+  });
+
+  it('getTagDefinitions は GET /api/tag-definitions を叩く', async () => {
+    const fetchMock = mockFetch({ tags: [], config_version: 'v1' });
+    await MapoiApi.getTagDefinitions();
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/tag-definitions');
+  });
+
+  it('navInitialPose は POST /api/nav/initial-pose を叩く', async () => {
+    const fetchMock = mockFetch({ success: true });
+    await MapoiApi.navInitialPose('p1');
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/nav/initial-pose');
+    expect(fetchMock.mock.calls[0][1].method).toBe('POST');
+  });
+});

--- a/mapoi_webui/tests/web/api-nav.test.js
+++ b/mapoi_webui/tests/web/api-nav.test.js
@@ -93,14 +93,14 @@ describe('MapoiApi.saveRoutes', () => {
 });
 
 describe('MapoiApi.saveCustomTags', () => {
-  it('POST /api/custom_tags に custom_tags と expected_version を JSON body で送る', async () => {
+  it('POST /api/custom-tags に custom_tags と expected_version を JSON body で送る', async () => {
     const fetchMock = mockFetch({ success: true, config_version: 'v2' });
     const customTags = [{ name: 'zone_a', description: 'Zone A' }];
     const res = await MapoiApi.saveCustomTags(customTags, 'v1');
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, opts] = fetchMock.mock.calls[0];
-    expect(url).toBe('/api/custom_tags');
+    expect(url).toBe('/api/custom-tags');
     expect(opts.method).toBe('POST');
     expect(JSON.parse(opts.body)).toEqual({ custom_tags: customTags, expected_version: 'v1' });
     expect(res).toEqual({

--- a/mapoi_webui/tests/web/e2e/server/mock_server.py
+++ b/mapoi_webui/tests/web/e2e/server/mock_server.py
@@ -8,7 +8,7 @@ rclpy / mapoi_interfaces を要し CI が重く、フィクスチャも制御で
 
 - 静的: `/` -> web/index.html, `/css/<f>` -> web/css/<f>, `/js/<f>` -> web/js/<f>
 - API GET: /api/maps, /api/maps/<n>/metadata, /api/maps/<n>/image (動的生成 PNG),
-           /api/pois, /api/routes, /api/tag_definitions, /api/nav/status, /api/mode
+           /api/pois, /api/routes, /api/tag-definitions, /api/nav/status, /api/mode
 - API POST: /api/pois ほか -> {"success": true, ...} (テストは save を踏まないが契約上用意)
 - SSE: /api/events -> text/event-stream を張りっぱなしにし keepalive (フロントの
        EventSource が onerror で再接続を繰り返さないように 200 を返し続ける)
@@ -179,7 +179,7 @@ class Handler(BaseHTTPRequestHandler):
         if path == "/api/routes":
             self._send_json({"routes": STATE["routes"], "map_name": STATE["current_map"]})
             return
-        if path == "/api/tag_definitions":
+        if path == "/api/tag-definitions":
             self._send_json({"tags": STATE["tags"]})
             return
         if path == "/api/nav/status":
@@ -202,7 +202,7 @@ class Handler(BaseHTTPRequestHandler):
         if path == "/api/pois":
             self._send_json({"success": True, "config_version": STATE["config_version"]})
             return
-        # routes / custom_tags / maps/select / nav/* など一律 success
+        # routes / custom-tags / editor/select-map / nav/* など一律 success
         self._send_json({"success": True})
 
 

--- a/mapoi_webui/web/js/api.js
+++ b/mapoi_webui/web/js/api.js
@@ -17,7 +17,7 @@ const MapoiApi = {
   },
 
   async selectMap(mapName) {
-    const res = await fetch('/api/maps/select', {
+    const res = await fetch('/api/editor/select-map', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ map_name: mapName }),
@@ -64,16 +64,16 @@ const MapoiApi = {
   },
 
   async getTagDefinitions() {
-    const res = await fetch('/api/tag_definitions');
+    const res = await fetch('/api/tag-definitions');
     return res.json();
   },
 
   /**
-   * POST /api/custom_tags (#343: #241 の楽観的競合検出を custom_tags にも展開)。
+   * POST /api/custom-tags (#343: #241 の楽観的競合検出を custom_tags にも展開)。
    * 返値の形は savePois と同じ { ok, status, conflict, ...body } (#343)。
    */
   async saveCustomTags(customTags, expectedVersion) {
-    const res = await fetch('/api/custom_tags', {
+    const res = await fetch('/api/custom-tags', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ custom_tags: customTags, expected_version: expectedVersion }),
@@ -145,7 +145,7 @@ const MapoiApi = {
   },
 
   async navInitialPose(poiName) {
-    const res = await fetch('/api/nav/initialpose', {
+    const res = await fetch('/api/nav/initial-pose', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ poi_name: poiName }),


### PR DESCRIPTION
## 背景

`POST /api/maps/select` (mapoi_server の編集 context 切替、Nav2 非接触) と
`POST /api/nav/switch-map` (稼働中ロボットの Nav2 map を実際に切替える) は
名称が似ているため挙動を誤推測しやすく、稼働中ロボットに対する意図しない
map 切替、あるいは「切替わったはず」という誤認につながりうる、安全に
関わる誤用リスクがあった。また `/api/maps/select` を単独で叩くと server
の編集 context と Nav2 の実際の map が乖離した状態を作れる点も自明でない。

v1.0.0 で REST API を固定する前に、editor 系と nav 系の URL 階層を分離
(breaking: URL rename、互換 alias なし)。併せて URL separator が
snake_case / 無区切りで不統一だった残り 3 件を kebab-case に統一
(#343 チェックリスト 5 項目目)。

## rename 一覧 (この 4 つのみ)

| 旧 | 新 |
|---|---|
| `POST /api/maps/select` | `POST /api/editor/select-map` |
| `GET /api/tag_definitions` | `GET /api/tag-definitions` |
| `POST /api/custom_tags` | `POST /api/custom-tags` |
| `POST /api/nav/initialpose` | `POST /api/nav/initial-pose` |

追従: `mapoi_webui_node.py` の `@app.route` / `web/js/api.js` の fetch URL /
pytest (`test_api_select_map.py`, `test_api_save_pois_version_conflict.py`) /
vitest (`api-nav.test.js`) / Playwright e2e mock server
(`e2e/server/mock_server.py`)。e2e spec 側は URL 直書きなし (grep で確認済み)。

## README 再構成

`mapoi_webui/README.md` の REST API 表に **「作用対象」列**を追加し、各
endpoint を「編集 context のみ (実ロボット非接触)」/「実ロボットに作用」/
「読み取りのみ」で分類。特に `/api/editor/select-map`
(mapoi_server の編集 context 切替のみ、Nav2 / 実ロボットには作用しない。
単独で叩くと server context と Nav2 実 map が乖離しうる) と
`/api/nav/switch-map` (稼働中ロボットの Nav2 map を実際に切替える) の
違いを表の下に注意書きとして明記。これまで REST API 表に
`/api/maps/select` (現 `/api/editor/select-map`) 自体が抜けていたため
新規追加も兼ねる。

`CHANGELOG.rst` Unreleased の Breaking changes、`docs/migration/v0.5.0.md`
にも同内容のセクションを追加 (URL 対応表 + 互換 alias なし・旧 URL は 404)。

## 検証結果

- jazzy docker: `colcon build` 成功、`colcon test` 214 tests, 0 errors, 0 failures, 0 skipped (baseline と一致)
- vitest (`rtk proxy npx vitest run` で raw 実行): 8 files / 80 tests 全 pass
- consistency check 3 本 (`check_robot_radius_drift.py` / `check_sample_yaml_consistency.py` / `check_docs_consistency.py`): 全 OK
- Playwright e2e: ローカル未実行 (chromium 未インストール、CI に委任)。mock_server.py と e2e spec の URL 追従漏れが無いことは repo 全体 grep で確認済み

Closes #340