### PR TITLE
feat(webui): Ctrl+S で dirty なエディタを Save (#375)

### DIFF
--- a/mapoi_webui/tests/web/e2e/helpers.js
+++ b/mapoi_webui/tests/web/e2e/helpers.js
@@ -3,10 +3,13 @@ const { expect } = require('@playwright/test');
 
 // app 起動を明示待ちする。SSE (/api/events) が開きっぱなしで 'networkidle' は来ないため、
 // 代わりに「全 POI marker が描画される」= loadMaps→switchMap→loadPois→showPois 完了 を待つ。
+// marker は初期化の途中 (loadPois) で描画され、keydown listener 登録は IIFE 末尾なので、
+// load 直後に keyboard 操作するテストが race しないよう data-mapoi-ready も併せて待つ (#375)。
 async function loadApp(page) {
   const resp = await page.goto('/');
   expect(resp.status()).toBe(200);
   await expect(page.locator('.poi-arrow-icon')).toHaveCount(5);
+  await expect(page.locator('body[data-mapoi-ready="1"]')).toHaveCount(1);
 }
 
 // POI 名の完全一致で card を返す。'poi_wedge' が 'poi_wedge2' に部分一致しないよう anchored regex。

--- a/mapoi_webui/tests/web/e2e/save-shortcut.e2e.js
+++ b/mapoi_webui/tests/web/e2e/save-shortcut.e2e.js
@@ -94,6 +94,45 @@ test.describe('Save shortcut Ctrl+S (#375)', () => {
     expect(posted).toBe(false);
   });
 
+  test('Ctrl+S does not save when the open route form fails validation', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-route-toggle', '#route-body', true);
+    await page.locator('.route-item .btn-edit').first().click();
+    await expect(page.locator('#route-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await page.locator('#route-name').fill('');
+
+    let alertMessage = '';
+    page.once('dialog', async (dialog) => {
+      alertMessage = dialog.message();
+      await dialog.accept();
+    });
+    let posted = false;
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && req.url().includes('/api/routes')) posted = true;
+    });
+    await page.keyboard.press('Control+s');
+
+    // routeEditor.formOk の validation alert が出てフォームは開いたまま、save へは進まない。
+    await expect(page.locator('#route-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    expect(alertMessage).toContain('required');
+    expect(posted).toBe(false);
+  });
+
+  test('Ctrl+S saves a dirty tag editor', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-tag-toggle', '#tag-body', true);
+    await page.locator('#tag-add-name').fill('temp_tag');
+    await page.locator('#btn-tag-add').click();
+    await expect(page.locator('#btn-save-tags')).toBeEnabled();
+
+    const post = page.waitForRequest((req) =>
+      req.url().includes('/api/custom-tags') && req.method() === 'POST');
+    await page.keyboard.press('Control+s');
+    await post;
+
+    await expect(page.locator('#btn-save-tags')).toBeDisabled();
+  });
+
   test('Ctrl+S saves multiple dirty editors in one press', async ({ page }) => {
     await loadApp(page);
     // route を先に dirty にする: rename して OK (フォームは閉じるが Save routes はまだ)。

--- a/mapoi_webui/tests/web/e2e/save-shortcut.e2e.js
+++ b/mapoi_webui/tests/web/e2e/save-shortcut.e2e.js
@@ -1,0 +1,118 @@
+// Ctrl+S で dirty なエディタを Save (#375) の browser smoke。
+// document keydown IIFE (app.js) は jsdom で実体テストしない方針 (#300 risk-based) のため、
+// Delete (#374 poi-delete-key) / Escape / Ctrl+Z と同じく e2e 層で配線を pin する。
+const { test, expect } = require('@playwright/test');
+const { loadApp, poiCard, setSectionOpen } = require('./helpers');
+
+// POI working copy を dirty にする最短経路 (Del ボタン → 削除は Save まで永続化されない)。
+async function makePoiDirty(page) {
+  await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+  await poiCard(page, 'poi_wedge').locator('.btn-delete').click();
+  await expect(page.locator('#btn-save')).toBeEnabled();
+}
+
+test.describe('Save shortcut Ctrl+S (#375)', () => {
+  test('Ctrl+S saves a dirty POI editor', async ({ page }) => {
+    await loadApp(page);
+    await makePoiDirty(page);
+
+    const post = page.waitForRequest((req) =>
+      req.url().includes('/api/pois') && req.method() === 'POST');
+    await page.keyboard.press('Control+s');
+    await post;
+
+    // save 成功 → dirty 解消 (既存 save() 経路: originalPois 更新 + setDirty(false))。
+    await expect(page.locator('#btn-save')).toBeDisabled();
+    await expect(page.locator('#dirty-indicator')).toBeEmpty();
+  });
+
+  test('Ctrl+S works while an input field has focus', async ({ page }) => {
+    await loadApp(page);
+    await makePoiDirty(page);
+    await setSectionOpen(page, '#btn-tag-toggle', '#tag-body', true);
+    await page.locator('#tag-add-name').focus();
+
+    const post = page.waitForRequest((req) =>
+      req.url().includes('/api/pois') && req.method() === 'POST');
+    await page.keyboard.press('Control+s');
+    await post;
+
+    await expect(page.locator('#btn-save')).toBeDisabled();
+  });
+
+  test('Ctrl+S with nothing dirty shows a feedback toast and does not POST', async ({ page }) => {
+    await loadApp(page);
+
+    let posted = false;
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && req.url().includes('/api/')) posted = true;
+    });
+    await page.keyboard.press('Control+s');
+
+    await expect(page.locator('.toast')).toContainText('No unsaved changes');
+    expect(posted).toBe(false);
+  });
+
+  test('Ctrl+S commits an open POI edit form (OK 相当) and then saves', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await poiCard(page, 'poi_wedge').locator('.btn-edit').click();
+    await expect(page.locator('#poi-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await page.locator('#poi-name').fill('poi_wedge_renamed');
+
+    const post = page.waitForRequest((req) =>
+      req.url().includes('/api/pois') && req.method() === 'POST');
+    await page.keyboard.press('Control+s');
+    await post;
+
+    // フォームが閉じて (formOk)、リネームが working copy 経由で保存済みになる。
+    await expect(page.locator('#poi-edit-form')).toHaveClass(/(^|\s)hidden(\s|$)/);
+    await expect(poiCard(page, 'poi_wedge_renamed')).toHaveCount(1);
+    await expect(page.locator('#btn-save')).toBeDisabled();
+  });
+
+  test('Ctrl+S does not save when the open form fails validation', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await poiCard(page, 'poi_wedge').locator('.btn-edit').click();
+    await page.locator('#poi-name').fill('');
+
+    let alertMessage = '';
+    page.once('dialog', async (dialog) => {
+      alertMessage = dialog.message();
+      await dialog.accept();
+    });
+    let posted = false;
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && req.url().includes('/api/pois')) posted = true;
+    });
+    await page.keyboard.press('Control+s');
+
+    // formOk の validation alert が出てフォームは開いたまま、save へは進まない。
+    await expect(page.locator('#poi-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    expect(alertMessage).toContain('required');
+    expect(posted).toBe(false);
+  });
+
+  test('Ctrl+S saves multiple dirty editors in one press', async ({ page }) => {
+    await loadApp(page);
+    // route を先に dirty にする: rename して OK (フォームは閉じるが Save routes はまだ)。
+    // POI 削除を先にすると formOk が missing waypoint の confirm を出し得るため順序固定。
+    await setSectionOpen(page, '#btn-route-toggle', '#route-body', true);
+    await page.locator('.route-item .btn-edit').first().click();
+    await page.locator('#route-name').fill('test_route_renamed');
+    await page.locator('#btn-route-form-ok').click();
+    await expect(page.locator('#btn-save-routes')).toBeEnabled();
+    await makePoiDirty(page);
+
+    const poiPost = page.waitForRequest((req) =>
+      req.url().includes('/api/pois') && req.method() === 'POST');
+    const routePost = page.waitForRequest((req) =>
+      req.url().includes('/api/routes') && req.method() === 'POST');
+    await page.keyboard.press('Control+s');
+    await Promise.all([poiPost, routePost]);
+
+    await expect(page.locator('#btn-save')).toBeDisabled();
+    await expect(page.locator('#btn-save-routes')).toBeDisabled();
+  });
+});

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -154,7 +154,7 @@
             <button id="btn-tag-add">+ Add</button>
           </div>
           <div id="tag-toolbar">
