### PR TITLE
feat(rviz): 走行中の拒否コマンドを一時表示 (#398)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,7 +130,7 @@ All interfaces of the core nodes. Types are `mapoi_interfaces` unless another pa
 | `mapoi/nav/switch_map` | `std_msgs/msg/String` | WebUI, MapoiPanel, example client → `mapoi_nav2_bridge` | map name (operator map switch) |
 | `mapoi/nav/cancel` / `pause` / `resume` | `std_msgs/msg/String` | WebUI, MapoiPanel (resume also from `camera_node` demo) → `mapoi_nav2_bridge` | |
 | `mapoi/nav/status` | `std_msgs/msg/String` | `mapoi_nav2_bridge` → WebUI, MapoiPanel | `transient_local` depth 1; payload `status[:target]` |
-| `mapoi/nav/command_rejected` | `std_msgs/msg/String` | `mapoi_nav2_bridge` → WebUI | volatile depth 10; reject events (#354) |
+| `mapoi/nav/command_rejected` | `std_msgs/msg/String` | `mapoi_nav2_bridge` → WebUI, MapoiPanel | volatile depth 10; reject events (#354, #398) |
 | `mapoi/nav/backend_status` | `msg/NavigationBackendStatus` | `mapoi_nav2_bridge` → WebUI, MapoiPanel | 1 Hz; `transient_local` + `MANUAL_BY_TOPIC` liveliness, 5 s lease (#208) |
 | `mapoi/localization/backend_status` | `msg/LocalizationBackendStatus` | `mapoi_amcl_localization_bridge` → WebUI, MapoiPanel | same QoS contract as above |
 | `mapoi/events` | `msg/PoiEvent` | `mapoi_nav2_bridge` → user nodes (see example nodes) | depth 10; `EVENT_ENTER`/`EVENT_PAUSED`/`EVENT_EXIT`, route driving only |

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
@@ -4,6 +4,7 @@
 #include <rclcpp/rclcpp.hpp>
 #endif
 
+#include <QTimer>
 #include <rviz_common/panel.hpp>
 #include <rviz_common/display_context.hpp>
 #include <geometry_msgs/msg/pose.hpp>
@@ -89,6 +90,13 @@ protected:
   void NavStatusCallback(std_msgs::msg::String::SharedPtr msg);
   std::string current_nav_mode_;
   std::string current_nav_target_;
+
+  // #398: mapoi/nav/command_rejected 購読。latched な NavStatusLabel とは別 label (CommandRejectedLabel)
+  // に一時表示することで、権威的な状態スナップショットと揮発的なイベント通知を分離する。
+  // nav_mode を問わず全 reject で publish される (#354 設計) ので走行中の誤操作にも気づける。
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr command_rejected_sub_;
+  void CommandRejectedCallback(std_msgs::msg::String::SharedPtr msg);
+  QTimer* reject_clear_timer_ {nullptr};
 
   // Navigation backend readiness subscribe (#198, #205 minimal contract):
   // bridge が `mapoi/nav/backend_status` を publish する場合は backend_ready で navigation

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -91,6 +91,21 @@ void MapoiPanel::onInitialize()
       "mapoi/nav/status", rclcpp::QoS(1).transient_local(),
       std::bind(&MapoiPanel::NavStatusCallback, this, std::placeholders::_1));
 
+  // #398: command_rejected は volatile depth 10 (publisher と整合)。latched 不要 (イベント通知)。
+  command_rejected_sub_ = node_->create_subscription<std_msgs::msg::String>(
+      "mapoi/nav/command_rejected", rclcpp::QoS(10),
+      std::bind(&MapoiPanel::CommandRejectedCallback, this, std::placeholders::_1));
+
+  // reject_clear_timer_: 受信から 5 秒後に CommandRejectedLabel をクリアする。
+  // singleShot=true かつ再受信時に start() を呼ぶことで連続 reject でも先行タイマーが
+  // 後続表示を早期クリアする race を防ぐ (start() は未満了タイマーを自動リスタートする)。
+  reject_clear_timer_ = new QTimer(this);
+  reject_clear_timer_->setSingleShot(true);
+  reject_clear_timer_->setInterval(5000);
+  connect(reject_clear_timer_, &QTimer::timeout, this, [this]() {
+    ui_->CommandRejectedLabel->setText(QString{});
+  });
+
   // Navigation / Localization backend readiness (#198, #209) の QoS は msg contract (#208)
   // に従う: transient_local + liveliness (publisher=MANUAL_BY_TOPIC, subscriber=AUTOMATIC)
   // + lease 5s (両側必須)。subscriber 側 policy を AUTOMATIC にするのは pub=MANUAL_BY_TOPIC

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -91,20 +91,22 @@ void MapoiPanel::onInitialize()
       "mapoi/nav/status", rclcpp::QoS(1).transient_local(),
       std::bind(&MapoiPanel::NavStatusCallback, this, std::placeholders::_1));
 
-  // #398: command_rejected は volatile depth 10 (publisher と整合)。latched 不要 (イベント通知)。
-  command_rejected_sub_ = node_->create_subscription<std_msgs::msg::String>(
-      "mapoi/nav/command_rejected", rclcpp::QoS(10),
-      std::bind(&MapoiPanel::CommandRejectedCallback, this, std::placeholders::_1));
-
   // reject_clear_timer_: 受信から 5 秒後に CommandRejectedLabel をクリアする。
   // singleShot=true かつ再受信時に start() を呼ぶことで連続 reject でも先行タイマーが
   // 後続表示を早期クリアする race を防ぐ (start() は未満了タイマーを自動リスタートする)。
+  // 購読より先に生成しておく (callback の queued lambda が timer を参照するため、
+  // 将来 onInitialize 内に Qt イベント処理が入っても null 参照にならない順序を保つ)。
   reject_clear_timer_ = new QTimer(this);
   reject_clear_timer_->setSingleShot(true);
   reject_clear_timer_->setInterval(5000);
   connect(reject_clear_timer_, &QTimer::timeout, this, [this]() {
     ui_->CommandRejectedLabel->setText(QString{});
   });
+
+  // #398: command_rejected は volatile depth 10 (publisher と整合)。latched 不要 (イベント通知)。
+  command_rejected_sub_ = node_->create_subscription<std_msgs::msg::String>(
+      "mapoi/nav/command_rejected", rclcpp::QoS(10),
+      std::bind(&MapoiPanel::CommandRejectedCallback, this, std::placeholders::_1));
 
   // Navigation / Localization backend readiness (#198, #209) の QoS は msg contract (#208)
   // に従う: transient_local + liveliness (publisher=MANUAL_BY_TOPIC, subscriber=AUTOMATIC)

--- a/mapoi_rviz_plugins/src/mapoi_panel_nav_status.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_nav_status.cpp
@@ -79,4 +79,19 @@ void MapoiPanel::NavStatusCallback(std_msgs::msg::String::SharedPtr msg)
   }, Qt::QueuedConnection);
 }
 
