### PR TITLE
perf(server): rviz2_publisher に差分ゲートを追加 (#402)

### DIFF
--- a/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
+++ b/mapoi_server/include/mapoi_server/mapoi_rviz2_publisher.hpp
@@ -116,6 +116,25 @@ private:
   size_t routes_fetch_generation_ = 0;
   // 前回 publish 時の route marker max id (DELETEALL 判定用、id_buf_ と独立)
   int route_id_buf_ = 0;
+
+  // --- 差分ゲート (#402) ---
+  // 1Hz の timer_callback で毎 tick フル再構築 (cos/sin/頂点列生成) するのが無駄なため、
+  // データ (pois_list_ / all_routes_ / highlight / 描画 parameter) が変わった tick だけ
+  // marker を再構築し、変化なしの tick は cache の header.stamp だけ更新して再 publish する。
+  // 再 publish 自体は継続する: 購読側 QoS が volatile なので、後着 RViz へ marker を届けるには
+  // 1Hz 再送を保つ必要がある (issue #402 の要件)。
+  // dirty フラグはデータ書き込み点 (subscription callback / service callback) で立て、
+  // timer_callback がフル構築した tick で消費 (クリア) する。data_mutex_ 下で読み書きする。
+  bool marker_data_dirty_ = true;  // 初期 true で初回 tick は必ずフル構築する
+  // 直近のフル構築結果 (dirty tick でここに保存、clean tick は stamp のみ更新して再 publish)
+  visualization_msgs::msg::MarkerArray cached_ma_pois_;
+  visualization_msgs::msg::MarkerArray cached_ma_routes_;
+
+  // 描画 parameter の前回値 (timer_callback 冒頭で現値と比較し、変化していたら dirty を立てる)。
+  // parameter callback 機構は追加せず、get_parameter (現状も毎 tick 呼んでいる) の結果で検出する。
+  bool last_show_sector_ = true;               // show_tolerance_sector の default
+  std::string last_poi_label_format_ = "index";  // poi_label_format の default
+  std::string last_route_display_mode_ = "selected";  // route_display_mode の default
 };
 
 #endif  // MAPOI_SERVER__MAPOI_RVIZ2_PUBLISHER_HPP_