-            <button id="btn-save-tags" title="Save tag changes" disabled>Save</button>
+            <button id="btn-save-tags" title="Save tag changes (Ctrl+S)" disabled>Save</button>
             <button id="btn-discard-tags" title="Discard tag changes" disabled>Discard</button>
             <span id="tag-dirty-indicator"></span>
           </div>
@@ -216,7 +216,7 @@
           <div id="poi-toolbar" class="editor-toolbar">
             <button id="btn-add-poi" class="toolbar-primary" title="Add POI">+ Add POI</button>
             <span class="toolbar-command-group">
-              <button id="btn-save" title="Save changes" disabled>Save</button>
+              <button id="btn-save" title="Save changes (Ctrl+S)" disabled>Save</button>
               <button id="btn-discard" title="Discard changes" disabled>Discard</button>
             </span>
             <span class="toolbar-command-group toolbar-history-group" aria-label="POI history">
@@ -283,7 +283,7 @@
           <div id="route-toolbar" class="editor-toolbar">
             <button id="btn-add-route" class="toolbar-primary" title="Add Route">+ Add Route</button>
             <span class="toolbar-command-group">
-              <button id="btn-save-routes" title="Save route changes" disabled>Save</button>
+              <button id="btn-save-routes" title="Save route changes (Ctrl+S)" disabled>Save</button>
               <button id="btn-discard-routes" title="Discard route changes" disabled>Discard</button>
             </span>
             <span class="toolbar-command-group toolbar-history-group" aria-label="Route history">

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -949,15 +949,56 @@
     console.warn('SSE connection error, browser will auto-reconnect:', err);
   };
 
