### PR TITLE
feat(webui): beforeunload で未保存編集の離脱ガード (#380)

### DIFF
--- a/mapoi_webui/tests/web/e2e/beforeunload.e2e.js
+++ b/mapoi_webui/tests/web/e2e/beforeunload.e2e.js
@@ -1,0 +1,69 @@
+// beforeunload 未保存ガード (#380) の browser smoke。
+// 判定 (collectReloadBlockers / shouldBlockUnload) は reload-guard.test.js で unit 済。
+// ここでは window beforeunload の実配線を pin する: dirty / form open でブラウザ標準の
+// 離脱確認が出ること、clean では素通しでタブが閉じられることの両面。
+//
+// Playwright では page.close({ runBeforeUnload: true }) が beforeunload を発火させ、
+// ガードが働くと type 'beforeunload' の dialog が来る。dialog listener を登録しない場合
+// Playwright は dialog を自動 dismiss する (= dismiss は「ページに留まる」) ため、
+// clean ケースは「close イベントが来る = ダイアログが出ていない」ことの証明になる。
+const { test, expect } = require('@playwright/test');
+const { loadApp, selectPoi, setSectionOpen, poiCard } = require('./helpers');
+
+test.describe('beforeunload unsaved-edit guard (#380)', () => {
+  test('dirty POI edit triggers the leave confirmation; dismiss keeps the page', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await selectPoi(page, 'poi_wedge');
+    await page.keyboard.press('Delete');
+    await expect(page.locator('#btn-save')).toBeEnabled();
+
+    const dialogPromise = page.waitForEvent('dialog');
+    await page.close({ runBeforeUnload: true });
+    const dialog = await dialogPromise;
+    expect(dialog.type()).toBe('beforeunload');
+    await dialog.dismiss();
+
+    // 留まったページはそのまま操作できる (dirty も保持)
+    await expect(page.locator('#btn-save')).toBeEnabled();
+  });
+
+  test('an open edit form (not dirty yet) also triggers the confirmation', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await poiCard(page, 'poi_wedge').locator('.btn-edit').click();
+    await expect(page.locator('#poi-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+    // form 内の入力は OK まで dirty にならないが、unload は入力を失わせる
+    await expect(page.locator('#btn-save')).toBeDisabled();
+
+    const dialogPromise = page.waitForEvent('dialog');
+    await page.close({ runBeforeUnload: true });
+    const dialog = await dialogPromise;
+    expect(dialog.type()).toBe('beforeunload');
+    await dialog.dismiss();
+    await expect(page.locator('#poi-edit-form')).not.toHaveClass(/(^|\s)hidden(\s|$)/);
+  });
+
+  test('clean state closes without any confirmation', async ({ page }) => {
+    await loadApp(page);
+    // dialog listener を登録しない: ガードが誤発火すると Playwright の自動 dismiss で
+    // ページが閉じられず、close イベント待ちが timeout して fail する。
+    const closed = page.waitForEvent('close');
+    await page.close({ runBeforeUnload: true });
+    await closed;
+  });
+
+  test('undo back to clean removes the guard again', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+    await selectPoi(page, 'poi_wedge');
+    await page.keyboard.press('Delete');
+    await expect(page.locator('#btn-save')).toBeEnabled();
+    await page.keyboard.press('Control+z');
+    await expect(page.locator('#btn-save')).toBeDisabled();
+
+    const closed = page.waitForEvent('close');
+    await page.close({ runBeforeUnload: true });
+    await closed;
+  });
+});

--- a/mapoi_webui/tests/web/reload-guard.test.js
+++ b/mapoi_webui/tests/web/reload-guard.test.js
@@ -42,6 +42,23 @@ describe('collectReloadBlockers', () => {
   });
 });
 
