### PR TITLE
feat(rviz): ルート走行の通過 POI 進捗を表示 (#406)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,7 @@ All interfaces of the core nodes. Types are `mapoi_interfaces` unless another pa
 | `mapoi/nav/command_rejected` | `std_msgs/msg/String` | `mapoi_nav2_bridge` → WebUI, MapoiPanel | volatile depth 10; reject events (#354, #398) |
 | `mapoi/nav/backend_status` | `msg/NavigationBackendStatus` | `mapoi_nav2_bridge` → WebUI, MapoiPanel | 1 Hz; `transient_local` + `MANUAL_BY_TOPIC` liveliness, 5 s lease (#208) |
 | `mapoi/localization/backend_status` | `msg/LocalizationBackendStatus` | `mapoi_amcl_localization_bridge` → WebUI, MapoiPanel | same QoS contract as above |
-| `mapoi/events` | `msg/PoiEvent` | `mapoi_nav2_bridge` → user nodes (see example nodes) | depth 10; `EVENT_ENTER`/`EVENT_PAUSED`/`EVENT_EXIT`, route driving only |
+| `mapoi/events` | `msg/PoiEvent` | `mapoi_nav2_bridge` → MapoiPanel, user nodes (see example nodes) | depth 10; `EVENT_ENTER`/`EVENT_PAUSED`/`EVENT_EXIT`, route driving only |
 | `mapoi/markers/pois` / `mapoi/markers/routes` | `visualization_msgs/msg/MarkerArray` | `mapoi_rviz2_publisher` → RViz2 | 1 Hz; POI labels, tolerance circles/sectors, route lines |
 | `mapoi/highlight/goal` / `mapoi/highlight/route` | `std_msgs/msg/String` | MapoiPanel → `mapoi_rviz2_publisher` | highlight selection |
 | `mapoi_rviz_pose` | `geometry_msgs/msg/PoseStamped` | MapoiPoseTool → PoiEditorPanel | pose input by click & drag in RViz |

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
@@ -105,6 +105,10 @@ protected:
   // 外部ノード起点の走行 (panel 未選択) では総数が不明になるケースがある。
   rclcpp::Subscription<mapoi_interfaces::msg::PoiEvent>::SharedPtr poi_event_sub_;
   void PoiEventCallback(mapoi_interfaces::msg::PoiEvent::SharedPtr msg);
+  // 終了系 nav/status の受信後に遅延到着した events で進捗表示が復活するのを抑制する
+  // (nav/status と events はトピック間で到達順序が保証されない)。navigating 受信で解除。
+  // UI スレッド (queued lambda 内) でのみ読み書きする。
+  bool route_progress_suppressed_ {false};
 
   // Navigation backend readiness subscribe (#198, #205 minimal contract):
   // bridge が `mapoi/nav/backend_status` を publish する場合は backend_ready で navigation

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
@@ -12,6 +12,7 @@
 #include <std_msgs/msg/int8.hpp>
 #include <std_msgs/msg/string.hpp>
 #include "mapoi_interfaces/msg/point_of_interest.hpp"
+#include "mapoi_interfaces/msg/poi_event.hpp"
 #include "mapoi_interfaces/srv/request_initial_pose.hpp"
 #include "mapoi_interfaces/msg/navigation_backend_status.hpp"
 #include "mapoi_interfaces/msg/localization_backend_status.hpp"
@@ -97,6 +98,13 @@ protected:
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr command_rejected_sub_;
   void CommandRejectedCallback(std_msgs::msg::String::SharedPtr msg);
   QTimer* reject_clear_timer_ {nullptr};
+
+  // #406: mapoi/events 購読。ROUTE 走行中の通過 POI 進捗を RouteProgressLabel に表示する。
+  // events は ROUTE 走行時のみ発火 (IDLE/GOAL では無音) なのでアイドル時の負荷はゼロ。
+  // 総数は highlighted_route_poi_names_ (panel でルート選択時に取得) を参照するため、
+  // 外部ノード起点の走行 (panel 未選択) では総数が不明になるケースがある。
+  rclcpp::Subscription<mapoi_interfaces::msg::PoiEvent>::SharedPtr poi_event_sub_;
+  void PoiEventCallback(mapoi_interfaces::msg::PoiEvent::SharedPtr msg);
 
   // Navigation backend readiness subscribe (#198, #205 minimal contract):
   // bridge が `mapoi/nav/backend_status` を publish する場合は backend_ready で navigation

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -108,6 +108,11 @@ void MapoiPanel::onInitialize()
       "mapoi/nav/command_rejected", rclcpp::QoS(10),
       std::bind(&MapoiPanel::CommandRejectedCallback, this, std::placeholders::_1));
 
+  // #406: mapoi/events は volatile depth 10 (publisher と整合)。ROUTE 走行時のみ受信される。
+  poi_event_sub_ = node_->create_subscription<mapoi_interfaces::msg::PoiEvent>(
+      "mapoi/events", rclcpp::QoS(10),
+      std::bind(&MapoiPanel::PoiEventCallback, this, std::placeholders::_1));
+
   // Navigation / Localization backend readiness (#198, #209) の QoS は msg contract (#208)
   // に従う: transient_local + liveliness (publisher=MANUAL_BY_TOPIC, subscriber=AUTOMATIC)
   // + lease 5s (両側必須)。subscriber 側 policy を AUTOMATIC にするのは pub=MANUAL_BY_TOPIC

--- a/mapoi_rviz_plugins/src/mapoi_panel_nav_status.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_nav_status.cpp
@@ -2,6 +2,7 @@
 // nav status 文字列のパースと NavStatusLabel への表示更新を担う。
 #include "mapoi_rviz_plugins/mapoi_panel.hpp"
 #include "ui_mapoi_panel.h"
+#include <algorithm>
 
 namespace mapoi_rviz_plugins
 {
@@ -35,16 +36,19 @@ void MapoiPanel::NavStatusCallback(std_msgs::msg::String::SharedPtr msg)
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("到着")
                          : QString::fromStdString("到着: " + target));
+      ui_->RouteProgressLabel->setText(QString{});
     } else if (status == "aborted") {
       current_nav_mode_ = "idle";
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("走行失敗")
                          : QString::fromStdString("走行失敗: " + target));
+      ui_->RouteProgressLabel->setText(QString{});
     } else if (status == "canceled") {
       current_nav_mode_ = "idle";
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("走行キャンセル")
                          : QString::fromStdString("走行キャンセル: " + target));