-  // --- Keyboard shortcuts (#300 / #303 / #321 / #374) ---
-  // active editor の Escape / Undo/Redo / Delete を document レベルで拾う。
+  // --- Keyboard shortcuts (#300 / #303 / #321 / #374 / #375) ---
+  // active editor の Escape / Undo/Redo / Delete / Ctrl+S を document レベルで拾う。
   // Escape はフォームの Cancel 相当として編集モードを抜ける。Undo/Redo は入力欄
   // (name / x / y / tags 等) の編集中はブラウザ標準の text undo を優先するため無視する。
   // owned key のみ preventDefault し、他ハンドラを妨げない。
+
+  // Ctrl+S の保存対象決定 (#375)。編集フォームが開いていればまずフォーム内容を working
+  // copy に確定 (OK ボタン相当の formOk) してから save する — フォーム内の入力は OK まで
+  // working copy に載らないため、確定せずに save すると「見えている編集が保存されない」
+  // 齟齬が起きる。formOk は validation 失敗時に alert を出してフォームを開いたまま返る
+  // ので、editingIndex が -1 に戻らなかったら保存へ進まない。フォームが無ければ dirty な
+  // エディタを全て保存する (POI / route / tag は別 endpoint で独立、各 save() は 409
+  // conflict ダイアログ (#241/#343) 含め既存経路をそのまま通す)。
+  // 保存対象が無い時は toast で応答を返す: ショートカットが「効かない」ように見える
+  // 無反応を避ける (ブラウザ拡張のキー横取り等との切り分けにもなる)。
+  let saveShortcutInFlight = false;
+  async function saveViaShortcut() {
+    if (routeEditor.editingIndex !== -1) {
+      routeEditor.formOk();
+      if (routeEditor.editingIndex !== -1) return;
+    } else if (poiEditor.editingIndex !== -1) {
+      poiEditor.formOk();
+      if (poiEditor.editingIndex !== -1) return;
+    }
+    if (!(poiEditor.dirty || routeEditor.dirty || tagEditor.dirty)) {
+      MapoiToast.showToast(document, 'No unsaved changes');
+      return;
+    }
+    if (poiEditor.dirty) await poiEditor.save();
+    if (routeEditor.dirty) await routeEditor.save();
+    if (tagEditor.dirty) await tagEditor.save();
+  }
+
   document.addEventListener('keydown', (e) => {
     const t = e.target;
     const isEditableTarget = t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA'
         || t.tagName === 'SELECT' || t.isContentEditable);
+    // Ctrl+S / Cmd+S で dirty なエディタを Save (#375)。ブラウザ既定の「ページを保存」は
+    // どの状態でも誤って出したくないため、入力欄 focus 中 (フォーム入力途中の確定 → save
+    // も #375 の仕様) や保存対象が無い時も含め常に preventDefault する。このため
+    // isEditableTarget guard より前に置く。Ctrl+Shift+S (ブラウザの別機能) は所有しない。
+    if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 's') {
+      e.preventDefault();
+      // 長押し repeat / 保存中の再入は無視: dirty クリアが fetch 完了後のため、再入する
+      // と同じ configVersion で二重 POST になり直後に 409 conflict を踏む。
+      if (e.repeat || saveShortcutInFlight) return;
+      saveShortcutInFlight = true;
+      saveViaShortcut().finally(() => { saveShortcutInFlight = false; });
+      return;
+    }
     if (e.key === 'Escape') {
       if (e.isComposing) return;
       if (routeEditor.editingIndex !== -1) {
@@ -1022,4 +1063,9 @@
       else poiEditor.redo();
     }
   });