+describe('shouldBlockUnload (#380)', () => {
+  it('blocks unload while any blocker exists (collectReloadBlockers と同じ定義)', () => {
+    expect(guard.shouldBlockUnload(
+      guard.collectReloadBlockers({ ...CLEAN_STATE, poiDirty: true }),
+    )).toBe(true);
+    expect(guard.shouldBlockUnload(
+      guard.collectReloadBlockers({ ...CLEAN_STATE, routeFormOpen: true }),
+    )).toBe(true);
+  });
+
+  it('passes through when clean (常時ブロックはブラウザに抑止される)', () => {
+    expect(guard.shouldBlockUnload(guard.collectReloadBlockers(CLEAN_STATE))).toBe(false);
+    expect(guard.shouldBlockUnload([])).toBe(false);
+    expect(guard.shouldBlockUnload(null)).toBe(false);
+  });
+});
+
 describe('isSelfConfigChange', () => {
   it('recognizes a version any editor already holds as self-change (skip reload)', () => {
     // save 応答で受領済み = 自タブ発。reload は undo 履歴と map 視点を失わせるだけ (#384)。

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -1092,6 +1092,27 @@
     }
   });
 
+  // --- 未保存編集の離脱ガード (#380) ---
+  // dirty なエディタ / 開いている edit form があるままタブを閉じる・F5 リロード・ページ
+  // 遷移すると、編集内容と undo 履歴が黙って消える。map 切替 (既存 confirm) と SSE 全体
+  // reload (#373 の reload guard) は既にガード済みで、タブ閉じ / リロードが最後の無防備
+  // 経路。blocker の定義は reload-guard.js の collectReloadBlockers (「reload で失われる
+  // もの」と同一 = dirty 3 editor + 開いている edit form) をそのまま再利用する。
+  // clean 時は必ず素通し (常時ブロックはブラウザにダイアログ自体を抑止される + UX 悪)。
+  // 文言はブラウザ標準でカスタム不可。preventDefault + returnValue 設定が互換のお作法。
+  window.addEventListener('beforeunload', (e) => {
+    const blockers = MapoiReloadGuard.collectReloadBlockers({
+      poiDirty: poiEditor.dirty,
+      routeDirty: routeEditor.dirty,
+      tagDirty: tagEditor.dirty,
+      poiFormOpen: poiEditor.editingIndex !== -1,
+      routeFormOpen: routeEditor.editingIndex !== -1,
+    });
+    if (!MapoiReloadGuard.shouldBlockUnload(blockers)) return;
+    e.preventDefault();
+    e.returnValue = '';
+  });
+
   // 初期化完了 (keydown listener 登録まで済み) の目印 (#375)。POI marker は初期化途中
   // (loadMaps 内の loadPois) で描画されるため、marker 出現だけを待って直後に keyboard
   // 操作すると listener 未登録に当たる race がある。e2e はこの flag で完了を待つ。

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -888,6 +888,21 @@
   // を失わせるだけで、working copy は既に最新のため。
   // version 引数は event 受信時のみ渡す (null = version 不明)。maybeResume からの再呼び出し
   // は引数なしで、保留中 event の version をそのまま使う。
+
+  // collectReloadBlockers に渡す現在の editor state (#373 / #380 共通)。SSE reload guard と
+  // beforeunload guard は「失われるもの」の定義を共有するので、state の収集も一本化して
+  // 片方だけの更新漏れ (定義乖離) を防ぐ。tag editor は inline の add form のみで開閉式
+  // edit form を持たないため *FormOpen は POI / route の 2 つ (tag は dirty のみ blocker)。
+  function currentEditorBlockerState() {
+    return {
+      poiDirty: poiEditor.dirty,
+      routeDirty: routeEditor.dirty,
+      tagDirty: tagEditor.dirty,
+      poiFormOpen: poiEditor.editingIndex !== -1,
+      routeFormOpen: routeEditor.editingIndex !== -1,
+    };
+  }
+
   function scheduleConfigChangedReload(version) {
     if (version !== undefined) configChangedVersion = version;
     if (configChangedTimer) clearTimeout(configChangedTimer);
@@ -908,13 +923,7 @@
         tagEditor.configVersion = configChangedVersion;
         return;
       }
-      const blockers = MapoiReloadGuard.collectReloadBlockers({
-        poiDirty: poiEditor.dirty,
-        routeDirty: routeEditor.dirty,
-        tagDirty: tagEditor.dirty,
-        poiFormOpen: poiEditor.editingIndex !== -1,
-        routeFormOpen: routeEditor.editingIndex !== -1,
-      });
+      const blockers = MapoiReloadGuard.collectReloadBlockers(currentEditorBlockerState());
       const action = MapoiReloadGuard.decideReloadAction(blockers, configReloadDeferred);
       if (action === 'hold') return;
       if (action === 'prompt'
@@ -1101,13 +1110,7 @@
   // clean 時は必ず素通し (常時ブロックはブラウザにダイアログ自体を抑止される + UX 悪)。
   // 文言はブラウザ標準でカスタム不可。preventDefault + returnValue 設定が互換のお作法。
   window.addEventListener('beforeunload', (e) => {
-    const blockers = MapoiReloadGuard.collectReloadBlockers({
-      poiDirty: poiEditor.dirty,
-      routeDirty: routeEditor.dirty,
-      tagDirty: tagEditor.dirty,
-      poiFormOpen: poiEditor.editingIndex !== -1,
-      routeFormOpen: routeEditor.editingIndex !== -1,
-    });
+    const blockers = MapoiReloadGuard.collectReloadBlockers(currentEditorBlockerState());
     if (!MapoiReloadGuard.shouldBlockUnload(blockers)) return;
     e.preventDefault();
     e.returnValue = '';

--- a/mapoi_webui/web/js/reload-guard.js
+++ b/mapoi_webui/web/js/reload-guard.js
@@ -82,6 +82,8 @@
    *
    * blocker の定義は collectReloadBlockers と同一 — 「reload で失われるもの」と
    * 「unload で失われるもの」は同じ (dirty 3 editor + 開いている edit form)。
+   * この同一性は今後も維持する前提: unload だけの別条件が必要になったら、この
+   * 関数に分岐を足すのではなく別の判定関数を切ること。
    * clean (blocker なし) 時に必ず素通しさせるのが不変条件: 常時ブロックすると
    * ブラウザがダイアログ自体を抑止するようになる + UX が悪い。
    *

--- a/mapoi_webui/web/js/reload-guard.js
+++ b/mapoi_webui/web/js/reload-guard.js
@@ -78,6 +78,21 @@
   }
 
   /**
+   * beforeunload (#380) でタブ閉じ / リロードをブロックすべきかの判定。
+   *
+   * blocker の定義は collectReloadBlockers と同一 — 「reload で失われるもの」と
+   * 「unload で失われるもの」は同じ (dirty 3 editor + 開いている edit form)。
+   * clean (blocker なし) 時に必ず素通しさせるのが不変条件: 常時ブロックすると
+   * ブラウザがダイアログ自体を抑止するようになる + UX が悪い。
+   *
+   * @param {string[]} blockers collectReloadBlockers() の結果
+   * @returns {boolean} true なら e.preventDefault() + e.returnValue でブロック
+   */
+  function shouldBlockUnload(blockers) {
+    return (blockers || []).length > 0;
+  }
+
+  /**
    * prompt 用メッセージ。#343 の 409 conflict ダイアログと同じ言い回しに揃える。
    * blocker は「未保存変更」だけでなく「開いている edit form」も含むため、
    * "unsaved edits" と断定せず "edits in progress" と表現する。
@@ -98,6 +113,7 @@
     collectReloadBlockers,
     decideReloadAction,
     isSelfConfigChange,
+    shouldBlockUnload,
     buildReloadConfirmMessage,
   };
 


### PR DESCRIPTION
Closes #380

## 変更内容

dirty (未保存編集) のままタブを閉じる / F5 リロード / ページ遷移した時に、ブラウザ標準の離脱確認を出す。map 切替 (既存 confirm) と SSE 全体 reload (#373) は既にガード済みで、タブ閉じ / リロードが未保存破棄の最後の無防備経路だった。

- **app.js**: `window` に `beforeunload` listener を追加。`e.preventDefault()` + `e.returnValue` 設定 (互換のお作法)。文言はブラウザ標準でカスタム不可
- **blocker 判定は #373 の `collectReloadBlockers` をそのまま再利用** (issue の提案通り): dirty 3 editor + 開いている edit form。「reload で失われるもの」と「unload で失われるもの」の定義は同一なので、開いている form の未確定入力も守られる
- **`shouldBlockUnload` を reload-guard.js に追加**: clean 時に必ず素通しさせる不変条件 (常時ブロックはブラウザにダイアログ自体を抑止される + UX 悪) を pure 関数として pin できる seam にした

## テスト

- `reload-guard.test.js`: `shouldBlockUnload` — blocker あり (dirty / form open) でブロック、clean で素通しを pin
- `beforeunload.e2e.js` (新規, playwright) 4 本: `page.close({ runBeforeUnload: true })` で発火を検証 — dirty で dialog (dismiss で留まる) / form open のみ (未 dirty) でも dialog / clean は dialog 無しで閉じる / undo で clean に戻すとガード解除
  - clean ケースは dialog listener を登録しないことで「ガード誤発火 → Playwright 自動 dismiss → close timeout で fail」となる構成にし、「dialog が出ない」ことを能動的に検証
- vitest 92/92 pass (9 ファイル)、e2e 全 52/52 pass

## 動作確認手順

1. POI をドラッグ / 削除して dirty 化 → タブを閉じる or F5 → 「サイトを離れますか?」確認が出る。キャンセルで編集が残る
2. Edit フォームを開いただけ (OK 前) でも同様に確認が出る
3. Save (Ctrl+S) 後にタブを閉じる → 確認なしで閉じる