### PR TITLE
fix(webui): SSE reload が dirty なタブの未保存編集を無警告破棄するのを guard (#373)

### DIFF
--- a/mapoi_webui/tests/web/reload-guard.test.js
+++ b/mapoi_webui/tests/web/reload-guard.test.js
@@ -67,6 +67,12 @@ describe('buildReloadConfirmMessage', () => {
     expect(msg).toContain('[OK]');
     expect(msg).toContain('[Cancel]');
   });
+
+  it('says "edits in progress", not "unsaved edits" (open form は未 dirty でも blocker)', () => {
+    const msg = guard.buildReloadConfirmMessage(['POI']);
+    expect(msg).toContain('edits in progress');
+    expect(msg).not.toContain('unsaved edits');
+  });
 });
 
 // 編集続行 (Cancel) を選んで reload が保留されている間、poiEditor.configVersion は

--- a/mapoi_webui/tests/web/reload-guard.test.js
+++ b/mapoi_webui/tests/web/reload-guard.test.js
@@ -1,0 +1,117 @@
+// vitest unit tests for the SSE config_changed reload dirty guard (#373).
+//
+// 対象: MapoiReloadGuard.{collectReloadBlockers, decideReloadAction, buildReloadConfirmMessage}
+//
+// テスト方針: 「未保存編集・undo 履歴の無警告破棄」の防止は編集ロストに直結する致命核。
+//   判定を DOM 非依存の pure モジュール (reload-guard.js) に切り出してここで厚く pin し、
+//   app.js 側の配線 (SSE handler / debounce / 再開 hook) は手動 / e2e に委ねる。
+//   あわせて「編集続行 (Cancel) 選択後の Save が #343 の 409 安全網 (conflict ダイアログ)
+//   に落ちる」連鎖を thin instance の PoiEditor.save() で pin する
+//   (poi-editor-history-dirty.test.js と同じ constructor 非経由パターン)。
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as guard from '../../web/js/reload-guard.js';
+import PoiEditor from '../../web/js/poi-editor.js';
+
+const CLEAN_STATE = {
+  poiDirty: false,
+  routeDirty: false,
+  tagDirty: false,
+  poiFormOpen: false,
+  routeFormOpen: false,
+};
+
+describe('collectReloadBlockers', () => {
+  it('returns no blockers when every editor is clean and closed', () => {
+    expect(guard.collectReloadBlockers(CLEAN_STATE)).toEqual([]);
+  });
+
+  it('collects each dirty editor as a blocker', () => {
+    expect(guard.collectReloadBlockers({ ...CLEAN_STATE, poiDirty: true, tagDirty: true }))
+      .toEqual(['POI', 'Tag']);
+    expect(guard.collectReloadBlockers({ ...CLEAN_STATE, routeDirty: true }))
+      .toEqual(['Route']);
+  });
+
+  it('treats an open edit form as a blocker even when not dirty yet', () => {
+    // form 内の入力は [OK] を押すまで dirty にならないが、reload は form を閉じて
+    // 入力を失わせる (#334 の loadRoutes guard と同じ扱い)。
+    expect(guard.collectReloadBlockers({ ...CLEAN_STATE, poiFormOpen: true }))
+      .toEqual(['POI']);
+    expect(guard.collectReloadBlockers({ ...CLEAN_STATE, routeFormOpen: true }))
+      .toEqual(['Route']);
+  });
+});
+
+describe('decideReloadAction', () => {
+  it('reloads immediately when there is no blocker', () => {
+    expect(guard.decideReloadAction([], false)).toBe('reload');
+  });
+
+  it('resumes a deferred reload once all blockers are gone', () => {
+    expect(guard.decideReloadAction([], true)).toBe('reload');
+  });
+
+  it('prompts on the first config_changed while blockers exist', () => {
+    expect(guard.decideReloadAction(['POI'], false)).toBe('prompt');
+  });
+
+  it('holds silently (no repeated prompt) after the user chose to keep editing', () => {
+    expect(guard.decideReloadAction(['POI'], true)).toBe('hold');
+  });
+});
+
+describe('buildReloadConfirmMessage', () => {
+  it('lists the blocked editors and offers both choices', () => {
+    const msg = guard.buildReloadConfirmMessage(['POI', 'Route']);
+    expect(msg).toContain('POI, Route');
+    expect(msg).toContain('[OK]');
+    expect(msg).toContain('[Cancel]');
+  });
+});
+
+// 編集続行 (Cancel) を選んで reload が保留されている間、poiEditor.configVersion は
+// 外部 save 前の古い token のまま残る。その状態での Save が #343 の 409 安全網に
+// 落ちる連鎖 (古い token 送信 → conflict → ダイアログ → 続行なら working copy 無傷)。
+describe('keep-editing falls into the #343 conflict net on save', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function makeDirtyEditor() {
+    const editor = Object.create(PoiEditor.prototype);
+    editor.pois = [{ name: 'edited', pose: { x: 1, y: 0, yaw: 0 } }];
+    editor.dirty = true;
+    editor.configVersion = 'stale-token-before-external-save';
+    editor.btnSave = {};
+    editor.setDirty = vi.fn((isDirty) => { editor.dirty = isDirty; });
+    editor.onConflictReload = vi.fn();
+    return editor;
+  }
+
+  it('sends the stale version token, gets 409, and keeps edits on Cancel', async () => {
+    const editor = makeDirtyEditor();
+    const savePois = vi.fn(async () => ({ ok: false, status: 409, conflict: true }));
+    const confirm = vi.fn(() => false); // 409 ダイアログでも編集続行
+    vi.stubGlobal('MapoiApi', { savePois });
+    vi.stubGlobal('window', { confirm });
+
+    await editor.save();
+
+    expect(savePois).toHaveBeenCalledWith(editor.pois, 'stale-token-before-external-save');
+    expect(confirm).toHaveBeenCalled();
+    expect(editor.onConflictReload).not.toHaveBeenCalled();
+    expect(editor.dirty).toBe(true);
+  });
+
+  it('runs the full reload via onConflictReload when the user accepts the dialog', async () => {
+    const editor = makeDirtyEditor();
+    vi.stubGlobal('MapoiApi', {
+      savePois: vi.fn(async () => ({ ok: false, status: 409, conflict: true })),
+    });
+    vi.stubGlobal('window', { confirm: vi.fn(() => true) });
+
+    await editor.save();
+
+    expect(editor.onConflictReload).toHaveBeenCalled();
+  });
+});

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -356,6 +356,9 @@
   <!-- toast.js は MapoiToast を window に attach する auto-dismiss 通知 helper (#354)。
        app.js の SSE ハンドラより前に読み込む。 -->
   <script src="/js/toast.js"></script>
+  <!-- reload-guard.js は MapoiReloadGuard を window に attach する pure helper 群 (#373)。
+       app.js の SSE ハンドラより前に読み込む (config_changed reload の dirty guard 判定)。 -->
+  <script src="/js/reload-guard.js"></script>
   <!-- tag-editor.js は TagEditor クラス (タグ定義エディタ、#346)。app.js が `new TagEditor()` する
        ため、app.js より前に読み込む。 -->
   <script src="/js/tag-editor.js"></script>

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -25,6 +25,17 @@
   // ナビゲーション/監視に対して「たまに行う設定変更」なので既定はロック (安全側)。
   // リロードで再度ロックへ戻り、解除状態は永続化しない。
   let poiPositionLocked = true;
+  // SSE config_changed reload の debounce timer と dirty guard の保留 state (#373)。
+  // 保留 (deferred) = 「blocker (未保存編集 / 開いている edit form) があり、ユーザーが
+  // 編集続行 (Cancel) を選んだ」状態。blocker 解消時に保留分の reload を再開する。
+  // in-flight/queued は reload 実行中に届いた次の config_changed の扱い: dirty クリアが
+  // fetch 完了後になるため、実行中に再判定すると直後に同じ prompt を重ねて出してしまう。
+  // 実行中は queue に積み、完了後に 1 回だけ再判定する。
+  // 初期 load 中の onDirtyChange からも参照されるため IIFE 冒頭で宣言する。
+  let configChangedTimer = null;
+  let configReloadDeferred = false;
+  let configReloadInFlight = false;
+  let configReloadQueued = false;
 
   // --- Tag editor (tag-editor.js に切り出し、#346) ---
   // save 成功 / discard 後は tag 定義の再取得のみ、409 確認後は全体 reload
@@ -35,6 +46,9 @@
     await loadTagDefinitions();
     await loadPois();
     await loadRoutes();
+  };
+  tagEditor.onDirtyChange = (isDirty) => {
+    if (!isDirty) maybeResumeDeferredConfigReload();
   };
 
   // --- Load maps list ---
@@ -357,6 +371,7 @@
           routeEditor.populateLandmarkSelect();
         }
       }