+// #398: mapoi/nav/command_rejected コールバック。payload は target 名のみの文字列
+// (README §Publishers command_rejected 節参照)。NavStatusLabel (latched 状態スナップショット) には
+// 一切触れず、CommandRejectedLabel に一時表示して 5 秒後にクリアする。
+void MapoiPanel::CommandRejectedCallback(std_msgs::msg::String::SharedPtr msg)
+{
+  const std::string target = msg->data;
+  QMetaObject::invokeMethod(this, [this, target]() {
+    const QString text = target.empty()
+      ? QString::fromStdString("コマンド拒否")
+      : QString::fromStdString("コマンド拒否: " + target);
+    ui_->CommandRejectedLabel->setText(text);
+    reject_clear_timer_->start();  // 連続 reject 時は自動リスタートで 5 秒延長
+  }, Qt::QueuedConnection);
+}
+
 }  // namespace mapoi_rviz_plugins

--- a/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
+++ b/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
@@ -139,6 +139,9 @@
      <property name="styleSheet">
       <string notr="true">color: red;</string>
      </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
     </widget>
    </item>
   </layout>

--- a/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
+++ b/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
@@ -131,6 +131,16 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QLabel" name="CommandRejectedLabel">
+     <property name="text">
+      <string></string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: red;</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
## 目的

#398。走行中 (nav_mode != IDLE) のコマンド拒否は latched な `mapoi/nav/status` に書かれない仕様のため、RViz パネルでは Go/Run 誤操作が無反応に見えていた (WebUI はトースト表示済みで非対称)。`mapoi/nav/command_rejected` を購読して一時表示する。

## 変更

- `mapoi/nav/command_rejected` (std_msgs/String, volatile depth 10 = publisher と整合) を購読
- 新設の `CommandRejectedLabel` (赤字、NavStatusLabel 直下) に「コマンド拒否: <target>」を表示し、メンバ QTimer (singleShot 5s) でクリア。連続 reject は start() の自動リスタートで「最新 reject を 5 秒表示」(WebUI トーストと同じ意味論)
- latched な NavStatusLabel には一切触れない (権威的状態スナップショットと揮発的イベント通知の分離)
- callback 定義は #397 step 3 で分割済みの `mapoi_panel_nav_status.cpp` に配置 (PR #408 の just-in-time 分割の回収)
- `docs/architecture.md` の宛先表に MapoiPanel を追記
- payload は target 名のみの生文字列 (`mapoi_server/README.md` §command_rejected)。server 改修不要 (bridge は全 reject で publish 済み)

## 軽量性

- volatile depth 10・イベント駆動 (通常 0 Hz)。callback は setText + QTimer start のみで service 往復・周期処理なし

## 検証

- humble / jazzy 両 Docker で colcon build 通過、gtest 39 件全パス