### PR TITLE
feat(webui): map cursor の world 座標 readout (#381)

### DIFF
--- a/mapoi_webui/tests/web/e2e/cursor-readout.e2e.js
+++ b/mapoi_webui/tests/web/e2e/cursor-readout.e2e.js
@@ -1,0 +1,28 @@
+// Map cursor の world 座標 readout (#381) の browser smoke。
+// mousemove → latLngToWorld → 表示更新の Leaflet 配線は jsdom で動かないため e2e 層で
+// pin する (フォーマット自体は poi-filter.test.js の formatCursorCoords で unit 済)。
+const { test, expect } = require('@playwright/test');
+const { loadApp } = require('./helpers');
+
+test.describe('cursor coordinate readout (#381)', () => {
+  test('shows world coordinates while hovering the map and hides on leave', async ({ page }) => {
+    await loadApp(page);
+    const readout = page.locator('#cursor-readout');
+    await expect(readout).toBeHidden();
+
+    const box = await page.locator('#map').boundingBox();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await expect(readout).toBeVisible();
+    // 桁は POI yaml の丸め (POSE_XY_DIGITS = 3) に固定
+    await expect(readout).toHaveText(/^x: -?\d+\.\d{3}, y: -?\d+\.\d{3}$/);
+
+    // カーソル移動で値が追従する
+    const first = await readout.textContent();
+    await page.mouse.move(box.x + box.width / 4, box.y + box.height / 4);
+    await expect(readout).not.toHaveText(first);
+
+    // map 外 (ヘッダ側) へ出たら非表示に戻る
+    await page.mouse.move(box.x + box.width / 2, 5);
+    await expect(readout).toBeHidden();
+  });
+});

--- a/mapoi_webui/tests/web/poi-filter.test.js
+++ b/mapoi_webui/tests/web/poi-filter.test.js
@@ -19,6 +19,7 @@ const {
   degToRad,
   radToDeg,
   formatToleranceYawDeg,
+  formatCursorCoords,
   roundTo,
   TOLERANCE_MIN,
   POSE_XY_DIGITS,
@@ -45,6 +46,20 @@ describe('formatToleranceYawDeg (#267)', () => {
       const resavedRad = roundTo(degToRad(shownDeg), TOLERANCE_YAW_DIGITS);
       expect(resavedRad).toBe(storedRad);
     });
+  });
+});
+
+describe('formatCursorCoords (#381)', () => {
+  it('formats with fixed POSE_XY_DIGITS decimals (幅が揺れない)', () => {
+    // toFixed 固定桁: 末尾ゼロを保持し、mousemove 中の文字幅ちらつきを防ぐ
+    expect(formatCursorCoords(1.2, -3.45678)).toBe('x: 1.200, y: -3.457');
+    expect(formatCursorCoords(0, 0)).toBe('x: 0.000, y: 0.000');
+  });
+
+  it('returns empty string for non-finite input (呼び出し側は表示を更新しない)', () => {
+    expect(formatCursorCoords(NaN, 1)).toBe('');
+    expect(formatCursorCoords(1, Infinity)).toBe('');
+    expect(formatCursorCoords(undefined, 1)).toBe('');
   });
 });
 

--- a/mapoi_webui/tests/web/poi-filter.test.js
+++ b/mapoi_webui/tests/web/poi-filter.test.js
@@ -56,7 +56,7 @@ describe('formatCursorCoords (#381)', () => {
     expect(formatCursorCoords(0, 0)).toBe('x: 0.000, y: 0.000');
   });
 