+      maybeResumeDeferredConfigReload();
     }
   };
 
@@ -479,6 +494,7 @@
       // populate で options が rebuild されるが、選択中なら value を再同期して
       // ユーザーの選択 state を保持する。
       syncNavRouteSelect();
+      maybeResumeDeferredConfigReload();
     }
   };
 
@@ -843,11 +859,14 @@
     if (isOpen) activateSidebarFocus('poi');
     else restoreSidebarFocus('poi');
     updateMapLayerPriority();
+    // edit form open は dirty と独立した reload blocker (#373)。close 時に保留分を再開判定。
+    if (!isOpen) maybeResumeDeferredConfigReload();
   };
   routeEditor.onEditFormVisibilityChange = (isOpen) => {
     if (isOpen) activateSidebarFocus('route');
     else restoreSidebarFocus('route');
     updateMapLayerPriority();
+    if (!isOpen) maybeResumeDeferredConfigReload();
   };
 
   // --- Initialize ---
@@ -859,14 +878,52 @@
   // なるのを回避)。mapoi_webui_node が mapoi/config_path topic 受信時に push する。
   // EventSource は browser が自動 reconnect するので最初の setup のみ。
   // 短時間のバースト時は 200ms にまとめて 1 回だけ fetch する debounce (#173 Round 1 medium)。
