### PR TITLE
feat(webui): POI list 選択で画面外 POI へ map をパン (#382)

### DIFF
--- a/mapoi_webui/tests/web/e2e/poi-jump-to.e2e.js
+++ b/mapoi_webui/tests/web/e2e/poi-jump-to.e2e.js
@@ -1,0 +1,90 @@
+// POI list 選択で map を該当 POI へパンする jump-to (#382) の browser smoke。
+// Leaflet の viewport 判定 (getBounds/panTo) は jsdom で動かないため e2e 層で pin する。
+//
+// marker の特定方法: 選択中 marker は highlight icon (stroke #e67e22, map-icons.js) で
+// 一意に locate できる。未選択 marker は DOM 順 = showPois の生成順 (= pois 配列順:
+// wedge, wedge2, disc, pause, landmark) で nth 指定する (highlightPoi の setIcon が
+// 要素を作り直すまでは生成順が保たれる)。
+//
+// map のパン操作は背景の mouse drag (Leaflet 標準)。背景 drag は POI 選択に影響しない。
+// 慣性で drag 後も少し流れるため、位置を比較する検証は静定待ちを挟む。
+const { test, expect } = require('@playwright/test');
+const { loadApp, poiCard, setSectionOpen } = require('./helpers');
+
+// icon の外枠 div で比較する (path は stroke 幅で bounding box が変わるため)
+const HIGHLIGHTED = '.poi-arrow-icon:has(path[stroke="#e67e22"])';
+
+// map を左へ 2 回 drag して view を右へ大きくずらす (POI 群は初期 fitBounds の中央
+// 付近に固まっているので、計 ~800px で全て viewport 外へ出る)。
+async function panMapAway(page) {
+  const box = await page.locator('#map').boundingBox();
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  for (let i = 0; i < 2; i += 1) {
+    await page.mouse.move(cx + 200, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx - 200, cy, { steps: 10 });
+    await page.mouse.up();
+  }
+  // 慣性の静定を待つ
+  await page.waitForTimeout(500);
+}
+
+test.describe('POI list jump-to pan (#382)', () => {
+  test('selecting an off-screen POI pans it into view without changing zoom', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+
+    // poi_pause (生成順 4 番目 = nth(3)) を viewport 外へ追いやる
+    const pauseMarker = page.locator('.poi-arrow-icon').nth(3);
+    await expect(pauseMarker).toBeInViewport();
+    await panMapAway(page);
+    await expect(pauseMarker).not.toBeInViewport();
+    const zoomBefore = await page.locator('#map').getAttribute('data-zoom');
+
+    await poiCard(page, 'poi_pause').locator('.poi-card-name').click();
+
+    // panTo (アニメーション) 完了後、選択 marker が viewport 内に戻る。zoom は不変
+    await expect(page.locator(HIGHLIGHTED)).toBeInViewport();
+    expect(await page.locator('#map').getAttribute('data-zoom')).toBe(zoomBefore);
+  });
+
+  test('selecting a visible POI does not move the map', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+
+    const pauseMarker = page.locator('.poi-arrow-icon').nth(3);
+    const before = await pauseMarker.boundingBox();
+
+    await poiCard(page, 'poi_pause').locator('.poi-card-name').click();
+
+    // highlight で icon は作り直されるが、パンしないので位置は変わらない
+    const highlighted = page.locator(HIGHLIGHTED);
+    await expect(highlighted).toHaveCount(1);
+    const after = await highlighted.boundingBox();
+    expect(Math.abs(after.x - before.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(after.y - before.y)).toBeLessThanOrEqual(1);
+  });
+
+  test('selecting a visibility-off POI (no marker) does not pan or throw', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+
+    // poi_pause の marker を消してから viewport 外相当の状況を作る
+    await poiCard(page, 'poi_pause').locator('.poi-card-checkbox').uncheck();
+    await expect(page.locator('.poi-arrow-icon')).toHaveCount(4);
+    await panMapAway(page);
+
+    const reference = page.locator('.poi-arrow-icon').first();
+    const before = await reference.boundingBox();
+
+    await poiCard(page, 'poi_pause').locator('.poi-card-name').click();
+    await expect(poiCard(page, 'poi_pause')).toHaveClass(/(^|\s)selected(\s|$)/);
+    await page.waitForTimeout(500);
+
+    // marker が無い POI ではパンしない (基準 marker の位置が不変)
+    const after = await page.locator('.poi-arrow-icon').first().boundingBox();
+    expect(Math.abs(after.x - before.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(after.y - before.y)).toBeLessThanOrEqual(1);
+  });
+});