+      ui_->RouteProgressLabel->setText(QString{});
     } else if (status == "paused") {
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("一時停止中")
@@ -58,16 +62,19 @@ void MapoiPanel::NavStatusCallback(std_msgs::msg::String::SharedPtr msg)
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("地図切替完了")
                          : QString::fromStdString("地図切替完了: " + target));
+      ui_->RouteProgressLabel->setText(QString{});
     } else if (status == "map_switch_failed") {
       current_nav_mode_ = "idle";
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("地図切替失敗")
                          : QString::fromStdString("地図切替失敗: " + target));
+      ui_->RouteProgressLabel->setText(QString{});
     } else if (status == "backend_unavailable") {
       current_nav_mode_ = "idle";
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("ナビゲーション利用不可")
                          : QString::fromStdString("ナビゲーション利用不可: " + target));
+      ui_->RouteProgressLabel->setText(QString{});
     } else if (status == "rejected") {
       // #339: 受理前に拒否されたコマンド (存在しない POI 名、landmark POI を goal 指定、
       // 空 route 等)。直前の status が居座って誤操作に気づけない事態を防ぐ。
@@ -75,7 +82,49 @@ void MapoiPanel::NavStatusCallback(std_msgs::msg::String::SharedPtr msg)
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("コマンド拒否")
                          : QString::fromStdString("コマンド拒否: " + target));
+      ui_->RouteProgressLabel->setText(QString{});
     }