-  let configChangedTimer = null;
+  // 未保存編集や開いている edit form があるうちは黙って loadMaps() せず、conflict
+  // ダイアログ相当の選択 (最新読込 or 編集続行) を挟む (#373)。判定は reload-guard.js。
   function scheduleConfigChangedReload() {
     if (configChangedTimer) clearTimeout(configChangedTimer);
     configChangedTimer = setTimeout(() => {
       configChangedTimer = null;
+      if (configReloadInFlight) {
+        configReloadQueued = true;
+        return;
+      }
+      const blockers = MapoiReloadGuard.collectReloadBlockers({
+        poiDirty: poiEditor.dirty,
+        routeDirty: routeEditor.dirty,
+        tagDirty: tagEditor.dirty,
+        poiFormOpen: poiEditor.editingIndex !== -1,
+        routeFormOpen: routeEditor.editingIndex !== -1,
+      });
+      const action = MapoiReloadGuard.decideReloadAction(blockers, configReloadDeferred);
+      if (action === 'hold') return;
+      if (action === 'prompt'
+          && !window.confirm(MapoiReloadGuard.buildReloadConfirmMessage(blockers))) {
+        // 編集続行: reload を保留。configVersion が古いまま残るので、後続の Save は
+        // #343 の 409 安全網 (version_mismatch conflict ダイアログ) に落ちる。
+        configReloadDeferred = true;
+        return;
+      }
+      configReloadDeferred = false;
+      configReloadInFlight = true;
       loadMaps()
-        .catch((err) => console.error('SSE reload failed:', err));
+        .catch((err) => console.error('SSE reload failed:', err))
+        .finally(() => {
+          configReloadInFlight = false;
+          if (configReloadQueued) {
+            configReloadQueued = false;
+            scheduleConfigChangedReload();
+          }
+        });
     }, 200);
+  }
+
+  // 保留中 reload の再開点 (#373)。blocker になり得る state の解消時 (dirty クリア /
+  // edit form close) に呼ぶ。判定は scheduleConfigChangedReload の decide に集約して
+  // いるので、blocker が残っていれば hold のまま、全て解消済みなら reload が走る。
+  function maybeResumeDeferredConfigReload() {
+    if (!configReloadDeferred) return;
+    scheduleConfigChangedReload();
   }
 
   const evtSrc = new EventSource('/api/events');

