### PR TITLE
feat(webui): L/U キーで POI ロックと UI 表示をトグル (#390)

### DIFF
--- a/mapoi_webui/tests/web/e2e/lock-hide-shortcut.e2e.js
+++ b/mapoi_webui/tests/web/e2e/lock-hide-shortcut.e2e.js
@@ -1,4 +1,4 @@
-// POI 位置ロック (L) / UI 一括表示 (H) の単キーショートカット (#390) の browser smoke。
+// POI 位置ロック (L) / UI 一括表示 (U) の単キーショートカット (#390) の browser smoke。
 // document keydown IIFE (app.js) は jsdom で実体テストしない方針 (#300 risk-based) のため、
 // Delete (#374) / Ctrl+S (#375) と同じく e2e 層で配線を pin する。
 // 実装は既存ボタンの .click() 再利用 (single code path) なので、ボタン側の挙動
@@ -22,7 +22,7 @@ function dispatchRepeatKeydown(page, key) {
   }, key);
 }
 
-test.describe('L/H キーボードショートカット (#390)', () => {
+test.describe('L/U キーボードショートカット (#390)', () => {
   test('L がロックボタンと同経路でトグルし、選択中 POI の draggable に反映される', async ({ page }) => {
     await loadApp(page);
 
@@ -44,33 +44,33 @@ test.describe('L/H キーボードショートカット (#390)', () => {
     await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(0);
   });
 
-  test('H が Hide UI ボタンと同経路で body.ui-hidden をトグルする', async ({ page }) => {
+  test('U が Hide UI ボタンと同経路で body.ui-hidden をトグルする', async ({ page }) => {
     await loadApp(page);
-    await expect(page.locator('#btn-ui-toggle')).toHaveAttribute('title', /\(H\)$/);
+    await expect(page.locator('#btn-ui-toggle')).toHaveAttribute('title', /\(U\)$/);
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
 
-    await page.keyboard.press('h');
+    await page.keyboard.press('u');
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(true);
-    // ui-hidden 中も #ui-controls は残る仕様 (復帰手段) — H での復帰もその一部。
-    // 大文字 (Shift+H) も L 側と対称に pin する (Cursor review low 対応)
-    await page.keyboard.press('Shift+H');
+    // ui-hidden 中も #ui-controls は残る仕様 (復帰手段) — U での復帰もその一部。
+    // 大文字 (Shift+U) も L 側と対称に pin する (Cursor review low 対応)
+    await page.keyboard.press('Shift+U');
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
   });
 
-  test('入力欄 focus 中は L/H とも無視され、文字入力として通る', async ({ page }) => {
+  test('入力欄 focus 中は L/U とも無視され、文字入力として通る', async ({ page }) => {
     await loadApp(page);
     const lockBtn = page.locator('#btn-poi-lock-toggle');
 
     await page.locator('#poi-search').focus();
     await page.keyboard.press('l');
-    await page.keyboard.press('h');
+    await page.keyboard.press('u');
 
-    await expect(page.locator('#poi-search')).toHaveValue('lh');
+    await expect(page.locator('#poi-search')).toHaveValue('lu');
     await expect(lockBtn).toHaveAttribute('aria-pressed', 'true');
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
   });
 
-  test('Ctrl+L / Ctrl+H / Cmd+L / Cmd+H (ブラウザショートカット) は所有しない', async ({ page }) => {
+  test('Ctrl+L / Ctrl+U / Cmd+L / Cmd+U (ブラウザショートカット) は所有しない', async ({ page }) => {
     await loadApp(page);
 
     // headless では実ブラウザ機能 (アドレスバー等) は発火しないが、app 側の
@@ -78,7 +78,7 @@ test.describe('L/H キーボードショートカット (#390)', () => {
     // metaKey (Mac の Cmd) / altKey も同じ guard を通ることを pin する (Cursor review 対応)。
     await page.evaluate(() => {
       for (const mod of [{ ctrlKey: true }, { metaKey: true }, { altKey: true }]) {
-        for (const key of ['l', 'h']) {
+        for (const key of ['l', 'u']) {
           document.body.dispatchEvent(
             new KeyboardEvent('keydown', { key, bubbles: true, ...mod }));
         }
@@ -94,7 +94,7 @@ test.describe('L/H キーボードショートカット (#390)', () => {
     const lockBtn = page.locator('#btn-poi-lock-toggle');
 
     await dispatchRepeatKeydown(page, 'l');
-    await dispatchRepeatKeydown(page, 'h');
+    await dispatchRepeatKeydown(page, 'u');
 
     await expect(lockBtn).toHaveAttribute('aria-pressed', 'true');
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);

--- a/mapoi_webui/tests/web/e2e/lock-hide-shortcut.e2e.js
+++ b/mapoi_webui/tests/web/e2e/lock-hide-shortcut.e2e.js
@@ -75,9 +75,9 @@ test.describe('L/H キーボードショートカット (#390)', () => {
 
     // headless では実ブラウザ機能 (アドレスバー等) は発火しないが、app 側の
     // ハンドラが修飾キー付きを無視することは合成 dispatch で検証できる。
-    // metaKey (Mac の Cmd) も同じ guard を通ることを pin する (Cursor review medium 対応)。
+    // metaKey (Mac の Cmd) / altKey も同じ guard を通ることを pin する (Cursor review 対応)。
     await page.evaluate(() => {
-      for (const mod of [{ ctrlKey: true }, { metaKey: true }]) {
+      for (const mod of [{ ctrlKey: true }, { metaKey: true }, { altKey: true }]) {
         for (const key of ['l', 'h']) {
           document.body.dispatchEvent(
             new KeyboardEvent('keydown', { key, bubbles: true, ...mod }));

--- a/mapoi_webui/tests/web/e2e/lock-hide-shortcut.e2e.js
+++ b/mapoi_webui/tests/web/e2e/lock-hide-shortcut.e2e.js
@@ -51,8 +51,9 @@ test.describe('L/H キーボードショートカット (#390)', () => {
 
     await page.keyboard.press('h');
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(true);
-    // ui-hidden 中も #ui-controls は残る仕様 (復帰手段) — H での復帰もその一部
-    await page.keyboard.press('h');
+    // ui-hidden 中も #ui-controls は残る仕様 (復帰手段) — H での復帰もその一部。
+    // 大文字 (Shift+H) も L 側と対称に pin する (Cursor review low 対応)
+    await page.keyboard.press('Shift+H');
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
   });
 
@@ -69,16 +70,19 @@ test.describe('L/H キーボードショートカット (#390)', () => {
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
   });
 
-  test('Ctrl+L / Ctrl+H (ブラウザショートカット) は所有しない', async ({ page }) => {
+  test('Ctrl+L / Ctrl+H / Cmd+L / Cmd+H (ブラウザショートカット) は所有しない', async ({ page }) => {
     await loadApp(page);
 
     // headless では実ブラウザ機能 (アドレスバー等) は発火しないが、app 側の
     // ハンドラが修飾キー付きを無視することは合成 dispatch で検証できる。
+    // metaKey (Mac の Cmd) も同じ guard を通ることを pin する (Cursor review medium 対応)。
     await page.evaluate(() => {
-      document.body.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'l', ctrlKey: true, bubbles: true }));
-      document.body.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'h', ctrlKey: true, bubbles: true }));
+      for (const mod of [{ ctrlKey: true }, { metaKey: true }]) {
+        for (const key of ['l', 'h']) {
+          document.body.dispatchEvent(
+            new KeyboardEvent('keydown', { key, bubbles: true, ...mod }));
+        }
+      }
     });
 
     await expect(page.locator('#btn-poi-lock-toggle')).toHaveAttribute('aria-pressed', 'true');

--- a/mapoi_webui/tests/web/e2e/lock-hide-shortcut.e2e.js
+++ b/mapoi_webui/tests/web/e2e/lock-hide-shortcut.e2e.js
@@ -1,0 +1,105 @@
+// POI 位置ロック (L) / UI 一括表示 (H) の単キーショートカット (#390) の browser smoke。
+// document keydown IIFE (app.js) は jsdom で実体テストしない方針 (#300 risk-based) のため、
+// Delete (#374) / Ctrl+S (#375) と同じく e2e 層で配線を pin する。
+// 実装は既存ボタンの .click() 再利用 (single code path) なので、ボタン側の挙動
+// (poi-position-lock.e2e.js / ui-settings.e2e.js) は再検証せず、キー→ボタンの配線と
+// guard (入力欄 focus / e.repeat) だけを見る。
+const { test, expect } = require('@playwright/test');
+const { loadApp, selectPoi } = require('./helpers');
+
+const DRAGGABLE_ARROW = '.poi-arrow-icon.leaflet-marker-draggable';
+
+function bodyHasClass(page, cls) {
+  return page.locator('body').evaluate((el, c) => el.classList.contains(c), cls);
+}
+
+// Playwright の keyboard.press は repeat イベントを合成できないため、
+// e.repeat=true の keydown を直接 dispatch する (listener は document なので届く)。
+function dispatchRepeatKeydown(page, key) {
+  return page.evaluate((k) => {
+    document.body.dispatchEvent(
+      new KeyboardEvent('keydown', { key: k, repeat: true, bubbles: true }));
+  }, key);
+}
+
+test.describe('L/H キーボードショートカット (#390)', () => {
+  test('L がロックボタンと同経路でトグルし、選択中 POI の draggable に反映される', async ({ page }) => {
+    await loadApp(page);
+
+    const lockBtn = page.locator('#btn-poi-lock-toggle');
+    await expect(lockBtn).toHaveAttribute('aria-pressed', 'true');
+    // ショートカットの発見手段は title 表記 (#375 の (Ctrl+S) と同じ流儀)
+    await expect(lockBtn).toHaveAttribute('title', /\(L\)$/);
+
+    await selectPoi(page, 'poi_wedge');
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(0);
+
+    await page.keyboard.press('l');
+    await expect(lockBtn).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(1);
+
+    // 大文字 (Shift+L) でも同じ (Caps Lock / Shift 状態に依存しない)
+    await page.keyboard.press('Shift+L');
+    await expect(lockBtn).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator(DRAGGABLE_ARROW)).toHaveCount(0);
+  });
+
+  test('H が Hide UI ボタンと同経路で body.ui-hidden をトグルする', async ({ page }) => {
+    await loadApp(page);
+    await expect(page.locator('#btn-ui-toggle')).toHaveAttribute('title', /\(H\)$/);
+    expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
+
+    await page.keyboard.press('h');
+    expect(await bodyHasClass(page, 'ui-hidden')).toBe(true);
+    // ui-hidden 中も #ui-controls は残る仕様 (復帰手段) — H での復帰もその一部
+    await page.keyboard.press('h');
+    expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
+  });
+
+  test('入力欄 focus 中は L/H とも無視され、文字入力として通る', async ({ page }) => {
+    await loadApp(page);
+    const lockBtn = page.locator('#btn-poi-lock-toggle');
+
+    await page.locator('#poi-search').focus();
+    await page.keyboard.press('l');
+    await page.keyboard.press('h');
+
+    await expect(page.locator('#poi-search')).toHaveValue('lh');
+    await expect(lockBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
+  });
+
+  test('Ctrl+L / Ctrl+H (ブラウザショートカット) は所有しない', async ({ page }) => {
+    await loadApp(page);
+
+    // headless では実ブラウザ機能 (アドレスバー等) は発火しないが、app 側の
+    // ハンドラが修飾キー付きを無視することは合成 dispatch で検証できる。
+    await page.evaluate(() => {
+      document.body.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'l', ctrlKey: true, bubbles: true }));
+      document.body.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'h', ctrlKey: true, bubbles: true }));
+    });
+
+    await expect(page.locator('#btn-poi-lock-toggle')).toHaveAttribute('aria-pressed', 'true');
+    expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
+  });
+
+  test('長押し repeat (e.repeat) では状態が変わらない', async ({ page }) => {
+    await loadApp(page);
+    const lockBtn = page.locator('#btn-poi-lock-toggle');
+
+    await dispatchRepeatKeydown(page, 'l');
+    await dispatchRepeatKeydown(page, 'h');
+
+    await expect(lockBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
+
+    // 非 repeat の合成 keydown は通る = dispatch 経路自体が有効なことの対照
+    await page.evaluate(() => {
+      document.body.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'l', bubbles: true }));
+    });
+    await expect(lockBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/mapoi_webui/tests/web/e2e/ui-settings.e2e.js
+++ b/mapoi_webui/tests/web/e2e/ui-settings.e2e.js
@@ -30,24 +30,27 @@ async function setAlphaPercent(page, percent) {
 }
 
 test.describe('UI 表示コントロール (#323 / #324)', () => {
-  test('トグルで header/panel を隠し、再クリックで戻す。#ui-controls は残り icon が swap する', async ({ page }) => {
+  test('トグルで header/panel を隠し、再クリックで戻す。#ui-controls は残り pressed 状態が同期する', async ({ page }) => {
     await loadApp(page);
+    const toggleBtn = page.locator('#btn-ui-toggle');
     expect(await displayOf(page, 'header')).not.toBe('none');
     expect(await displayOf(page, '#poi-panel')).not.toBe('none');
-    // 表示中は「隠す」action の eye-off icon
-    expect(await displayOf(page, '#ui-toggle-icon-hide')).not.toBe('none');
-    expect(await displayOf(page, '#ui-toggle-icon-show')).toBe('none');
+    // アイコンは固定の ☰ (#390、swap しない)。状態は aria-pressed と title で示す
+    await expect(toggleBtn.locator('.ui-control-glyph')).toHaveText('☰');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
+    await expect(toggleBtn).toHaveAttribute('title', 'Hide UI (U)');
 
-    await page.locator('#btn-ui-toggle').click();
+    await toggleBtn.click();
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(true);
     expect(await displayOf(page, 'header')).toBe('none');
     expect(await displayOf(page, '#poi-panel')).toBe('none');
-    // UI を復帰できるようコントロール自身は残し、icon は「戻す」action の eye に swap
+    // UI を復帰できるようコントロール自身は残し、pressed (青) + title が「戻す」側へ同期
     expect(await displayOf(page, '#ui-controls')).not.toBe('none');
-    expect(await displayOf(page, '#ui-toggle-icon-hide')).toBe('none');
-    expect(await displayOf(page, '#ui-toggle-icon-show')).not.toBe('none');
+    await expect(toggleBtn.locator('.ui-control-glyph')).toHaveText('☰');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
+    await expect(toggleBtn).toHaveAttribute('title', 'Show UI (U)');
 
-    await page.locator('#btn-ui-toggle').click();
+    await toggleBtn.click();
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(false);
     expect(await displayOf(page, 'header')).not.toBe('none');
     expect(await displayOf(page, '#poi-panel')).not.toBe('none');

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -62,7 +62,7 @@
           <span class="ui-control-glyph" aria-hidden="true">&#8630;</span>
         </button>
         <button id="btn-ui-toggle" type="button" class="ui-control-btn"
-                aria-pressed="false" title="Hide UI (H)" aria-label="Toggle UI visibility">
+                aria-pressed="false" title="Hide UI (U)" aria-label="Toggle UI visibility">
           <svg id="ui-toggle-icon-hide" class="ui-control-icon-svg" viewBox="0 0 24 24"
                fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                stroke-linejoin="round" aria-hidden="true">

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -38,7 +38,7 @@
              対象外 (誤操作リスクが無い)。配線は app.js、実体制御は
              MapViewer.setPoiDraggingAllowed (route 編集中の抑止と AND)。 -->
         <button id="btn-poi-lock-toggle" type="button" class="ui-control-btn"
-                aria-pressed="true" title="Unlock POI position editing" aria-label="Toggle POI position lock">
+                aria-pressed="true" title="Unlock POI position editing (L)" aria-label="Toggle POI position lock">
           <svg id="poi-lock-icon-locked" class="ui-control-icon-svg" viewBox="0 0 24 24"
                fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                stroke-linejoin="round" aria-hidden="true">
@@ -62,7 +62,7 @@
           <span class="ui-control-glyph" aria-hidden="true">&#8630;</span>
         </button>
         <button id="btn-ui-toggle" type="button" class="ui-control-btn"
-                aria-pressed="false" title="Hide UI" aria-label="Toggle UI visibility">
+                aria-pressed="false" title="Hide UI (H)" aria-label="Toggle UI visibility">
           <svg id="ui-toggle-icon-hide" class="ui-control-icon-svg" viewBox="0 0 24 24"
                fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                stroke-linejoin="round" aria-hidden="true">

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -25,10 +25,12 @@
       <div id="cursor-readout" class="hidden"></div>
 
       <!-- 地図上にフロートする UI 一括表示/非表示トグル (#324)。ui-hidden 時も残る
-           ので UI を復帰できる。アイコンは action-based の eye SVG (表示中 = eye-off
-           「隠す」、非表示中 = eye「戻す」)。◑/⚙ グリフはダークモード/アプリ設定と
-           誤読されるため不採用。overlay / 不透明度の設定はパネル内 Display section
-           (#323)。配線は ui-settings.js。 -->
+           ので UI を復帰できる。アイコンは固定の ☰ (Gmail/YouTube の sidebar トグルと
+           同じ流儀、#390)。状態は swap でなく aria-pressed (青ハイライト) とパネル自体の
+           有無で示す — 当初の eye/eye-off swap (#324) は「アイコンが状態か操作か」の
+           両義性に加え、地図文脈では marker/レイヤー可視と誤読され得るため置換。
+           ◑/⚙ グリフはダークモード/アプリ設定と誤読されるため不採用 (#324)。
+           overlay / 不透明度の設定はパネル内 Display section (#323)。配線は ui-settings.js。 -->
       <div id="ui-controls">
         <!-- 選択中 POI の位置編集 (drag + yaw ハンドル) を明示的にロック/アンロックする
              (#333)。位置編集はロボット運用の主作業 (ナビゲーション/監視) に対して「たまに
@@ -63,20 +65,7 @@
         </button>
         <button id="btn-ui-toggle" type="button" class="ui-control-btn"
                 aria-pressed="false" title="Hide UI (U)" aria-label="Toggle UI visibility">
-          <svg id="ui-toggle-icon-hide" class="ui-control-icon-svg" viewBox="0 0 24 24"
-               fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-               stroke-linejoin="round" aria-hidden="true">
-            <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/>
-            <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/>
-            <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24"/>
-            <line x1="1" y1="1" x2="23" y2="23"/>
-          </svg>
-          <svg id="ui-toggle-icon-show" class="ui-control-icon-svg hidden" viewBox="0 0 24 24"
-               fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-               stroke-linejoin="round" aria-hidden="true">
-            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
-            <circle cx="12" cy="12" r="3"/>
-          </svg>
+          <span class="ui-control-glyph" aria-hidden="true">&#9776;</span>
         </button>
       </div>
     </div>

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -1095,12 +1095,14 @@
         document, name ? `Deleted POI "${name}" (Ctrl+Z to undo)` : 'Deleted POI (Ctrl+Z to undo)');
       return;
     }
-    // POI 位置ロック / UI 一括表示の単キートグル (#390)。地図右上の既存ボタンの .click()
-    // を呼ぶだけの single code path (状態同期・永続化は各 click handler に集約済み)。
-    // Ctrl+L (アドレスバー) / Ctrl+H (履歴) 等のブラウザショートカットは所有しないため
-    // 修飾キーなしに限定。toggle なので長押し repeat で状態が暴れないよう e.repeat は
-    // 無視する。toast は出さない: どちらのボタンも地図上に常時見えており (ui-hidden 中も
-    // #ui-controls は残る)、icon / aria-pressed の変化で足りる。
+    // POI 位置ロック (L) / UI 一括表示 (U) の単キートグル (#390)。キーは対象の頭文字
+    // (Lock / UI)。U は Hide/Show が状態で反転して頭文字にできない (H 案は棄却) ため。
+    // 地図右上の既存ボタンの .click() を呼ぶだけの single code path (状態同期・永続化は
+    // 各 click handler に集約済み)。Ctrl+L (アドレスバー) / Ctrl+U (ソース表示) 等の
+    // ブラウザショートカットは所有しないため修飾キーなしに限定。toggle なので長押し
+    // repeat で状態が暴れないよう e.repeat は無視する。toast は出さない: どちらの
+    // ボタンも地図上に常時見えており (ui-hidden 中も #ui-controls は残る)、
+    // icon / aria-pressed の変化で足りる。
     if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.repeat) {
       const key = e.key.toLowerCase();
       if (key === 'l') {
@@ -1108,7 +1110,7 @@
         if (btnPoiLockToggle) btnPoiLockToggle.click();
         return;
       }
-      if (key === 'h') {
+      if (key === 'u') {
         e.preventDefault();
         // 配線は ui-settings.js initDom。app.js は要素を掴むだけで状態を持たない。
         const btnUiToggle = document.getElementById('btn-ui-toggle');

--- a/mapoi_webui/web/js/app.js
+++ b/mapoi_webui/web/js/app.js
@@ -423,7 +423,8 @@
   function applyPoiLockUi() {
     if (btnPoiLockToggle) {
       btnPoiLockToggle.setAttribute('aria-pressed', String(poiPositionLocked));
-      btnPoiLockToggle.title = poiPositionLocked ? 'Unlock POI position editing' : 'Lock POI position editing';
+      btnPoiLockToggle.title = poiPositionLocked
+        ? 'Unlock POI position editing (L)' : 'Lock POI position editing (L)';
     }
     if (poiLockIconLocked) poiLockIconLocked.classList.toggle('hidden', !poiPositionLocked);
     if (poiLockIconUnlocked) poiLockIconUnlocked.classList.toggle('hidden', poiPositionLocked);
@@ -1093,6 +1094,27 @@
       MapoiToast.showToast(
         document, name ? `Deleted POI "${name}" (Ctrl+Z to undo)` : 'Deleted POI (Ctrl+Z to undo)');
       return;
+    }
+    // POI 位置ロック / UI 一括表示の単キートグル (#390)。地図右上の既存ボタンの .click()
+    // を呼ぶだけの single code path (状態同期・永続化は各 click handler に集約済み)。
+    // Ctrl+L (アドレスバー) / Ctrl+H (履歴) 等のブラウザショートカットは所有しないため
+    // 修飾キーなしに限定。toggle なので長押し repeat で状態が暴れないよう e.repeat は
+    // 無視する。toast は出さない: どちらのボタンも地図上に常時見えており (ui-hidden 中も
+    // #ui-controls は残る)、icon / aria-pressed の変化で足りる。
+    if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.repeat) {
+      const key = e.key.toLowerCase();
+      if (key === 'l') {
+        e.preventDefault();
+        if (btnPoiLockToggle) btnPoiLockToggle.click();
+        return;
+      }
+      if (key === 'h') {
+        e.preventDefault();
+        // 配線は ui-settings.js initDom。app.js は要素を掴むだけで状態を持たない。
+        const btnUiToggle = document.getElementById('btn-ui-toggle');
+        if (btnUiToggle) btnUiToggle.click();
+        return;
+      }
     }
     if (!(e.ctrlKey || e.metaKey)) return;
     const key = e.key.toLowerCase();

--- a/mapoi_webui/web/js/ui-settings.js
+++ b/mapoi_webui/web/js/ui-settings.js
@@ -143,8 +143,6 @@
 
     const body = doc.body;
     const toggleBtn = doc.getElementById('btn-ui-toggle');
-    const iconHide = doc.getElementById('ui-toggle-icon-hide');
-    const iconShow = doc.getElementById('ui-toggle-icon-show');
     const displayToggleBtn = doc.getElementById('btn-display-toggle');
     const displayBody = doc.getElementById('display-body');
     const overlayChk = doc.getElementById('ui-overlay-toggle');
@@ -173,13 +171,12 @@
       }
     }
 
-    // action-based icon: 表示中は eye-off (「隠す」)、非表示中は eye (「戻す」)。
+    // アイコンは固定の ☰ (#390、index.html 側)。状態は aria-pressed (青ハイライト) と
+    // title だけを同期し、icon swap はしない — Gmail/YouTube の sidebar トグルと同じ流儀。
     function syncToggleBtn() {
       if (!toggleBtn) return;
       toggleBtn.setAttribute('aria-pressed', settings.hidden ? 'true' : 'false');
       toggleBtn.title = settings.hidden ? 'Show UI (U)' : 'Hide UI (U)';
-      if (iconHide) iconHide.classList.toggle('hidden', settings.hidden);
-      if (iconShow) iconShow.classList.toggle('hidden', !settings.hidden);
     }
 
     function syncAlphaControls() {

--- a/mapoi_webui/web/js/ui-settings.js
+++ b/mapoi_webui/web/js/ui-settings.js
@@ -177,7 +177,7 @@
     function syncToggleBtn() {
       if (!toggleBtn) return;
       toggleBtn.setAttribute('aria-pressed', settings.hidden ? 'true' : 'false');
-      toggleBtn.title = settings.hidden ? 'Show UI (H)' : 'Hide UI (H)';
+      toggleBtn.title = settings.hidden ? 'Show UI (U)' : 'Hide UI (U)';
       if (iconHide) iconHide.classList.toggle('hidden', settings.hidden);
       if (iconShow) iconShow.classList.toggle('hidden', !settings.hidden);
     }

--- a/mapoi_webui/web/js/ui-settings.js
+++ b/mapoi_webui/web/js/ui-settings.js
@@ -177,7 +177,7 @@
     function syncToggleBtn() {
       if (!toggleBtn) return;
       toggleBtn.setAttribute('aria-pressed', settings.hidden ? 'true' : 'false');
-      toggleBtn.title = settings.hidden ? 'Show UI' : 'Hide UI';
+      toggleBtn.title = settings.hidden ? 'Show UI (H)' : 'Hide UI (H)';
       if (iconHide) iconHide.classList.toggle('hidden', settings.hidden);
       if (iconShow) iconShow.classList.toggle('hidden', !settings.hidden);
     }


### PR DESCRIPTION
Closes #390

## 変更内容

POI 位置ロック (#333) と UI 一括表示切替 (#324) に単キーショートカットを追加する。

| キー | 動作 | 相当ボタン |
|---|---|---|
| `L` | POI position lock ⇄ unlock | `#btn-poi-lock-toggle` |
| `U` | UI hide ⇄ show | `#btn-ui-toggle` |

## 実装

- **app.js の document keydown funnel** (#300/#374/#375 と同じ) に追加。`isEditableTarget` guard の**後**に置き、入力欄で l/u をタイプしても発火しない
- **既存ボタンの `.click()` を呼ぶ single code path**: lock は app.js の click handler (toggle → applyPoiLockUi → refreshPoiDraggingAllowed)、Hide UI は ui-settings.js initDom の handler (applySettings → persist → syncToggleBtn → notifyMapResize) をそのまま再利用。状態同期・localStorage 永続の二重実装を作らない
- 修飾キー付き (Ctrl+L アドレスバー / Ctrl+U ソース表示等のブラウザショートカット) は所有しない。toggle なので長押し repeat で状態が暴れないよう `e.repeat` は無視
- ボタン `title` に `(L)` / `(U)` を追記 (#375 の `(Ctrl+S)` 表記と同じ流儀)。title は applyPoiLockUi / syncToggleBtn が動的に上書きするため、**JS 側の文字列と index.html の初期値の両方**を更新
- toast は出さない: どちらのボタンも地図上に常時見えており (ui-hidden 中も `#ui-controls` は残る仕様)、icon / aria-pressed の変化で十分

## テスト

- e2e `lock-hide-shortcut.e2e.js` (新規 5 件): L→aria-pressed 反転 + 選択 POI の draggable 反映 / U→`body.ui-hidden` 反転・復帰 / 入力欄 focus 中は両方無視 (文字入力として通る) / Ctrl+L / Ctrl+U 無視 / `e.repeat` 無視
- ボタン側の挙動は poi-position-lock.e2e.js / ui-settings.e2e.js で pin 済みのため再検証しない (キー→ボタンの配線と guard のみ)
- ローカル: vitest 97 pass / playwright e2e 67 pass (全 suite)

## 備考

- Vimium 等の Vim 系ブラウザ拡張は l/u 等の単キーを横取りするため、「効かない」報告はまず拡張のサイト除外を案内する (issue 記載)。Help overlay (#391) のショートカット一覧にも注記予定
- #391 (Help overlay) はこの PR の merge 後に merge する (Help の一覧に L/U を載せるため)
- UI トグルは当初 `H` (Hide) だったが、Hide/Show が状態で反転して頭文字にできず覚えにくいため、「キー = 対象の頭文字 (Lock / UI)」方式で `U` に変更 (2026-07-10 実機確認後の判断)
- UI トグルのアイコンも eye/eye-off swap (#324) から**固定 ☰ + aria-pressed (青ハイライト)** に変更 (同日の判断)。eye は「アイコンが状態か操作か」の両義性があり、地図文脈では marker/レイヤー可視とも誤読され得る。Gmail/YouTube の sidebar トグルと同じ流儀で、swap ロジックも削除して簡素化