+
+  // 初期化完了 (keydown listener 登録まで済み) の目印 (#375)。POI marker は初期化途中
+  // (loadMaps 内の loadPois) で描画されるため、marker 出現だけを待って直後に keyboard
+  // 操作すると listener 未登録に当たる race がある。e2e はこの flag で完了を待つ。
+  document.body.dataset.mapoiReady = '1';
 })();

--- a/mapoi_webui/web/js/tag-editor.js
+++ b/mapoi_webui/web/js/tag-editor.js
@@ -150,6 +150,15 @@ class TagEditor {
     this.render();
   }
 
+  /**
+   * Ctrl+S (#375) 用の公開 entry。Save ボタンと同じ経路 (_handleSave) で、
+   * poi-editor.js / route-editor.js の save() と同じく dirty でなければ no-op。
+   */
+  async save() {
+    if (!this.dirty) return;
+    await this._handleSave();
+  }
+
   async _handleSave() {
     const customTags = this.tags
       .filter((t) => !t.is_system)


### PR DESCRIPTION
Closes #375

> **Note**: #378 の引き継ぎ (base branch feat/374-poi-delete-key の削除で auto-close され、rebase 済み head の reopen が不可だったため新規起票)。レビュー 2 round と対応の経緯は #378 参照。本 PR は main に rebase 済みで #374 の commit は含まない。

## 変更内容

Ctrl+S (Cmd+S) で dirty なエディタを Save する。ブラウザ既定の「ページを保存」ダイアログは、入力欄 focus 中・保存対象が無い時も含め**常に preventDefault で抑止**する (誤って出す事故の方が有害なため)。document keydown IIFE (#300/#321/#303/#374 と同じ流儀) に追加。

**保存対象の決定規則** (issue の論点への回答):

1. **編集フォームが開いている場合**: まず formOk (OK ボタン相当) でフォーム内容を working copy に確定してから save する。フォーム内の入力は OK まで working copy に載らないため、確定せずに save すると「見えている編集が保存されない」齟齬が起きる。formOk が validation で失敗 (alert) した場合はフォームが開いたままなので保存へ進まない
2. **フォームが無い場合**: dirty なエディタ (POI / route / tag) を**全て**保存する。3 者は別 endpoint で独立しており「保存したい」という意図に優先順位を付ける理由が無いため。各 save() は 409 conflict ダイアログ (#241/#343) 含め既存経路をそのまま通す
3. **入力欄 focus 中も拾う** (issue の要検討事項): Ctrl+Z と違いテキスト編集と衝突せず、拾わないとブラウザの保存ダイアログが出てしまうため

その他:

- **長押し repeat / 保存中の再入は無視**: dirty クリアが fetch 完了後のため、再入すると同じ configVersion で二重 POST になり直後に 409 を踏む
- **保存対象が無い時は 'No unsaved changes' toast**: ショートカットが「効かない」ように見える無反応を避ける (ブラウザ拡張のキー横取り等との切り分けにも有効)
- tag-editor.js に公開 `save()` を追加 (Save ボタンと同経路 `_handleSave` の thin entry、poi/route の `save()` と同 signature)
- Save ボタン 3 つの title に `(Ctrl+S)` を表記
- **e2e の潜在 race を修正**: `loadApp` は POI marker 5 個 (= 初期化**途中**の loadPois) しか待っておらず、load 直後に keyboard 操作すると keydown listener 登録前に当たる。既存テストはクリック操作が先に入るため潜在化していたが、no-dirty toast テストで顕在化した。app.js 末尾に `data-mapoi-ready` を追加し loadApp で初期化完了を待つようにした

## テスト

- `save-shortcut.e2e.js` (新規、playwright) 6 本: dirty POI 保存 / 入力欄 focus 中でも保存 / no-dirty で toast + POST 無し / フォーム開 → formOk 確定 → 保存 / validation 失敗で保存中断 / POI+route 複数 dirty の一括保存
- e2e 全 43/43 pass (`--repeat-each=3` でも安定)、vitest 既存 86/86 pass

## 動作確認手順

1. POI をドラッグ等で dirty 化 → Ctrl+S → 保存されて Unsaved changes が消える (ブラウザの保存ダイアログは出ない)
2. POI 編集フォームで名前を変更し (OK を押さずに) Ctrl+S → フォームが閉じて変更が保存される
3. 名前を空にして Ctrl+S → 'POI name is required.' の alert、保存されない
4. クリーンな状態で Ctrl+S → 'No unsaved changes' の toast