--- a/mapoi_webui/web/js/reload-guard.js
+++ b/mapoi_webui/web/js/reload-guard.js
@@ -1,0 +1,90 @@
+/**
+ * Pure decision helpers guarding the SSE config_changed full reload (#373).
+ *
+ * app.js の scheduleConfigChangedReload() → loadMaps() は全 working copy
+ * (POI / route / tag) をサーバ最新で置き換える。dirty な editor や開いている
+ * edit form がある時に黙って走ると、未保存編集・undo 履歴を無警告で破棄する。
+ * 「reload を保留して conflict ダイアログ相当の選択を出す」ための判定を
+ * この pure モジュールに集約し、単体テスト
+ * (mapoi_webui/tests/web/reload-guard.test.js) で回帰検知する
+ * (poi-history.js #300 と同じ dual-export パターン)。
+ *
+ * 編集続行 (Cancel) を選んだ場合、各 editor の configVersion は据え置かれる
+ * ので、後続の Save は #343 の 409 安全網 (version_mismatch conflict
+ * ダイアログ) にそのまま落ちる。
+ *
+ * Browser からは `MapoiReloadGuard.*` のグローバルとして使い、Node (vitest)
+ * からは `module.exports` 経由で import する (DOM / window 非依存)。
+ */
+(function () {
+  'use strict';
+
+  /**
+   * reload が破棄してしまうユーザー作業 (blocker) を人間可読ラベルで列挙する。
+   *
+   * dirty (未保存変更) だけでなく、開いている edit form も blocker に含める:
+   * form 内の入力は [OK] を押すまで dirty にならないが、reload は form を
+   * 閉じて入力を失わせるため (#334 の loadRoutes guard と同じ扱い)。
+   *
+   * @param {object} state
+   * @param {boolean} state.poiDirty POI editor に未保存変更がある
+   * @param {boolean} state.routeDirty route editor に未保存変更がある
+   * @param {boolean} state.tagDirty tag editor に未保存変更がある
+   * @param {boolean} state.poiFormOpen POI edit form が開いている
+   * @param {boolean} state.routeFormOpen route edit form が開いている
+   * @returns {string[]} confirm メッセージに列挙するラベル (空なら即 reload 可)
+   */
+  function collectReloadBlockers(state) {
+    const blockers = [];
+    if (state.poiDirty || state.poiFormOpen) blockers.push('POI');
+    if (state.routeDirty || state.routeFormOpen) blockers.push('Route');
+    if (state.tagDirty) blockers.push('Tag');
+    return blockers;
+  }
+
+  /**
+   * config_changed 受信 (debounce 後) に取るべき action を決める。
+   *
+   * - 'reload': blocker なし。即 full reload してよい (保留中だった分の再開を含む)
+   * - 'prompt': blocker あり・未保留。confirm でユーザーに選ばせる
+   * - 'hold'  : blocker あり・保留中 (一度「編集続行」を選択済)。再 prompt せず
+   *             黙って保留を続ける (Save 時に #343 の 409 安全網が改めて警告する)
+   *
+   * @param {string[]} blockers collectReloadBlockers() の結果
+   * @param {boolean} deferred 既に「編集続行」で reload を保留中か
+   * @returns {'reload'|'prompt'|'hold'}
+   */
+  function decideReloadAction(blockers, deferred) {
+    if (blockers.length === 0) return 'reload';
+    return deferred ? 'hold' : 'prompt';
+  }
+
+  /**
+   * prompt 用メッセージ。#343 の 409 conflict ダイアログと同じ言い回しに揃える。
+   *
+   * @param {string[]} blockers collectReloadBlockers() の結果 (1 件以上)
+   * @returns {string} window.confirm に渡すメッセージ
+   */
+  function buildReloadConfirmMessage(blockers) {
+    return (
+      'The YAML file was changed outside this page.\n'
+      + 'You have unsaved edits: ' + blockers.join(', ') + '.\n'
+      + '\n[OK] Load the latest file. Unsaved edits and undo history will be lost.'
+      + '\n[Cancel] Keep editing. Reload stays postponed; Save will warn on conflict.'
+    );
+  }
+
+  const api = {
+    collectReloadBlockers,
+    decideReloadAction,
+    buildReloadConfirmMessage,
+  };
+
+  if (typeof window !== 'undefined') {
+    window.MapoiReloadGuard = window.MapoiReloadGuard || {};
+    Object.assign(window.MapoiReloadGuard, api);
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+}());

--- a/mapoi_webui/web/js/reload-guard.js
+++ b/mapoi_webui/web/js/reload-guard.js
@@ -61,6 +61,8 @@
 
   /**
    * prompt 用メッセージ。#343 の 409 conflict ダイアログと同じ言い回しに揃える。
+   * blocker は「未保存変更」だけでなく「開いている edit form」も含むため、
+   * "unsaved edits" と断定せず "edits in progress" と表現する。
    *
    * @param {string[]} blockers collectReloadBlockers() の結果 (1 件以上)
    * @returns {string} window.confirm に渡すメッセージ
@@ -68,8 +70,8 @@
   function buildReloadConfirmMessage(blockers) {
     return (
       'The YAML file was changed outside this page.\n'
-      + 'You have unsaved edits: ' + blockers.join(', ') + '.\n'
-      + '\n[OK] Load the latest file. Unsaved edits and undo history will be lost.'
+      + 'You have edits in progress: ' + blockers.join(', ') + '.\n'
+      + '\n[OK] Load the latest file. Edits in progress and undo history will be lost.'
       + '\n[Cancel] Keep editing. Reload stays postponed; Save will warn on conflict.'
     );
   }

--- a/mapoi_webui/web/js/tag-editor.js
+++ b/mapoi_webui/web/js/tag-editor.js
@@ -24,6 +24,7 @@ class TagEditor {
 
     this.onReload = null;         // async callback() — save 成功 / discard 後の再取得
     this.onConflictReload = null; // async callback() — 409 確認後の全体 reload
+    this.onDirtyChange = null;    // callback(isDirty) — 保留中 SSE reload の再開判定 (#373)
 
     this.listEl = document.getElementById('tag-list');
     this.addNameEl = document.getElementById('tag-add-name');
@@ -44,6 +45,9 @@ class TagEditor {
   setTagDefinitions(tags, configVersion) {
     this.tags = (tags || []).map((t) => ({ ...t }));
     this.configVersion = configVersion || null;
+    // 全 reload の単一 funnel (poi-editor.js loadPois / route-editor.js loadRoutes と同じ)。
+    // working copy を置き換えたのに dirty (Save 有効) が残る非一貫を防ぐ (#373)。
+    this.setDirty(false);
     this.render();
   }
 
@@ -52,6 +56,7 @@ class TagEditor {
     this.btnSave.disabled = !dirty;
     this.btnDiscard.disabled = !dirty;
     this.dirtyIndicator.textContent = dirty ? 'unsaved changes' : '';
+    if (this.onDirtyChange) this.onDirtyChange(dirty);
   }
 
   render() {


### PR DESCRIPTION
Closes #373

## 変更内容

SSE `config_changed` → `loadMaps()` の全体 reload が、dirty なタブの未保存編集・undo 履歴を無警告で破棄していた。reload の前に blocker (未保存編集 / 開いている edit form) を判定し、conflict ダイアログ相当の選択を挟む。

- **reload-guard.js (新規)**: blocker 列挙 → `'reload' | 'prompt' | 'hold'` 判定 → confirm メッセージ生成の pure モジュール (poi-history.js #300 と同じ dual-export パターン)。app.js の SSE handler はこの判定に従うだけにする
- **prompt**: `[OK]` 最新を読み込む (編集破棄を明示) / `[Cancel]` 編集続行
- **編集続行 (Cancel) 後**: reload を保留し、同じ理由での再 prompt はしない (`hold`)。configVersion が古いまま残るので、後続の Save は #343 の 409 安全網 (version_mismatch conflict ダイアログ) にそのまま落ちる
- **保留の再開**: blocker 解消時 (dirty クリア / edit form close) に再判定して保留分の reload を実行。editor 側の discard で古い working copy に戻ったまま放置されない
- **開いている edit form も blocker 扱い**: form 内の入力は [OK] まで dirty にならないが reload が form を閉じて失わせるため (#334 の loadRoutes guard と同じ考え方)
- **reload 実行中の config_changed は queue**: dirty クリアが fetch 完了後になるため、実行中に再判定すると直後に同じ prompt を重ねて出してしまう。完了後に 1 回だけ再判定
- **tagEditor.setTagDefinitions の非一貫も修正** (issue 記載の併発): working copy 置き換え時に dirty をリセットし、poi-editor.js `loadPois` / route-editor.js `loadRoutes` と同じ「全 reload の単一 funnel で clean 化」に揃えた

## テスト

- `reload-guard.test.js` (新規、vitest):
  - blocker 列挙 (dirty 3 editor / 開いている form) と `'reload' | 'prompt' | 'hold'` 判定を pin
  - 「編集続行 → stale な configVersion で Save → 409 conflict ダイアログ → Cancel なら working copy 無傷」の #343 安全網への接続を thin instance の `PoiEditor.save()` で pin
- 既存含め 85/85 pass。app.js 側の配線 (SSE handler / debounce / 再開 hook) は方針どおり自動テスト外 (risk-based)

## 動作確認手順 (issue の再現手順ベース)

1. 2 タブで WebUI を開き、タブ A で POI をドラッグ (未保存 dirty)
2. タブ B で任意の POI を編集して Save
3. タブ A に確認ダイアログが出る。Cancel → 編集・undo 履歴が残る。その後タブ A で Save すると #343 の conflict ダイアログが出る
4. 3 で Cancel 後にタブ A の編集を Discard → 保留していた reload が走り、タブ B の保存内容が反映される