### PR TITLE
feat(webui): POI list の名前検索ボックス (#383)

### DIFF
--- a/mapoi_webui/tests/web/e2e/poi-search.e2e.js
+++ b/mapoi_webui/tests/web/e2e/poi-search.e2e.js
@@ -1,0 +1,73 @@
+// POI list 検索ボックス (#383) の browser smoke。
+// 絞り込み判定 (matchesPoiName) は poi-filter.test.js で unit 済。ここでは
+// input → renderList の配線、実 index 整合 (選択 / nav dropdown 連動)、
+// map marker の可視状態と独立であること、Escape / 編集フォームとの共存を pin する。
+const { test, expect } = require('@playwright/test');
+const { loadApp, poiCard, selectPoi, setSectionOpen } = require('./helpers');
+
+test.describe('POI list search box (#383)', () => {
+  test('narrows the list by name without touching map markers', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await expect(page.locator('.poi-card')).toHaveCount(5);
+
+    await page.locator('#poi-search').fill('wedge');
+    await expect(page.locator('.poi-card')).toHaveCount(2);
+    await expect(poiCard(page, 'poi_wedge')).toHaveCount(1);
+    await expect(poiCard(page, 'poi_wedge2')).toHaveCount(1);
+    // 絞り込みは list 表示のみ: marker は全件のまま
+    await expect(page.locator('.poi-arrow-icon')).toHaveCount(5);
+
+    // 大文字小文字不区別
+    await page.locator('#poi-search').fill('WEDGE');
+    await expect(page.locator('.poi-card')).toHaveCount(2);
+
+    // 一致なしは 0 件表示 (marker は変わらず)
+    await page.locator('#poi-search').fill('zzz');
+    await expect(page.locator('.poi-card')).toHaveCount(0);
+    await expect(page.locator('.poi-arrow-icon')).toHaveCount(5);
+
+    // クリアで全件復帰
+    await page.locator('#poi-search').fill('');
+    await expect(page.locator('.poi-card')).toHaveCount(5);
+  });
+
+  test('selecting a filtered card selects the right POI (index integrity)', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+
+    await page.locator('#poi-search').fill('pause');
+    await expect(page.locator('.poi-card')).toHaveCount(1);
+    await poiCard(page, 'poi_pause').locator('.poi-card-name').click();
+    await expect(poiCard(page, 'poi_pause')).toHaveClass(/(^|\s)selected(\s|$)/);
+    // card は実 index ベース (#383): 選択が nav goal dropdown 連動 (#111) でも正しい
+    // POI を指すことを、絞り込み表示中の選択で確認する。
+    await expect(page.locator('#nav-goal-select')).toHaveValue('poi_pause');
+  });
+
+  test('Escape clears a non-empty query without dropping the selection', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await selectPoi(page, 'poi_wedge');
+
+    await page.locator('#poi-search').fill('wedge');
+    await expect(page.locator('.poi-card')).toHaveCount(2);
+    await page.locator('#poi-search').press('Escape');
+    await expect(page.locator('#poi-search')).toHaveValue('');
+    await expect(page.locator('.poi-card')).toHaveCount(5);
+    // クリアは選択解除 (#309) より優先: 選択はそのまま残る
+    await expect(poiCard(page, 'poi_wedge')).toHaveClass(/(^|\s)selected(\s|$)/);
+  });
+
+  test('the search box hides while the POI edit form is open', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+
+    await poiCard(page, 'poi_wedge').locator('.btn-edit').click();
+    await expect(page.locator('#poi-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    await expect(page.locator('#poi-search')).toBeHidden();
+
+    await page.locator('#btn-form-cancel').click();
+    await expect(page.locator('#poi-search')).toBeVisible();
+  });
+});

--- a/mapoi_webui/tests/web/e2e/poi-search.e2e.js
+++ b/mapoi_webui/tests/web/e2e/poi-search.e2e.js
@@ -59,6 +59,24 @@ test.describe('POI list search box (#383)', () => {
     await expect(poiCard(page, 'poi_wedge')).toHaveClass(/(^|\s)selected(\s|$)/);
   });
 