--- a/mapoi_webui/tests/web/e2e/poi-jump-to.e2e.js
+++ b/mapoi_webui/tests/web/e2e/poi-jump-to.e2e.js
@@ -14,6 +14,20 @@ const { loadApp, poiCard, setSectionOpen } = require('./helpers');
 // icon の外枠 div で比較する (path は stroke 幅で bounding box が変わるため)
 const HIGHLIGHTED = '.poi-arrow-icon:has(path[stroke="#e67e22"])';
 
+// drag 慣性 / panTo アニメーションの静定待ち: 基準 marker の位置が短い間隔を挟んで
+// 動かなくなるまでポーリングする (固定 sleep はマシン差で flaky になるため)。
+async function waitForMapSettle(page) {
+  const reference = page.locator('.poi-arrow-icon').first();
+  let prev = await reference.boundingBox();
+  await expect(async () => {
+    await page.waitForTimeout(120);
+    const cur = await reference.boundingBox();
+    const moved = Math.abs(cur.x - prev.x) > 0.5 || Math.abs(cur.y - prev.y) > 0.5;
+    prev = cur;
+    expect(moved).toBe(false);
+  }).toPass({ timeout: 5000 });
+}
+
 // map を左へ 2 回 drag して view を右へ大きくずらす (POI 群は初期 fitBounds の中央
 // 付近に固まっているので、計 ~800px で全て viewport 外へ出る)。
 async function panMapAway(page) {
@@ -26,8 +40,7 @@ async function panMapAway(page) {
     await page.mouse.move(cx - 200, cy, { steps: 10 });
     await page.mouse.up();
   }
-  // 慣性の静定を待つ
-  await page.waitForTimeout(500);
+  await waitForMapSettle(page);
 }
 
 test.describe('POI list jump-to pan (#382)', () => {
@@ -80,11 +93,25 @@ test.describe('POI list jump-to pan (#382)', () => {
 
     await poiCard(page, 'poi_pause').locator('.poi-card-name').click();
     await expect(poiCard(page, 'poi_pause')).toHaveClass(/(^|\s)selected(\s|$)/);
-    await page.waitForTimeout(500);
+    await waitForMapSettle(page);
 
     // marker が無い POI ではパンしない (基準 marker の位置が不変)
     const after = await page.locator('.poi-arrow-icon').first().boundingBox();
     expect(Math.abs(after.x - before.x)).toBeLessThanOrEqual(1);
     expect(Math.abs(after.y - before.y)).toBeLessThanOrEqual(1);
+  });
+
+  test('nav goal dropdown selection also pans to an off-screen POI', async ({ page }) => {
+    await loadApp(page);
+    await setSectionOpen(page, '#btn-poi-toggle', '#poi-body', true);
+
+    await panMapAway(page);
+    await expect(page.locator('.poi-arrow-icon').nth(3)).not.toBeInViewport();
+
+    // nav dropdown (#262) も selectPoi → onSelectionChange の同一 funnel を通る
+    await page.locator('#nav-goal-select').selectOption('poi_pause');
+
+    await expect(poiCard(page, 'poi_pause')).toHaveClass(/(^|\s)selected(\s|$)/);
+    await expect(page.locator(HIGHLIGHTED)).toBeInViewport();
   });
 });

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -323,6 +323,12 @@
       mapViewer.showPois(poiEditor.pois, poiEditor.visiblePois);
       if (index >= 0) mapViewer.highlightPoi(index);
     }
