### PR TITLE
feat(webui): 選択中 POI を Delete キーで削除 (#374)

### DIFF
--- a/mapoi_webui/tests/web/e2e/poi-delete-key.e2e.js
+++ b/mapoi_webui/tests/web/e2e/poi-delete-key.e2e.js
@@ -1,0 +1,79 @@
+// 選択中 POI の Delete キー削除 (#374) の browser smoke。
+// document keydown IIFE (app.js) は jsdom で実体テストしない方針 (#300 risk-based) のため、
+// Escape (#302 map-edit-polish) / Ctrl+Z (#332 poi-drag) と同じく e2e 層で配線を pin する。
+const { test, expect } = require('@playwright/test');
+const { loadApp, poiCard, selectPoi, setSectionOpen } = require('./helpers');
+
+function routeItem(page, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return page.locator('.route-item').filter({
+    has: page.locator('.route-item-name', { hasText: new RegExp(`^${escaped}$`) }),
+  });
+}
+
+test.describe('POI delete key (#374)', () => {
+  test('Delete removes the selected POI with an undo toast, Ctrl+Z restores it', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await selectPoi(page, 'poi_wedge');
+
+    await page.keyboard.press('Delete');
+
+    // working copy から消え dirty 化する (確定は Save — 削除ボタンと同じ経路)。
+    await expect(poiCard(page, 'poi_wedge')).toHaveCount(0);
+    await expect(page.locator('.poi-arrow-icon')).toHaveCount(4);
+    await expect(page.locator('#btn-save')).toBeEnabled();
+    // confirm の代わりに undo 案内つき toast (#374 の選択肢のうち confirm 無し案)。
+    await expect(page.locator('.toast')).toContainText('Deleted POI "poi_wedge" (Ctrl+Z to undo)');
+
+    await page.keyboard.press('Control+z');
+    await expect(poiCard(page, 'poi_wedge')).toHaveCount(1);
+    await expect(page.locator('.poi-arrow-icon')).toHaveCount(5);
+    await expect(page.locator('#btn-save')).toBeDisabled();
+  });
+
+  test('Delete is ignored while an input field has focus', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await selectPoi(page, 'poi_wedge');
+    await setSectionOpen(page, '#btn-tag-toggle', '#tag-body', true);
+
+    await page.locator('#tag-add-name').fill('temp');
+    await page.locator('#tag-add-name').focus();
+    await page.keyboard.press('Delete');
+
+    await expect(poiCard(page, 'poi_wedge')).toHaveCount(1);
+    await expect(page.locator('#btn-save')).toBeDisabled();
+  });
+
+  test('Delete is ignored while route editing is active', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await selectPoi(page, 'poi_wedge');
+    await setSectionOpen(page, '#btn-route-toggle', '#route-body', true);
+    await routeItem(page, 'test_route').locator('.btn-edit').click();
+    await expect(page.locator('#route-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+
+    await page.keyboard.press('Delete');
+
+    // POI は消えず (alert も出ない)、route 編集はそのまま続行できる。
+    await expect(poiCard(page, 'poi_wedge')).toHaveCount(1);
+    await expect(page.locator('#route-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await expect(page.locator('#btn-save')).toBeDisabled();
+  });
+
+  test('Delete is ignored while the POI edit form is open', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await poiCard(page, 'poi_wedge').locator('.btn-edit').click();
+    await expect(page.locator('#poi-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+
+    // focus は Edit ボタン (入力欄ではない) のまま = isEditableTarget では弾かれない状態でも、
+    // 編集中は削除しない。
+    await page.keyboard.press('Delete');
+
+    await expect(poiCard(page, 'poi_wedge')).toHaveCount(1);
+    await expect(page.locator('#poi-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await expect(page.locator('#btn-save')).toBeDisabled();
+  });
+});

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -949,8 +949,8 @@
     console.warn('SSE connection error, browser will auto-reconnect:', err);
   };
 
-  // --- Keyboard shortcuts (#300 / #303 / #321) ---
-  // active editor の Escape / Undo/Redo を document レベルで拾う。
+  // --- Keyboard shortcuts (#300 / #303 / #321 / #374) ---
+  // active editor の Escape / Undo/Redo / Delete を document レベルで拾う。
   // Escape はフォームの Cancel 相当として編集モードを抜ける。Undo/Redo は入力欄
   // (name / x / y / tags 等) の編集中はブラウザ標準の text undo を優先するため無視する。
   // owned key のみ preventDefault し、他ハンドラを妨げない。
@@ -994,6 +994,22 @@
       return;
     }
     if (isEditableTarget) return;
+    // 選択中 POI の Delete キー削除 (#374)。削除前 confirm は置かない: 削除は working
+    // copy への変更で Save まで永続化されず Ctrl+Z (#300) で 1 手で戻せるため、
+    // toast + undo 案内で足りる (issue #374 の選択肢のうち後者)。route 編集中は map
+    // クリックが waypoint 操作の文脈なので発火しない (waypoint 削除への適用は scope 外)。
+    // POI form 編集中・配置中も、フォーム入力途中の誤爆と選択対象の曖昧さを避け無視する。
+    if (e.key === 'Delete' && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
+      if (isRouteEditingActive() || isPoiEditingActive()) return;
+      const index = poiEditor.selectedIndex;
+      if (index < 0) return;
+      e.preventDefault();
+      const name = poiEditor.pois[index]?.name;
+      poiEditor.deletePoi(index);
+      MapoiToast.showToast(
+        document, name ? `Deleted POI "${name}" (Ctrl+Z to undo)` : 'Deleted POI (Ctrl+Z to undo)');
+      return;
+    }
     if (!(e.ctrlKey || e.metaKey)) return;
     const key = e.key.toLowerCase();
     if (key === 'z' && !e.shiftKey) {

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -164,6 +164,7 @@ class PoiEditor {
       const delBtn = document.createElement('button');
       delBtn.className = 'btn-delete';
       delBtn.textContent = 'Del';
+      delBtn.title = 'Delete POI (Delete)';
       delBtn.addEventListener('click', (e) => {
         e.stopPropagation();
         this.deletePoi(i);


### PR DESCRIPTION
Closes #374

## 変更内容

POI を選択した状態で Delete キーを押すと、その POI を working copy から削除する (確定は従来どおり Save)。document keydown IIFE (#300/#321/#303 と同じ流儀) に追加。

- **guard**: 入力欄 focus 中 (`isEditableTarget`) は無視。修飾キー付き (Ctrl/Alt/Shift/Meta+Delete) も owned key 外として無視
- **編集モード中は発火しない**: route 編集中 (map クリックが waypoint 操作の文脈)、POI form 編集中・配置中 (入力途中の誤爆防止) は無視。既存の `_canStartEdit` の alert 経路に落とさず silent に譲る
- **削除前 confirm は置かない**: issue 記載の選択肢のうち「confirm 無しで toast + Ctrl+Z 案内」を採用。削除は working copy への変更で Save まで永続化されず、Undo (#300) で 1 手で戻せるため。toast は #354 の helper をそのまま使用
- **discoverability**: POI list の Del ボタンに `title="Delete POI (Delete)"` を追加 (Undo ボタンの `title="Undo (Ctrl+Z)"` と同じ流儀)
- route editor の waypoint 削除への適用は scope 外 (issue 記載どおり POI のみ)

## テスト

- `poi-delete-key.e2e.js` (新規、playwright): 削除 + toast + Ctrl+Z 復元 / 入力欄 focus 中 guard / route 編集中 guard / POI form 編集中 guard の 4 本
  - keydown IIFE の配線は jsdom (vitest) でなく e2e 層で pin する既存方針 (Escape = map-edit-polish, Ctrl+Z = poi-drag と同様)
- e2e 全 37/37 pass、vitest 既存 86/86 pass

## 動作確認手順

1. WebUI で POI カードをクリックして選択 → Delete キー → カードと marker が消え、"Deleted POI ... (Ctrl+Z to undo)" の toast、dirty (Unsaved changes) になる
2. Ctrl+Z → 復元、dirty 解消
3. POI 名入力欄など input に focus した状態で Delete → 何も起きない (テキスト編集のまま)
4. route の Edit 中に Delete → 何も起きない