+  }, Qt::QueuedConnection);
+}
+
+// #406: mapoi/events コールバック。ROUTE 走行中にのみ受信される (IDLE/GOAL では発火しない)。
+// n/総数の総数は highlighted_route_poi_names_ (panel でルート選択済み時に確定)。
+// 外部ノード起点の走行など panel が未選択の場合はリストが空になるため n/総数 を省略し
+// POI 名のみ表示するフォールバックとする。未知の event_type は無視する。
+void MapoiPanel::PoiEventCallback(mapoi_interfaces::msg::PoiEvent::SharedPtr msg)
+{
+  const uint8_t event_type = msg->event_type;
+  // 未知の event_type は無視 (EVENT_ENTER/EVENT_PAUSED/EVENT_EXIT のみ処理)
+  if (event_type != mapoi_interfaces::msg::PoiEvent::EVENT_ENTER &&
+      event_type != mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED &&
+      event_type != mapoi_interfaces::msg::PoiEvent::EVENT_EXIT) {
+    return;
+  }
+  const std::string poi_name = msg->poi.name;
+  QMetaObject::invokeMethod(this, [this, event_type, poi_name]() {
+    // n/総数: panel で選択したルートの POI リスト内での先頭一致 index + 1。
+    // リストが空 (外部ノード起点) または見つからない場合は n/総数 を省略する。
+    // highlighted_route_poi_names_ は UI スレッドが書き換えるメンバのため、参照も
+    // queued lambda 内 (UI スレッド) で行う (NavStatusCallback の current_nav_mode_ と同じ規約)。
+    const auto & names = highlighted_route_poi_names_;
+    std::string progress_suffix;
+    if (!names.empty()) {
+      const auto it = std::find(names.begin(), names.end(), poi_name);
+      if (it != names.end()) {
+        const int n = static_cast<int>(std::distance(names.begin(), it)) + 1;
+        const int total = static_cast<int>(names.size());
+        progress_suffix = " (" + std::to_string(n) + "/" + std::to_string(total) + ")";
+      }
+    }
+    std::string text;
+    if (event_type == mapoi_interfaces::msg::PoiEvent::EVENT_ENTER) {
+      text = "進入: " + poi_name + progress_suffix;
+    } else if (event_type == mapoi_interfaces::msg::PoiEvent::EVENT_PAUSED) {
+      text = "POI で一時停止中: " + poi_name + progress_suffix;
+    } else {  // EVENT_EXIT
+      text = "通過: " + poi_name + progress_suffix;
+    }
+    ui_->RouteProgressLabel->setText(QString::fromStdString(text));
   }, Qt::QueuedConnection);
 }
 

--- a/mapoi_rviz_plugins/src/mapoi_panel_nav_status.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_nav_status.cpp
@@ -17,7 +17,19 @@ void MapoiPanel::NavStatusCallback(std_msgs::msg::String::SharedPtr msg)
   const std::string status = (colon == std::string::npos) ? raw : raw.substr(0, colon);
   const std::string target = (colon == std::string::npos) ? std::string{} : raw.substr(colon + 1);
   QMetaObject::invokeMethod(this, [this, status, target]() {
+    // 走行終了系の分岐で共通: 進捗表示をクリアし、遅延到着した mapoi/events による
+    // 表示復活を抑制する (#406。抑制解除は navigating 分岐)。
+    auto clear_route_progress = [this]() {
+      route_progress_suppressed_ = true;
+      ui_->RouteProgressLabel->setText(QString{});
+    };
     if (status == "navigating") {
+      // 新しい走行の開始。前回終了時の抑制を解除する。抑制中だった場合のみクリアする
+      // (走行中の navigating 再受信で進行中の進捗表示を消さないため)。
+      if (route_progress_suppressed_) {
+        route_progress_suppressed_ = false;
+        ui_->RouteProgressLabel->setText(QString{});
+      }
       if (!target.empty() && current_nav_mode_ == "idle") {
         // 後起動 panel / 外部ノード発行 nav: payload の target を復元して表示。
         current_nav_target_ = target;
@@ -36,19 +48,19 @@ void MapoiPanel::NavStatusCallback(std_msgs::msg::String::SharedPtr msg)
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("到着")
                          : QString::fromStdString("到着: " + target));
-      ui_->RouteProgressLabel->setText(QString{});
+      clear_route_progress();
     } else if (status == "aborted") {
       current_nav_mode_ = "idle";
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("走行失敗")
                          : QString::fromStdString("走行失敗: " + target));
-      ui_->RouteProgressLabel->setText(QString{});
+      clear_route_progress();
     } else if (status == "canceled") {
       current_nav_mode_ = "idle";
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("走行キャンセル")
                          : QString::fromStdString("走行キャンセル: " + target));
-      ui_->RouteProgressLabel->setText(QString{});
+      clear_route_progress();
     } else if (status == "paused") {
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("一時停止中")
@@ -62,19 +74,19 @@ void MapoiPanel::NavStatusCallback(std_msgs::msg::String::SharedPtr msg)
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("地図切替完了")
                          : QString::fromStdString("地図切替完了: " + target));