+    // 画面外の POI を選んだら map をパンして見せる (#382)。map クリック由来の選択は
+    // クリックした POI が必ず viewport 内なのでパンしない (視点が飛ばない)。dirty 時の
+    // showPois 再描画より後に呼び、再生成後の実 marker 位置で判定する。
+    if (index >= 0) {
+      mapViewer.panToPoiIfHidden(index);
+    }
     // Enable pose tool when editing, disable when form closes
     if (poiEditor.editingIndex >= 0) {
       enablePoseToolForEditing();

--- a/mapoi_webui/web/js/map-viewer.js
+++ b/mapoi_webui/web/js/map-viewer.js
@@ -436,6 +436,24 @@ class MapViewer {
   }
 
   /**
+   * 選択 POI が viewport 外なら中心へパンする (#382)。ズームは変えない (panTo)。
+   *
+   * 「既に viewport 内なら動かさない」判定で選択経路を一本化する (issue #382 の
+   * 実装時判断): map クリック由来の選択はクリックした POI が必ず見えているので
+   * パンせず視点が飛ばない。list / nav dropdown (#262) 由来で画面外の POI を
+   * 選んだ時だけ寄せる。可視性 checkbox が off の POI は marker が無い (= 地図に
+   * 出ていない) のでパンしない。
+   */
+  panToPoiIfHidden(index) {
+    if (!this.metadata) return;
+    const item = this.poiMarkers.find((m) => m.index === index);
+    if (!item) return;
+    const latlng = item.marker.getLatLng();
+    if (this.map.getBounds().contains(latlng)) return;
+    this.map.panTo(latlng);
+  }
+
+  /**
    * 選択中 (highlighted) の POI marker だけドラッグ可能にする (#239)。_poiDraggingAllowed が
    * false (route 編集中等) のときは選択中でも無効。setIcon で DOM 要素が差し替わっても
    * Leaflet の dragging handler は marker に紐づくので enable/disable はそのまま効く。


### PR DESCRIPTION
Closes #382

## 変更内容

POI list / nav dropdown で選択した POI が画面外にある場合、map を該当 POI へパンする。ズームは変えない (`panTo`)。

- **map-viewer.js**: `panToPoiIfHidden(index)` を追加。marker の latlng が `map.getBounds()` 内なら no-op、外なら `panTo`
- **app.js**: `poiEditor.onSelectionChange` から呼ぶ (dirty 時の showPois 再描画より後、再生成後の実 marker 位置で判定)
- **選択経路の区別 (issue の論点) は「viewport 外の時だけパンする」判定で一本化**: map クリック由来の選択はクリックした POI が必ず viewport 内なのでパンせず視点が飛ばない。list / nav dropdown (#262) 由来で画面外の POI を選んだ時だけ寄る。経路ごとの分岐フラグが不要になり、既存の選択 funnel (selectPoi → onSelectionChange) に手を入れない
- **可視性 checkbox off の POI は marker が無いのでパンしない** (地図に出ていないものへ寄っても何も見えない)
- route 編集中の waypoint focus (#305 `onWaypointFocus`) は issue の通り初期 scope 外 (onSelectionChange 経由ではないため影響なし)

## テスト

`poi-jump-to.e2e.js` (新規, playwright) 3 本 (`--repeat-each=3` で安定確認済):

1. map を drag で退避 → 画面外の poi_pause を list 選択 → 選択 marker が viewport 内へ戻り、zoom (`data-zoom` test hook) は不変
2. 見えている POI の list 選択では map が動かない (highlight 前後で marker 位置が不変)
3. 可視性 off (marker 無し) の POI 選択ではパンも例外も起きない

Leaflet の getBounds/panTo は jsdom で動かないため e2e 層のみ (unit の切り出し対象になる pure ロジックが無い)。vitest 90/90 pass (9 ファイル)、e2e 全 51/51 pass。

## 動作確認手順

1. map をズーム/パンして POI を画面外へ → POI list でその POI をクリック → map が該当 POI へ滑らかにパン (ズーム不変)
2. 見えている POI をクリック → map は動かない
3. Navigation の goal dropdown で画面外 POI を選択 → 同様にパン