### PR TITLE
fix(webui): 自タブ save 起因の SSE reload で undo 履歴と map 視点を失わない (#384)

### DIFF
--- a/mapoi_webui/mapoi_webui/mapoi_webui_node.py
+++ b/mapoi_webui/mapoi_webui/mapoi_webui_node.py
@@ -406,7 +406,18 @@ class MapoiWebNode(Node):
                 # loadPois / loadRoutes / loadTagDefinitions を再実行させる (#135 (B))。
                 # map 名が正しく解釈できた時のみ broadcast: 期待形式に部分一致するが map 特定でき
                 # ないケースで無駄な reload を避ける (#173 Round 1 / 2 medium)。
-                self._broadcast_sse_event('config_changed', {'map_name': map_name_parsed})
+                payload = {'map_name': map_name_parsed}
+                # yaml 全体の内容 hash (#241 の config_version) を同梱する (#384)。保存した
+                # タブは save 応答で同じ値を既に持っており、frontend はこれと照合して自タブ発
+                # の変更なら reload (undo 履歴・map 視点の破棄) を skip できる。計算できない
+                # 場合 (config 不在等) は省略し、frontend は従来どおり reload する (安全側)。
+                try:
+                    version = compute_config_version(path)
+                except OSError:
+                    version = None
+                if version:
+                    payload['config_version'] = version
+                self._broadcast_sse_event('config_changed', payload)
         except Exception as e:
             self.get_logger().warn(f'Failed to parse config path: {e}')
 

--- a/mapoi_webui/test/test_api_sse_config_events.py
+++ b/mapoi_webui/test/test_api_sse_config_events.py
@@ -15,8 +15,11 @@ unbound メソッドに渡して呼ぶ (node 生成不要)。`/api/events` の g
 で blocking するため、view を直接呼んで Response を取り出し、別スレッドで 1 frame だけ drain して
 deterministically に検証する (put→get は即時なので client 登録さえ確認できれば race しない)。
 """
+import hashlib
 import json
+import os
 import queue
+import tempfile
 import threading
 import time
 import unittest
@@ -95,6 +98,26 @@ class TestConfigPathCallback(unittest.TestCase):
         self.assertEqual(node.map_name_, 'mapA')
         self.assertEqual(
             node.broadcasts, [('config_changed', {'map_name': 'mapA'})])
+
+    def test_broadcast_includes_config_version_when_file_readable(self):
+        # yaml が実在する場合は payload に config_version (yaml 全体の sha256, #241) を
+        # 同梱する (#384)。frontend はこれを save 応答の version と照合し、自タブ発の
+        # 変更なら reload (undo 履歴・map 視点の破棄) を skip する。
+        # 既存の他 test は実在しない path を使うため version は計算不能 → 省略 (後方互換)。
+        with tempfile.TemporaryDirectory() as tmp:
+            config_dir = os.path.join(tmp, 'maps', 'mapB')
+            os.makedirs(config_dir)
+            config_path = os.path.join(config_dir, 'mapoi_config.yaml')
+            content = b'poi: []\n'
+            with open(config_path, 'wb') as f:
+                f.write(content)
+            expected_version = hashlib.sha256(content).hexdigest()
+            node = _FakeConfigNode(map_name='mapA')
+            _call_config_path(node, config_path)
+            self.assertEqual(node.broadcasts, [('config_changed', {
+                'map_name': 'mapB',
+                'config_version': expected_version,
+            })])
 
     def test_path_without_config_file_does_not_broadcast(self):
         # config_file が path に現れない → map 特定不可 → 無駄な reload を避けて broadcast しない

--- a/mapoi_webui/tests/web/e2e/server/mock_server.py
+++ b/mapoi_webui/tests/web/e2e/server/mock_server.py
@@ -12,12 +12,16 @@ rclpy / mapoi_interfaces を要し CI が重く、フィクスチャも制御で
 - API POST: /api/pois ほか -> {"success": true, ...} (テストは save を踏まないが契約上用意)
 - SSE: /api/events -> text/event-stream を張りっぱなしにし keepalive (フロントの
        EventSource が onerror で再接続を繰り返さないように 200 を返し続ける)
+- test 専用: POST /test/sse-event -> body の JSON を接続中の全 SSE client へ配信 (#384)。
+       e2e から config_changed 等のイベント受信をシミュレートする (実 backend には無い)
 """
 import argparse
 import json
+import queue
 import re
 import struct
 import sys
+import threading
 import time
 import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -83,6 +87,11 @@ def make_png(width, height):
 _meta = STATE["metadata"]
 MAP_PNG = make_png(int(_meta["width"]), int(_meta["height"]))
 
+# POST /test/sse-event で e2e からイベントを注入するための接続中 SSE client 一覧 (#384)。
+# 実 backend (mapoi_webui_node) の _sse_clients と同じ queue fanout 構造の最小版。
+SSE_CLIENTS = set()
+SSE_LOCK = threading.Lock()
+
 
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
@@ -128,15 +137,27 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         if self.command == "HEAD":
             return  # HEAD は header のみ。stream loop に入らない (無限ループ回避)。
+        # /test/sse-event からの注入を受け取る client queue を登録 (#384)。イベントが無い間は
+        # 従来どおり 1 秒間隔の keepalive comment を流す (queue.get の timeout で兼ねる)。
+        q = queue.Queue(maxsize=10)
+        with SSE_LOCK:
+            SSE_CLIENTS.add(q)
         try:
             self.wfile.write(b": connected\n\n")
             self.wfile.flush()
             while True:
-                time.sleep(1.0)
-                self.wfile.write(b": keepalive\n\n")
+                try:
+                    event = q.get(timeout=1.0)
+                    body = json.dumps(event).encode("utf-8")
+                    self.wfile.write(b"data: " + body + b"\n\n")
+                except queue.Empty:
+                    self.wfile.write(b": keepalive\n\n")
                 self.wfile.flush()
         except (BrokenPipeError, ConnectionResetError, OSError):
             return
+        finally:
+            with SSE_LOCK:
+                SSE_CLIENTS.discard(q)
 
     # ---- routing ----
     def do_GET(self):
@@ -197,8 +218,23 @@ class Handler(BaseHTTPRequestHandler):
     def do_POST(self):
         path = unquote(urlparse(self.path).path)
         length = int(self.headers.get("Content-Length", 0) or 0)
-        if length:
-            self.rfile.read(length)  # body は破棄 (テストは結果を踏まない)
+        body = self.rfile.read(length) if length else b""
+        if path == "/test/sse-event":
+            # e2e 専用: body の JSON event を接続中の全 SSE client へ配信 (#384)。
+            try:
+                event = json.loads(body)
+            except (ValueError, UnicodeDecodeError):
+                self._send_json({"error": "invalid json"}, 400)
+                return
+            with SSE_LOCK:
+                clients = list(SSE_CLIENTS)
+            for q in clients:
+                try:
+                    q.put_nowait(event)
+                except queue.Full:
+                    pass
+            self._send_json({"success": True, "clients": len(clients)})
+            return
         if path == "/api/pois":
             self._send_json({"success": True, "config_version": STATE["config_version"]})
             return

--- a/mapoi_webui/tests/web/e2e/sse-self-change.e2e.js
+++ b/mapoi_webui/tests/web/e2e/sse-self-change.e2e.js
@@ -1,0 +1,85 @@
+// 自タブ save 起因の SSE config_changed で reload しない (#384) の browser smoke。
+// mock server の POST /test/sse-event (test 専用) で config_changed を注入する。
+// 注入は接続中の全 SSE client への broadcast で並走テストの page にも届くため、
+// この spec は専用 project (chromium-sse、他テスト完了後に単独実行) に隔離されている
+// (playwright.config.js)。
+const { test, expect } = require('@playwright/test');
+const { loadApp, poiCard, setSectionOpen } = require('./helpers');
+
+// EventSource の接続完了 (clients >= 1) を待ってから実 event を 1 回だけ送る。
+// 接続前に送ると event は誰にも届かず、reload を待つ側のテストが timeout する。
+// 接続確認の poll には frontend が無視する type を使い、二重配信の副作用を避ける。
+async function sendSse(page, event) {
+  await expect.poll(async () => {
+    const resp = await page.request.post('/test/sse-event', { data: { type: 'test_ping' } });
+    return (await resp.json()).clients;
+  }).toBeGreaterThan(0);
+  const resp = await page.request.post('/test/sse-event', { data: event });
+  expect(resp.ok()).toBeTruthy();
+}
+
+async function fixtureConfigVersion(page) {
+  const resp = await page.request.get('/api/pois');
+  return (await resp.json()).config_version;
+}
+
+// 共通前段: POI を 1 件削除して Save し、「自タブが version を既知として保持する」状態を作る。
+// mock の POST /api/pois は固定 state の config_version を返すので、実 backend の
+// save 応答 (新 version 受領) と同型になる。
+async function deletePoiAndSave(page) {
+  await poiCard(page, 'poi_wedge').locator('.btn-delete').click();
+  await page.locator('#btn-save').click();
+  await expect(page.locator('#btn-save')).toBeDisabled();
+  await expect(page.locator('.poi-card')).toHaveCount(4);
+}
+
+test.describe('SSE self-change skip (#384)', () => {
+  test('既知 version の config_changed では reload せず undo 履歴と作業状態が残る', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    const version = await fixtureConfigVersion(page);
+
+    await deletePoiAndSave(page);
+    await expect(page.locator('#btn-undo')).toBeEnabled(); // save 後も undo 履歴は残る (#300)
+
+    await sendSse(page, {
+      type: 'config_changed',
+      payload: { map_name: 'test_map', config_version: version },
+    });
+
+    // reload されると mock の固定 state から POI が 5 件に戻り undo も無効化される。
+    // debounce (200ms) を確実に跨いでから「何も起きていない」ことを pin する。
+    await page.waitForTimeout(800);
+    await expect(page.locator('.poi-card')).toHaveCount(4);
+    await expect(poiCard(page, 'poi_wedge')).toHaveCount(0);
+    await expect(page.locator('#btn-undo')).toBeEnabled();
+  });
+
+  test('未知 version の config_changed では従来どおり reload する', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+
+    await deletePoiAndSave(page);
+
+    await sendSse(page, {
+      type: 'config_changed',
+      payload: { map_name: 'test_map', config_version: 'external-version-differs' },
+    });
+
+    // 全体 reload で mock の固定 state (POI 5 件) に戻り、loadPois が undo 履歴を破棄する。
+    await expect(page.locator('.poi-card')).toHaveCount(5);
+    await expect(page.locator('#btn-undo')).toBeDisabled();
+  });
+
+  test('version 無しの config_changed は従来どおり reload に回す (後方互換)', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+
+    await deletePoiAndSave(page);
+
+    await sendSse(page, { type: 'config_changed', payload: { map_name: 'test_map' } });
+
+    await expect(page.locator('.poi-card')).toHaveCount(5);
+    await expect(page.locator('#btn-undo')).toBeDisabled();
+  });
+});