-      ui_->RouteProgressLabel->setText(QString{});
+      clear_route_progress();
     } else if (status == "map_switch_failed") {
       current_nav_mode_ = "idle";
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("地図切替失敗")
                          : QString::fromStdString("地図切替失敗: " + target));
-      ui_->RouteProgressLabel->setText(QString{});
+      clear_route_progress();
     } else if (status == "backend_unavailable") {
       current_nav_mode_ = "idle";
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("ナビゲーション利用不可")
                          : QString::fromStdString("ナビゲーション利用不可: " + target));
-      ui_->RouteProgressLabel->setText(QString{});
+      clear_route_progress();
     } else if (status == "rejected") {
       // #339: 受理前に拒否されたコマンド (存在しない POI 名、landmark POI を goal 指定、
       // 空 route 等)。直前の status が居座って誤操作に気づけない事態を防ぐ。
@@ -82,7 +94,7 @@ void MapoiPanel::NavStatusCallback(std_msgs::msg::String::SharedPtr msg)
       ui_->NavStatusLabel->setText(
           target.empty() ? QString::fromStdString("コマンド拒否")
                          : QString::fromStdString("コマンド拒否: " + target));
-      ui_->RouteProgressLabel->setText(QString{});
+      clear_route_progress();
     }
   }, Qt::QueuedConnection);
 }
@@ -101,9 +113,16 @@ void MapoiPanel::PoiEventCallback(mapoi_interfaces::msg::PoiEvent::SharedPtr msg
     return;
   }
   const std::string poi_name = msg->poi.name;
+  if (poi_name.empty()) {
+    return;  // bridge 契約上は非空だが、空名は表示価値が無いため防御的に無視
+  }
   QMetaObject::invokeMethod(this, [this, event_type, poi_name]() {
+    if (route_progress_suppressed_) {
+      return;  // 走行終了後に遅延到着した event。表示を復活させない
+    }
     // n/総数: panel で選択したルートの POI リスト内での先頭一致 index + 1。
     // リストが空 (外部ノード起点) または見つからない場合は n/総数 を省略する。
+    // 同名 POI がルートに複数回現れる場合は常に先頭の index を示す (単純表示の割り切り)。
     // highlighted_route_poi_names_ は UI スレッドが書き換えるメンバのため、参照も
     // queued lambda 内 (UI スレッド) で行う (NavStatusCallback の current_nav_mode_ と同じ規約)。
     const auto & names = highlighted_route_poi_names_;

--- a/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
+++ b/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
@@ -132,6 +132,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="RouteProgressLabel">
+     <property name="text">
+      <string></string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="CommandRejectedLabel">
      <property name="text">
       <string></string>


### PR DESCRIPTION
Closes #406

## 目的

ルート走行中の `mapoi/nav/status` は「navigating:<route名>」のみで、どの waypoint まで進んだかが RViz で分からなかった。bridge が publish 済みの `mapoi/events` (PoiEvent) を購読して進捗を表示する。

## 変更

- `mapoi/events` (volatile depth 10 = publisher 既定 QoS と整合) を購読
- 新設の `RouteProgressLabel` (NavStatusLabel 直下、PlainText 固定) に EVENT_ENTER →「進入: <poi> (n/総数)」、EVENT_PAUSED →「POI で一時停止中: …」、EVENT_EXIT →「通過: …」を表示。未知の event_type は無視
- n/総数はルート選択時に取得済みの `highlighted_route_poi_names_` の先頭一致 index。リストが空 (外部ノード起点の走行) や名前不一致時は n/総数 を省略して POI 名のみ表示
- **スレッド規約**: `highlighted_route_poi_names_` は UI スレッド所有のため、参照は queued lambda 内で実施 (NavStatusCallback の `current_nav_mode_` と同じ規約)
- NavStatusCallback の走行終了系 7 分岐 (succeeded/aborted/canceled/map_switch_*/backend_unavailable/rejected) に進捗ラベルのクリアを追加 (既存の表示文字列・状態遷移は不変)
- `docs/architecture.md` の宛先表に MapoiPanel を追記
- server 改修不要 (bridge は購読者を問わず publish 済み)。events は ROUTE 走行時のみ発火するためアイドル時 0 Hz

## 検証

- humble / jazzy 両 Docker で colcon build 通過、gtest 39 件全パス