--- a/mapoi_server/src/mapoi_gz_bridge.cpp
+++ b/mapoi_server/src/mapoi_gz_bridge.cpp
@@ -107,8 +107,9 @@ void MapoiGzBridge::on_initialpose_poi(
 void MapoiGzBridge::on_config_path(const std_msgs::msg::String::SharedPtr msg)
 {
   // 軽量。queue に push して即 return。state 操作と service call は worker。
-  // mapoi_server は config_path を 500ms 周期で re-publish するため、worker が
-  // service 不達などで blocking 中だと queue が際限なく膨らむ。常に latest 1 件のみ
+  // mapoi_server は config_path を event 駆動で publish する (周期 re-publish は #135 で廃止し
+  // transient_local QoS に移行。起動時 / select_map / reload_map_info の 3 箇所)。それでも worker が
+  // service 不達などで blocking 中に複数 event が来ると queue が膨らみ得るため、常に latest 1 件のみ
   // 保持する coalesce 戦略で、stale な path は破棄する。
   {
     std::lock_guard<std::mutex> lock(queue_mutex_);

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -120,6 +120,7 @@ void MapoiRviz2Publisher::on_routes_info_received(
   if (result->routes_list.empty()) {
     std::lock_guard<std::mutex> lock(data_mutex_);
     all_routes_.clear();
+    marker_data_dirty_ = true;  // #402: route 全消え → 次 tick で再構築 (DELETEALL 経路含む)
     return;
   }
 
@@ -157,6 +158,7 @@ void MapoiRviz2Publisher::on_routes_info_received(
         if (--(*remaining) == 0) {
           std::lock_guard<std::mutex> lock(data_mutex_);
           all_routes_ = std::move(*pending);
+          marker_data_dirty_ = true;  // #402: route 構成確定 → 次 tick で再構築
         }
       });
   }
@@ -164,9 +166,10 @@ void MapoiRviz2Publisher::on_routes_info_received(
 
 void MapoiRviz2Publisher::on_config_path_changed(const std_msgs::msg::String::SharedPtr msg)
 {
-  // mapoi_server は config path 文字列を周期 publish (default 5s) する。path だけで dedup すると
-  // map switch (path 変更) は拾えるが、WebUI/Panel Save (path 不変、内容のみ変更) を取りこぼす。
-  // YAML ファイルの mtime も併せて比較し、両 case を検出する。
+  // mapoi_server は config path 文字列を event 駆動で publish する (周期 publish は #135 で廃止し、
+  // subscriber を transient_local に揃えた。起動時 / select_map / reload_map_info の 3 箇所)。
+  // このうち reload_map_info (WebUI/Panel Save) は path 不変・内容のみ変更なので、path だけで dedup
+  // すると map switch (path 変更) は拾えるが Save を取りこぼす。YAML の mtime も併せて比較し両 case を検出する。
   const std::string & current_path = msg->data;
   std::filesystem::file_time_type current_mtime{};
   std::error_code ec;
@@ -220,6 +223,7 @@ void MapoiRviz2Publisher::on_poi_received(rclcpp::Client<mapoi_interfaces::srv::
   {
     std::lock_guard<std::mutex> lock(data_mutex_);
     pois_list_ = result->pois_list;
+    marker_data_dirty_ = true;  // #402: POI 更新 → 次 tick でフル再構築
   }
   RCLCPP_INFO(this->get_logger(), "Received %zu POIs.", pois_list_.size());
 }
@@ -232,6 +236,7 @@ void MapoiRviz2Publisher::on_highlight_goal_received(const std_msgs::msg::String
   if (!msg->data.empty()) {
     highlighted_goal_names_.insert(msg->data);
   }
+  marker_data_dirty_ = true;  // #402: goal highlight 変更 → POI 色が変わるので再構築
 }
 
 void MapoiRviz2Publisher::on_highlight_route_received(const std_msgs::msg::String::SharedPtr msg)
@@ -250,10 +255,57 @@ void MapoiRviz2Publisher::on_highlight_route_received(const std_msgs::msg::Strin
       }
     }
   }
+  marker_data_dirty_ = true;  // #402: route highlight 変更 → route 線/方向矢印が変わるので再構築
 }
 
 void MapoiRviz2Publisher::timer_callback(){
   std::lock_guard<std::mutex> lock(data_mutex_);
+
+  // --- 差分ゲート (#402) ---
+  // 1Hz でフル再構築 (cos/sin/頂点列生成) するのは無駄なので、データ (POI/route/highlight/
+  // 描画 parameter) が変わった tick だけ marker を再構築する。それ以外の tick は前回構築を
+  // cache しておき、header.stamp だけ現在時刻に差し替えて再 publish する。
+  // 再 publish を続ける理由: 購読側 QoS が volatile なので、後起動の RViz へ marker を届けるには
+  // marker 自体を 1Hz で送り続ける必要がある (stamp だけ更新すれば形状再計算は不要)。
+  // 描画 parameter (show_tolerance_sector / poi_label_format / route_display_mode) の変化は
+  // subscription を持たないため、ここで前回値と比較して dirty を立てる (get_parameter は元々
+  // 毎 tick 呼んでおりコスト増はない)。
+  const bool show_sector = this->get_parameter("show_tolerance_sector").as_bool();
+  const std::string label_format = this->get_parameter("poi_label_format").as_string();
+  const std::string route_mode = this->get_parameter("route_display_mode").as_string();
+  if (show_sector != last_show_sector_ ||
+      label_format != last_poi_label_format_ ||
+      route_mode != last_route_display_mode_) {
+    marker_data_dirty_ = true;
+    last_show_sector_ = show_sector;
+    last_poi_label_format_ = label_format;
+    last_route_display_mode_ = route_mode;
+  }
+
+  // 購読者ゼロスキップ (#402): pois / routes をそれぞれ独立に判定する。購読者ゼロの間は構築も
+  // publish もしないが、dirty フラグは「消費しない」(= クリアしない)。購読者が復帰した最初の
+  // tick で dirty が立っていれば必ずフル構築される。dirty=false のまま復帰した場合も cache は
+  // データ不変を意味するので、cache を stamp 更新して publish すれば正しい (下の clean 経路)。
+  const bool pois_has_sub = marker_pois_pub_->get_subscription_count() > 0;
+  const bool routes_has_sub = marker_routes_pub_->get_subscription_count() > 0;
+
+  // clean tick (dirty=false): 幾何再計算せず cache の stamp だけ更新して再 publish する。
+  // marker 数は不変なので DELETEALL 分岐 (id_buf_ / route_id_buf_) は通らない
+  // (id_buf_ / route_id_buf_ は dirty tick でのみ更新されるため整合する)。
+  if (!marker_data_dirty_) {
+    const auto now = rclcpp::Clock().now();
+    if (pois_has_sub) {
+      for (auto & m : cached_ma_pois_.markers) m.header.stamp = now;
+      marker_pois_pub_->publish(cached_ma_pois_);
+    }
+    if (routes_has_sub) {
+      for (auto & m : cached_ma_routes_.markers) m.header.stamp = now;
+      marker_routes_pub_->publish(cached_ma_routes_);
+    }
+    return;
+  }
+
+  // --- dirty tick: 従来通りフル構築する ---
   // publish markers on rviz
   visualization_msgs::msg::Marker default_arrow_marker;
   default_arrow_marker.header.frame_id = "map";
@@ -266,14 +318,12 @@ void MapoiRviz2Publisher::timer_callback(){
   default_arrow_marker.color.r = 0.0; default_arrow_marker.color.g = 1.0; default_arrow_marker.color.b = 0.0; default_arrow_marker.color.a = 0.7;
   default_arrow_marker.lifetime.sec = 2.0;
 
-  // tolerance visualization (#136 / #179) の表示制御。false で全 POI の円 + 扇形 + pause overlay を抑制。
-  // `show_tolerance_sector` は現在、yaw sector だけでなく POI tolerance layer 全体を制御する。
-  const bool show_sector = this->get_parameter("show_tolerance_sector").as_bool();
-
-  // POI label の format ("index" / "name" / "both" / "none") を runtime parameter で切替。
-  // 空文字列を返した場合は label を生成しない (none モード)。
-  const std::string label_format =
-    this->get_parameter("poi_label_format").as_string();
+  // tolerance visualization (#136 / #179) の表示制御 (show_sector) と POI label format
+  // (label_format: "index" / "name" / "both" / "none") は timer_callback 冒頭で取得済み
+  // (差分ゲートの parameter 変化検出と共有、#402)。
+  // - show_sector: false で全 POI の円 + 扇形 + pause overlay を抑制。yaw sector だけでなく
+  //   POI tolerance layer 全体を制御する。
+  // - label_format: 空文字列 ("none") を返した場合は label を生成しない。
   auto build_label = [&label_format](size_t index_one_based, const std::string & name) -> std::string {
     if (label_format == "none") return "";
     if (label_format == "name") return name;
@@ -563,6 +613,10 @@ void MapoiRviz2Publisher::timer_callback(){
     return color;
   };
 
+  // 購読者ゼロスキップ (#402): POI marker の購読者がいなければ幾何構築も publish も行わない。
+  // marker_data_dirty_ はこの分岐では消費しないため、購読者復帰後の最初の tick で必ず
+  // フル構築される (下の dirty クリアは pois/routes 双方の publish を経てから行う)。
+  if (pois_has_sub) {
   size_t poi_index_one_based = 0;
   for (const auto & poi : pois_list_) {
     poi_index_one_based += 1;  // POI Editor (mapoi_config.yaml の poi: 順) 行番号、1-based、tag フィルタ非依存
@@ -648,6 +702,9 @@ void MapoiRviz2Publisher::timer_callback(){
   id_buf_ = id;
 
   marker_pois_pub_->publish(ma_pois);
+  // clean tick で stamp 更新して再送するため構築結果を cache する (#402)。
+  cached_ma_pois_ = std::move(ma_pois);
+  }  // if (pois_has_sub)
 
   // Route markers (mapoi/markers/routes topic)。
   // route_display_mode parameter で表示制御:
@@ -668,7 +725,10 @@ void MapoiRviz2Publisher::timer_callback(){
     return ROUTE_PALETTE[h(name) % ROUTE_PALETTE.size()];
   };
 
-  const std::string route_mode = this->get_parameter("route_display_mode").as_string();
+  // route_mode は timer_callback 冒頭で取得済み (差分ゲートの parameter 変化検出と共有、#402)。
+  // 購読者ゼロスキップ (#402): route marker の購読者がいなければ構築も publish も行わない。
+  // marker_data_dirty_ はこの分岐では消費しない (dirty クリアは pois/routes 双方の後で行う)。
+  if (routes_has_sub) {
   visualization_msgs::msg::MarkerArray ma_routes;
   int route_id = 0;
 
@@ -757,6 +817,18 @@ void MapoiRviz2Publisher::timer_callback(){
   }
   route_id_buf_ = route_id;
   marker_routes_pub_->publish(ma_routes);
+  // clean tick で stamp 更新して再送するため構築結果を cache する (#402)。
+  cached_ma_routes_ = std::move(ma_routes);
+  }  // if (routes_has_sub)
+
+  // 差分ゲートの dirty クリア (#402): dirty は pois/routes 共通の単一フラグなので、両方が
+  // 購読者ありで揃って構築・cache 更新できたときだけ落とす。片側が購読者ゼロで skip した場合は
+  // その側の cache が古いままなので、購読者復帰後に再構築させるため dirty を残す
+  // (代償として購読者ありの側は復帰まで毎 tick 再構築されるが、購読者ゼロ運用は一時的とみなす)。
+  // 両側とも購読者ゼロなら次 tick もこの dirty 経路を通り、購読者復帰時に確実にフル構築される。
+  if (pois_has_sub && routes_has_sub) {
+    marker_data_dirty_ = false;
+  }
 }
 
 int main(int argc, char **argv)

--- a/mapoi_server/src/mapoi_rviz2_publisher.cpp
+++ b/mapoi_server/src/mapoi_rviz2_publisher.cpp
@@ -289,6 +289,13 @@ void MapoiRviz2Publisher::timer_callback(){
   const bool pois_has_sub = marker_pois_pub_->get_subscription_count() > 0;
   const bool routes_has_sub = marker_routes_pub_->get_subscription_count() > 0;
 
+  // 両 topic とも購読者ゼロなら dirty の有無に関わらず即 return する (RViz 未接続時の
+  // 毎 tick コストを default marker 構築含めゼロにする)。dirty はここでも消費しないため、
+  // 購読者復帰後の最初の tick で必ずフル構築される。
+  if (!pois_has_sub && !routes_has_sub) {
+    return;
+  }
+
   // clean tick (dirty=false): 幾何再計算せず cache の stamp だけ更新して再 publish する。
   // marker 数は不変なので DELETEALL 分岐 (id_buf_ / route_id_buf_) は通らない
   // (id_buf_ / route_id_buf_ は dirty tick でのみ更新されるため整合する)。


### PR DESCRIPTION
## 目的

#402。`mapoi_rviz2_publisher` の 1Hz timer_callback が POI/route データ不変でも毎 tick MarkerArray を全再構築 (POI×最大 5 marker の cos/sin 再計算) していたのを、変化があった tick だけ再構築するようにする。あわせて RViz 未接続時の構築コストをゼロにする。

## 変更

- **差分ゲート**: `marker_data_dirty_` フラグをデータ書き込み点 5 箇所 (on_poi_received / on_routes_info_received の clear・swap 両経路 / on_highlight_goal_received / on_highlight_route_received、いずれも data_mutex_ ロック下) で set。描画 parameter 3 種は timer_callback 冒頭で前回値比較 (新規 callback 機構なし)。clean tick は cache の header.stamp のみ更新して再 publish — **1Hz 再送は維持** (volatile QoS の後着 RViz 対応)
- **購読者ゼロスキップ**: pois / routes を `get_subscription_count()` で独立判定し、購読者ゼロの間は構築も publish もスキップ。dirty はこの経路では消費しないため、購読者復帰後の最初の tick で必ずフル構築される。dirty クリアは両側の構築が揃った時のみ (片側ゼロ時の代償はコード内コメントに明示)
- **古コメント修正 2 箇所**: rviz2_publisher / gz_bridge の「config_path 周期 publish」記述を event 駆動の実態 (#135 で周期廃止) に合わせ、`mapoi_server.hpp` の記述と整合させた

## 挙動不変の担保

- marker の形状・色・ns・id 採番ロジックは未変更。DELETEALL 二段 publish と `id_buf_`/`route_id_buf_` は「実際に構築・publish した dirty tick」でのみ更新され、clean tick (marker 数不変) は分岐を通らない
- 購読者ゼロスキップの `if` ブロックは既存 90/140 行を再インデントせず挿入 (diff を移動なし・純追加に保つ意図)

## レビュー観点 (issue 記載)

- id 手動採番 (`id += add_sector(...)`) の加算漏れは型検出できない → 本 PR は採番ロジックに触れていないこと
- 差分ゲートが「publish 停止」ではなく「幾何再計算スキップ」であること

## 検証

- humble / jazzy 両 Docker で colcon build 通過、mapoi_server の unit test 125 件全パス (launch_test は CI の main push / 週次で実行)
- `mapoi_server/test/` に marker topic を検証するテストは存在せず、既存 launch_test は marker publish に依存しない (grep 確認)