--- a/mapoi_webui/tests/web/playwright.config.js
+++ b/mapoi_webui/tests/web/playwright.config.js
@@ -28,7 +28,21 @@ module.exports = defineConfig({
     trace: 'on-first-retry',
   },
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      testIgnore: '**/sse-*.e2e.js',
+    },
+    // SSE 注入 (POST /test/sse-event) は接続中の全 client への broadcast で、並走中の
+    // 他テストの page にも届いて reload を誘発し得る。chromium project の完了後に
+    // 単独 (直列) で走らせて隔離する (#384)。
+    {
+      name: 'chromium-sse',
+      use: { ...devices['Desktop Chrome'] },
+      testMatch: '**/sse-*.e2e.js',
+      dependencies: ['chromium'],
+      fullyParallel: false,
+    },
   ],
   webServer: {
     command: `python3 e2e/server/mock_server.py --port ${PORT}`,

--- a/mapoi_webui/tests/web/reload-guard.test.js
+++ b/mapoi_webui/tests/web/reload-guard.test.js
@@ -42,6 +42,31 @@ describe('collectReloadBlockers', () => {
   });
 });
 
+describe('isSelfConfigChange', () => {
+  it('recognizes a version any editor already holds as self-change (skip reload)', () => {
+    // save 応答で受領済み = 自タブ発。reload は undo 履歴と map 視点を失わせるだけ (#384)。
+    expect(guard.isSelfConfigChange('v2', ['v2', 'v1', 'v1'])).toBe(true);
+    expect(guard.isSelfConfigChange('v1', ['v2', 'v1', null])).toBe(true);
+  });
+
+  it('treats an unknown version as external change (reload)', () => {
+    expect(guard.isSelfConfigChange('v9', ['v1', 'v2', 'v3'])).toBe(false);
+  });
+
+  it('falls back to reload when the event carries no version (old backend / config missing)', () => {
+    expect(guard.isSelfConfigChange(null, ['v1'])).toBe(false);
+    expect(guard.isSelfConfigChange(undefined, ['v1'])).toBe(false);
+    expect(guard.isSelfConfigChange('', ['v1'])).toBe(false);
+  });
+
+  it('never matches editors that have no version yet (null must not equal null)', () => {
+    // 初期 load 前 (configVersion=null) に version 無し event が来ても self 判定しない。
+    expect(guard.isSelfConfigChange(null, [null, null, null])).toBe(false);
+    expect(guard.isSelfConfigChange('v1', [])).toBe(false);
+    expect(guard.isSelfConfigChange('v1', undefined)).toBe(false);
+  });
+});
+
 describe('decideReloadAction', () => {
   it('reloads immediately when there is no blocker', () => {
     expect(guard.decideReloadAction([], false)).toBe('reload');

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -36,6 +36,9 @@
   let configReloadDeferred = false;
   let configReloadInFlight = false;
   let configReloadQueued = false;
+  // 直近の config_changed event が運んできた config_version (#384)。debounce や in-flight
+  // queue を跨いで保持し、自タブ発の変更 (= 既知 version) なら reload を skip する判定に使う。
+  let configChangedVersion = null;
 
   // --- Tag editor (tag-editor.js に切り出し、#346) ---
   // save 成功 / discard 後は tag 定義の再取得のみ、409 確認後は全体 reload
@@ -880,12 +883,29 @@
   // 短時間のバースト時は 200ms にまとめて 1 回だけ fetch する debounce (#173 Round 1 medium)。
   // 未保存編集や開いている edit form があるうちは黙って loadMaps() せず、conflict
   // ダイアログ相当の選択 (最新読込 or 編集続行) を挟む (#373)。判定は reload-guard.js。
-  function scheduleConfigChangedReload() {
+  // 自タブ発の変更 (save 応答で受領済みの config_version と一致) は reload 自体を skip
+  // する (#384) — reload は undo 履歴 (loadPois が破棄) と map 視点 (loadMap の fitBounds)
+  // を失わせるだけで、working copy は既に最新のため。
+  // version 引数は event 受信時のみ渡す (null = version 不明)。maybeResume からの再呼び出し
+  // は引数なしで、保留中 event の version をそのまま使う。
+  function scheduleConfigChangedReload(version) {
+    if (version !== undefined) configChangedVersion = version;
     if (configChangedTimer) clearTimeout(configChangedTimer);
     configChangedTimer = setTimeout(() => {
       configChangedTimer = null;
       if (configReloadInFlight) {
         configReloadQueued = true;
+        return;
+      }
+      if (MapoiReloadGuard.isSelfConfigChange(configChangedVersion, [
+        poiEditor.configVersion, routeEditor.configVersion, tagEditor.configVersion,
+      ])) {
+        // 従来この同期は reload の GET 群が担っていた: version は yaml 全体の hash なので
+        // 一 section の save で他 section の保持 version も古くなる。skip する場合もここで
+        // 配っておかないと、直後の別 section save が誤って 409 conflict に落ちる。
+        poiEditor.configVersion = configChangedVersion;
+        routeEditor.configVersion = configChangedVersion;
+        tagEditor.configVersion = configChangedVersion;
         return;
       }
       const blockers = MapoiReloadGuard.collectReloadBlockers({
@@ -931,7 +951,9 @@
     try {
       const data = JSON.parse(e.data);
       if (data.type === 'config_changed') {
-        scheduleConfigChangedReload();
+        // config_version 無し (旧 backend / config 不在) は null で上書きし、前 event の
+        // version で誤って self 判定しないようにする (#384)。
+        scheduleConfigChangedReload((data.payload && data.payload.config_version) || null);
       } else if (data.type === 'command_rejected') {
         // #354: mapoi/nav/command_rejected 経由の非破壊イベント通知。走行中の typo goal 等
         // でも mapoi/nav/status (latched snapshot) を汚さず、一時的な toast だけで知らせる。
@@ -980,6 +1002,12 @@
     if (poiEditor.dirty) await poiEditor.save();
     if (routeEditor.dirty) await routeEditor.save();
     if (tagEditor.dirty) await tagEditor.save();
+    // 保存完了の合図 (#384)。従来は自タブ save 起因の SSE reload のちらつきが事実上の
+    // 合図になっていたが、その reload を skip したので明示のフィードバックを出す。
+    // 409 conflict 等で dirty が残った場合は出さない (各 save() のダイアログが出ている)。
+    if (!(poiEditor.dirty || routeEditor.dirty || tagEditor.dirty)) {
+      MapoiToast.showToast(document, 'Saved');
+    }
   }
 
   document.addEventListener('keydown', (e) => {

--- a/mapoi_webui/web/js/reload-guard.js
+++ b/mapoi_webui/web/js/reload-guard.js
@@ -60,6 +60,24 @@
   }
 
   /**
+   * config_changed が自タブ発 (または取り込み済み) の変更かを判定する (#384)。
+   *
+   * version は yaml 全体の内容 hash (#241 の config_version)。save 応答か前回 load で
+   * このタブが既に知っている値なら working copy は最新で、reload は undo 履歴
+   * (loadPois が破棄) と map 視点 (loadMap の fitBounds) を失わせるだけなので skip
+   * してよい。version が取れない event (旧 backend / config 不在) は常に false =
+   * 従来どおり reload に回す (安全側)。
+   *
+   * @param {string|null|undefined} version SSE payload の config_version
+   * @param {Array<string|null>} knownVersions 各 editor が保持中の configVersion
+   * @returns {boolean} true なら reload 不要 (自タブ発 / 取り込み済み)
+   */
+  function isSelfConfigChange(version, knownVersions) {
+    if (!version) return false;
+    return (knownVersions || []).indexOf(version) !== -1;
+  }
+
+  /**
    * prompt 用メッセージ。#343 の 409 conflict ダイアログと同じ言い回しに揃える。
    * blocker は「未保存変更」だけでなく「開いている edit form」も含むため、
    * "unsaved edits" と断定せず "edits in progress" と表現する。
@@ -79,6 +97,7 @@
   const api = {
     collectReloadBlockers,
     decideReloadAction,
+    isSelfConfigChange,
     buildReloadConfirmMessage,
   };
 


### PR DESCRIPTION
Closes #384

## 変更内容

save すると mapoi_server が `mapoi/config_path` を再 publish し、SSE `config_changed` が**保存したタブ自身にも**届いて全体 reload (`loadMaps()`) が走っていた。この reload が undo 履歴 (loadPois の破棄、#300 の安全設計) と map 視点 (loadMap の fitBounds) を失わせる。保存したタブの working copy は既に最新なので reload 自体が不要 — Save ボタン / Ctrl+S (#375) の双方で発生していた。

- **backend**: `config_path_callback` の SSE payload に `config_version` (yaml 全体の sha256、#241 と同一) を同梱。計算不能 (config 不在等) 時は省略し frontend は従来動作
- **frontend**: 受信 version が**いずれかの editor が保持している configVersion と一致**なら自タブ発 (または取り込み済み) と判定して reload を skip。判定は `reload-guard.js` の純関数 `isSelfConfigChange` (#373 と同じ dual-export 流儀)
  - skip 時も 3 editor へ version を配布する: version は yaml 全体の hash なので、一 section の save で他 section の保持 version も古くなる。従来この同期は reload の GET 群が担っていた (配らないと直後の別 section save が誤って 409 conflict に落ちる)
  - 未知 version / version 無し (旧 backend) → 従来どおり #373 の blocker 判定 → reload。他タブ・外部編集の挙動は不変
- **Ctrl+S 成功時に 'Saved' toast**: 従来は reload のちらつきが事実上の保存合図だった (issue 報告者のコメント) ため、明示のフィードバックで代替。409 等で dirty が残る場合は出さない (各 save() のダイアログが出る)

## テスト

- python: SSE payload の version 同梱を pin (既存 test は実在しない path なので省略経路 = 後方互換のまま 15/15 pass、jazzy コンテナで確認。humble は PR CI)
- vitest: `isSelfConfigChange` の 4 ケース (既知/未知/version 無し/null 同士の非一致)。90/90 pass
- e2e: mock server に **test 専用の SSE 注入 endpoint** (`POST /test/sse-event`) を追加し、skip / reload(未知 version) / reload(version 無し) の 3 経路を実ブラウザで pin。注入は接続中全 client への broadcast で並走テストに届くため、**専用 project (chromium-sse) に隔離し他テスト完了後に単独実行**。48/48 pass

## 動作確認手順

1. POI をドラッグ → Ctrl+Z できる状態で Save (ボタン / Ctrl+S) → **ズームが維持され、Ctrl+Z で保存前に戻せる** (戻した分は dirty になり再 Save 可能)
2. Ctrl+S 時は 'Saved' toast が出る
3. 2 タブで開き、タブ B で Save → タブ A は従来どおり reload (dirty なら #373 の確認ダイアログ)