+  test('filtering out the selected POI hides its card but keeps the selection', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await selectPoi(page, 'poi_pause');
+    await expect(page.locator('#nav-goal-select')).toHaveValue('poi_pause');
+
+    await page.locator('#poi-search').fill('wedge');
+    await expect(poiCard(page, 'poi_pause')).toHaveCount(0);
+    // 絞り込みは list の見た目だけ (一貫規則): map の highlight (選択 marker は
+    // stroke #e67e22) と nav dropdown は選択を保持し続ける
+    await expect(page.locator('.poi-arrow-icon:has(path[stroke="#e67e22"])')).toHaveCount(1);
+    await expect(page.locator('#nav-goal-select')).toHaveValue('poi_pause');
+
+    // クリアすると card が選択状態のまま戻る
+    await page.locator('#poi-search').fill('');
+    await expect(poiCard(page, 'poi_pause')).toHaveClass(/(^|\s)selected(\s|$)/);
+  });
+
   test('the search box hides while the POI edit form is open', async ({ page }) => {
     await loadApp(page);
     await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);

--- a/mapoi_webui/tests/web/poi-filter.test.js
+++ b/mapoi_webui/tests/web/poi-filter.test.js
@@ -19,6 +19,7 @@ const {
   degToRad,
   radToDeg,
   formatToleranceYawDeg,
+  matchesPoiName,
   roundTo,
   TOLERANCE_MIN,
   POSE_XY_DIGITS,
@@ -67,6 +68,32 @@ describe('roundTo (#242)', () => {
     expect(roundTo(0.7850002283279937, TOLERANCE_YAW_DIGITS)).toBe(0.785);
     expect(roundTo(1.2345, 2)).toBe(1.23);
     expect(roundTo(1.2355, 2)).toBe(1.24);
+  });
+});
+
+describe('matchesPoiName (#383)', () => {
+  // POI list 検索の絞り込み判定。card 生成 skip の是非を決める唯一の関数なので、
+  // 大文字小文字不区別・部分一致・空 query 全件 match をここで pin する
+  // (list DOM との index 整合は e2e poi-search.e2e.js 側)。
+  it('matches case-insensitive substrings of the name', () => {
+    const poi = { name: 'Kitchen_Door' };
+    expect(matchesPoiName(poi, 'door')).toBe(true);
+    expect(matchesPoiName(poi, 'KITCHEN')).toBe(true);
+    expect(matchesPoiName(poi, 'hen_d')).toBe(true);
+    expect(matchesPoiName(poi, 'dining')).toBe(false);
+  });
+
+  it('empty / whitespace-only / null query matches everything (絞り込みなし)', () => {
+    expect(matchesPoiName({ name: 'a' }, '')).toBe(true);
+    expect(matchesPoiName({ name: 'a' }, '   ')).toBe(true);
+    expect(matchesPoiName({ name: 'a' }, null)).toBe(true);
+    expect(matchesPoiName({}, undefined)).toBe(true);
+  });
+
+  it('unnamed POI does not match a non-empty query', () => {
+    expect(matchesPoiName({}, 'a')).toBe(false);
+    expect(matchesPoiName({ name: '' }, 'a')).toBe(false);
+    expect(matchesPoiName(null, 'a')).toBe(false);
   });
 });
 

--- a/mapoi_webui/web/css/style.css
+++ b/mapoi_webui/web/css/style.css
@@ -221,6 +221,19 @@ main {
   color: #e74c3c;
 }
 
+/* POI list 検索ボックス (#383)。.section-body の横 padding (16px) に合わせて置く。
+   絞り込みは list 表示のみで map marker の可視状態とは独立 (poi-editor.js)。 */
+#poi-search {
+  display: block;
+  width: calc(100% - 32px);
+  margin: 4px 16px 0;
+  padding: 6px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  min-height: 36px;
+}
+
 /* POI List */
 #poi-list {
   flex: 1;

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -171,6 +171,10 @@
           </div>
         </div>
         <div id="poi-body">