-  it('returns empty string for non-finite input (呼び出し側は表示を更新しない)', () => {
+  it('returns empty string for non-finite input (呼び出し側は readout を隠す)', () => {
     expect(formatCursorCoords(NaN, 1)).toBe('');
     expect(formatCursorCoords(1, Infinity)).toBe('');
     expect(formatCursorCoords(undefined, 1)).toBe('');

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -87,6 +87,23 @@ main {
   pointer-events: none;
 }
 
+/* Cursor 位置の world 座標 readout (#381)。#map-status と同じ見た目で右下に置く
+   (右上の #ui-controls とは重ならない)。等幅フォントで mousemove 中の桁揺れを抑え、
+   pointer-events: none で真下の map 操作を邪魔しない。 */
+#cursor-readout {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  z-index: 1000;
+  pointer-events: none;
+}
+
 /* Sidebar drag-resize handle (#122 PR-2)。
    #map-container と #poi-panel の間に置く 6px 幅のスプリッタ。drag で
    #poi-panel 幅を変更し、localStorage に永続化する (sidebar-resizer.js)。

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -20,6 +20,9 @@
     <div id="map-container">
       <div id="map"></div>
       <div id="map-status"></div>
+      <!-- Cursor 位置の world 座標 readout (#381)。map 上の mousemove 中のみ表示
+           (map-viewer.js が更新)。#map-status (左下) と対になる右下配置。 -->
+      <div id="cursor-readout" class="hidden"></div>
 
       <!-- 地図上にフロートする UI 一括表示/非表示トグル (#324)。ui-hidden 時も残る
            ので UI を復帰できる。アイコンは action-based の eye SVG (表示中 = eye-off

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -101,7 +101,11 @@ class MapViewer {
       if (!this._cursorReadoutEl || !this.metadata) return;
       const world = this.latLngToWorld(e.latlng);
       const text = MapoiPoiFilter.formatCursorCoords(world.x, world.y);
-      if (!text) return;
+      // 非有限座標 (metadata 異常等) では古い値を残さず隠す (Cursor review medium 対応)。
+      if (!text) {
+        this._cursorReadoutEl.classList.add('hidden');
+        return;
+      }
       this._cursorReadoutEl.textContent = text;
       this._cursorReadoutEl.classList.remove('hidden');
     });

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -91,6 +91,24 @@ class MapViewer {
       }
     });
 
+    // Cursor 位置の world 座標 readout (#381)。mousemove で常時更新し、map 外へ出たら
+    // (mouseout) 非表示に戻す。touch 端末は mousemove が来ないので出ないまま (タップ時
+    // 表示は scope 外)。表示要素は index.html の #cursor-readout (右下固定 div —
+    // #map-status は左下、#ui-controls は右上で重ならない)。metadata 未 load 中は
+    // 座標変換できないので表示しない。桁は POI yaml の丸め (POSE_XY_DIGITS) に揃える。
+    this._cursorReadoutEl = document.getElementById('cursor-readout');
+    this.map.on('mousemove', (e) => {
+      if (!this._cursorReadoutEl || !this.metadata) return;
+      const world = this.latLngToWorld(e.latlng);
+      const text = MapoiPoiFilter.formatCursorCoords(world.x, world.y);
+      if (!text) return;
+      this._cursorReadoutEl.textContent = text;
+      this._cursorReadoutEl.classList.remove('hidden');
+    });
+    this.map.on('mouseout', () => {
+      if (this._cursorReadoutEl) this._cursorReadoutEl.classList.add('hidden');
+    });
+
     // zoom が変わると 1m あたりの pixel が変わるので、robot marker のピクセル
     // サイズを再計算するために再描画する (#116)。pose 未受信時は updateRobotMarker
     // が early return するので safe。

--- a/mapoi_webui/web/js/poi-filter.js
+++ b/mapoi_webui/web/js/poi-filter.js
@@ -104,6 +104,22 @@
   }
 
   /**
+   * Map cursor readout 用に world 座標を整形する純関数 (#381)。
+   * POI yaml の座標桁数 (POSE_XY_DIGITS) に合わせて toFixed で桁を固定し、
+   * mousemove 中に小数部の桁数が揺れて文字幅がちらつくのを防ぐ (roundTo だと
+   * 末尾ゼロが落ちて "1.2" ⇄ "1.234" と幅が変わる)。非有限入力は空文字 =
+   * 呼び出し側 (map-viewer.js) は表示を更新しない。
+   *
+   * @param {number} x world x (m)
+   * @param {number} y world y (m)
+   * @returns {string} 例 "x: -1.234, y: 5.678"、非有限入力は ''
+   */
+  function formatCursorCoords(x, y) {
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return '';
+    return `x: ${x.toFixed(POSE_XY_DIGITS)}, y: ${y.toFixed(POSE_XY_DIGITS)}`;
+  }
+
+  /**
    * POI form の tolerance round-trip を保つ純関数 (#87 / #138)。
    * `||` だと意図的な小さい値も default で上書きされるので Number.isFinite で判定。
    * 最終 xy / yaw は msg spec に従い `>= TOLERANCE_MIN` を保証する (UI HTML min を
@@ -160,6 +176,7 @@
     degToRad,
     radToDeg,
     formatToleranceYawDeg,
+    formatCursorCoords,
     roundTo,
     TOLERANCE_MIN,
     POSE_XY_DIGITS,


### PR DESCRIPTION
Closes #381

## 変更内容

map 上のマウス位置の world 座標 (x, y) を右下に常時表示する readout を追加。YAML 手編集・POI 配置の狙い付け・ロボット位置との照合に使う。

- **map-viewer.js**: Leaflet の `mousemove` → 既存の `latLngToWorld` → `#cursor-readout` を更新。`mouseout` で非表示に戻す。metadata 未 load 中は表示しない
- **表示桁**: POI yaml の丸め (`POSE_XY_DIGITS` = 3) に合わせる。フォーマットは pure helper `MapoiPoiFilter.formatCursorCoords` に切り出し (`formatToleranceYawDeg` と同じ置き場)。`toFixed` 固定桁 + 等幅フォントで mousemove 中の文字幅ちらつきを抑える
- **配置**: `#map-status` (左下) と対になる**右下**の固定 div。右上の `#ui-controls` (#324/#333) とは重ならない。`pointer-events: none` で map 操作を邪魔しない
- **モバイル (touch)**: mousemove が来ないので非表示のまま (タップ時表示は issue の通り scope 外)

## テスト

- `poi-filter.test.js`: `formatCursorCoords` の固定桁フォーマットと非有限入力 → 空文字を pin
- `cursor-readout.e2e.js` (新規, playwright): hover で表示 + 桁フォーマット / カーソル移動で値追従 / map 外へ出たら非表示
- vitest 92/92 pass (9 ファイル)、e2e 全 49/49 pass

## 動作確認手順

1. map 上にマウスを置く → 右下に `x: -1.234, y: 5.678` 形式の座標が出て、動かすと追従する
2. POI の上にカーソルを合わせ、POI 編集フォームの X/Y と読みが一致することを確認
3. マウスを map 外 (sidebar / header) へ出す → readout が消える