+          <!-- POI list の名前絞り込み (#383)。list 表示のみをフィルタし、map marker の
+               可視状態 (checkbox / All / None) とは独立。配線は poi-editor.js。 -->
+          <input type="search" id="poi-search" placeholder="Filter POIs by name"
+                 autocomplete="off" aria-label="Filter POIs by name" />
           <div id="poi-list" class="section-body"></div>
           <div id="poi-edit-form" class="hidden">
             <h3 id="form-title">Edit POI</h3>

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -47,16 +47,16 @@ class PoiEditor {
     this.dirtyIndicator = document.getElementById('dirty-indicator');
     this.btnUndo = document.getElementById('btn-undo');
     this.btnRedo = document.getElementById('btn-redo');
-    // POI list の名前絞り込み (#383)。filterText は renderList が card 生成を skip する
-    // 判定 (matchesPoiName) に使うだけで、map marker の可視状態 (visiblePois) とは独立。
-    // 入力欄は DOM harness 等で無くてもインスタンス化できるよう null guard (#300 と同流儀)。
-    this.filterText = '';
+    // POI list の名前絞り込み (#383)。query の真実は入力欄の DOM value 一本
+    // (_filterQuery で読む) で、editor 側に鏡写しの state を持たない — 二重管理は
+    // プログラム的な value 変更で不整合の温床になる。renderList が card 生成を skip
+    // する判定 (matchesPoiName) にだけ使い、map marker の可視状態 (visiblePois) とは
+    // 独立。入力欄は DOM harness 等で無くてもインスタンス化できるよう null guard
+    // (#300 と同流儀)。type="search" のクリアボタン (×) も input event を発火するので
+    // この配線だけで同期する。
     this.inputSearch = document.getElementById('poi-search');
     if (this.inputSearch) {
-      this.inputSearch.addEventListener('input', () => {
-        this.filterText = this.inputSearch.value;
-        this.renderList();
-      });
+      this.inputSearch.addEventListener('input', () => this.renderList());
       // Escape は入力があればクリア (選択解除 #309 には流さない)。空なら素通しさせ、
       // app.js 側の isEditableTarget guard で無視される (= 何も起きない)。
       this.inputSearch.addEventListener('keydown', (e) => {
@@ -64,7 +64,6 @@ class PoiEditor {
         e.preventDefault();
         e.stopPropagation();
         this.inputSearch.value = '';
-        this.filterText = '';
         this.renderList();
       });
     }
@@ -114,13 +113,24 @@ class PoiEditor {
   /**
    * Render the POI card list.
    */
+  /**
+   * 検索ボックスの現在 query (#383)。真実は DOM value のみ (入力欄が無い harness では
+   * 常に '' = 絞り込みなし)。
+   */
+  _filterQuery() {
+    return this.inputSearch ? this.inputSearch.value : '';
+  }
+
   renderList() {
     this.listEl.innerHTML = '';
+    const query = this._filterQuery();
     this.pois.forEach((poi, i) => {
       // 検索絞り込み (#383): 名前部分一致 (大文字小文字不区別)。card 生成を skip する
       // だけで forEach の実 index (i) は保たれるので、selectPoi / deletePoi / visibility
-      // checkbox の index 整合はずれない。
-      if (!MapoiPoiFilter.matchesPoiName(poi, this.filterText)) return;
+      // checkbox の index 整合はずれない。選択中 POI が query に一致しない場合も選択は
+      // 解除しない (card は隠れるが map の highlight / nav dropdown は選択を保持する —
+      // 絞り込みは list の見た目だけ、が一貫規則)。
+      if (!MapoiPoiFilter.matchesPoiName(poi, query)) return;
       const card = document.createElement('div');
       card.className = 'poi-card' + (i === this.selectedIndex ? ' selected' : '');
       card.dataset.index = i;

--- a/mapoi_webui/web/js/poi-editor.js
+++ b/mapoi_webui/web/js/poi-editor.js
@@ -47,6 +47,27 @@ class PoiEditor {
     this.dirtyIndicator = document.getElementById('dirty-indicator');
     this.btnUndo = document.getElementById('btn-undo');
     this.btnRedo = document.getElementById('btn-redo');
+    // POI list の名前絞り込み (#383)。filterText は renderList が card 生成を skip する
+    // 判定 (matchesPoiName) に使うだけで、map marker の可視状態 (visiblePois) とは独立。
+    // 入力欄は DOM harness 等で無くてもインスタンス化できるよう null guard (#300 と同流儀)。
+    this.filterText = '';
+    this.inputSearch = document.getElementById('poi-search');
+    if (this.inputSearch) {
+      this.inputSearch.addEventListener('input', () => {
+        this.filterText = this.inputSearch.value;
+        this.renderList();
+      });
+      // Escape は入力があればクリア (選択解除 #309 には流さない)。空なら素通しさせ、
+      // app.js 側の isEditableTarget guard で無視される (= 何も起きない)。
+      this.inputSearch.addEventListener('keydown', (e) => {
+        if (e.key !== 'Escape' || e.isComposing || !this.inputSearch.value) return;
+        e.preventDefault();
+        e.stopPropagation();
+        this.inputSearch.value = '';
+        this.filterText = '';
+        this.renderList();
+      });
+    }
 
     // Form inputs
     this.inputName = document.getElementById('poi-name');
@@ -96,6 +117,10 @@ class PoiEditor {
   renderList() {
     this.listEl.innerHTML = '';
     this.pois.forEach((poi, i) => {
+      // 検索絞り込み (#383): 名前部分一致 (大文字小文字不区別)。card 生成を skip する
+      // だけで forEach の実 index (i) は保たれるので、selectPoi / deletePoi / visibility
+      // checkbox の index 整合はずれない。
+      if (!MapoiPoiFilter.matchesPoiName(poi, this.filterText)) return;
       const card = document.createElement('div');
       card.className = 'poi-card' + (i === this.selectedIndex ? ' selected' : '');
       card.dataset.index = i;
@@ -492,11 +517,15 @@ class PoiEditor {
 
   showForm() {
     this.formEl.classList.remove('hidden');
+    // 編集フォーム中は app.js の sidebar focus (#240) が #poi-list を隠すので、
+    // list 専用の検索ボックス (#383) も一緒に隠して form に集中させる。
+    if (this.inputSearch) this.inputSearch.classList.add('hidden');
     if (this.onEditFormVisibilityChange) this.onEditFormVisibilityChange(true);
   }
 
   hideForm() {
     this.formEl.classList.add('hidden');
+    if (this.inputSearch) this.inputSearch.classList.remove('hidden');
     if (this.onEditFormVisibilityChange) this.onEditFormVisibilityChange(false);
   }
 

--- a/mapoi_webui/web/js/poi-filter.js
+++ b/mapoi_webui/web/js/poi-filter.js
@@ -104,6 +104,23 @@
   }
 
   /**
+   * POI list 検索ボックス (#383) の名前フィルタ判定。大文字小文字不区別の部分一致。
+   * 空 / 空白のみの query は全件 match (= 絞り込みなし)。名前なし POI は query が
+   * ある間は match しない。絞り込みは list 表示のみで、map marker の可視状態
+   * (visiblePois) とは独立 (poi-editor.js renderList が card 生成を skip するだけ)。
+   *
+   * @param {object} poi POI object ({ name, ... })
+   * @param {string} query 検索文字列 (未 trim で良い)
+   * @returns {boolean} 表示すべきなら true
+   */
+  function matchesPoiName(poi, query) {
+    const q = String(query == null ? '' : query).trim().toLowerCase();
+    if (!q) return true;
+    const name = poi && poi.name ? String(poi.name) : '';
+    return name.toLowerCase().includes(q);
+  }
+
+  /**
    * POI form の tolerance round-trip を保つ純関数 (#87 / #138)。
    * `||` だと意図的な小さい値も default で上書きされるので Number.isFinite で判定。
    * 最終 xy / yaw は msg spec に従い `>= TOLERANCE_MIN` を保証する (UI HTML min を
@@ -155,6 +172,7 @@
     filterWaypointCandidates,
     filterInitialPoseCandidates,
     filterRouteWaypointCandidates,
+    matchesPoiName,
     validatePoiTags,
     parseTolerance,
     degToRad,


### PR DESCRIPTION
Closes #383

## 変更内容

POI list 上部に検索欄を追加し、名前の部分一致 (大文字小文字不区別) で即時絞り込みする。

- **poi-editor.js**: `filterText` state を持ち `renderList()` で適用。判定は pure helper `MapoiPoiFilter.matchesPoiName` に切り出し。card 生成を skip するだけなので `pois` の実 index はずれず、selectPoi / deletePoi / visibility checkbox の整合は保たれる
- **絞り込みは list 表示のみ**: map marker の可視状態 (`visiblePois` / All / None) とは独立。検索で marker は消えない
- **Escape の扱い** (issue の実装時判断): 入力があれば**クリア優先** (選択解除 #309 には流さない)。空なら素通し → app.js の `isEditableTarget` guard で無視される。検索欄 focus 中の Delete キー (#374) は既存 guard で無効のまま
- **POI 編集フォームとの共存**: form open 中は sidebar focus (#240) が list を隠すのに合わせ、検索欄も `showForm`/`hideForm` で隠す/戻す
- tag での絞り込みは issue の通り scope 外

## テスト

- `poi-filter.test.js`: `matchesPoiName` の部分一致・大文字小文字不区別・空 query 全件 match・無名 POI を pin
- `poi-search.e2e.js` (新規, playwright) 4 本: 絞り込みと marker 独立性 / 絞り込み中選択の index 整合 (nav dropdown 連動込み) / Escape クリア優先 / form open 中の非表示
- vitest 93/93 pass (9 ファイル)、e2e 全 52/52 pass

## 動作確認手順

1. POI section の検索欄に `wedge` と入力 → card が 2 件に絞られ、map の marker は 5 個のまま
2. 絞り込み表示中に card を選択 → 正しい POI がハイライトされ、Navigation の goal dropdown にも同名が入る
3. Escape → 検索がクリアされ全件復帰 (選択は維持)
4. Edit ボタンでフォームを開く → 検索欄が消え、Cancel で戻る