### PR TITLE
feat(rviz): PoiEditor に未保存編集ガードを追加 (#399)

### DIFF
--- a/mapoi_rviz_plugins/CMakeLists.txt
+++ b/mapoi_rviz_plugins/CMakeLists.txt
@@ -32,8 +32,9 @@ ament_auto_add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES} ${HEADERS} ${UIC_F
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
-  # poi_editor_helpers.hpp の純関数 (try_parse_finite_double / split_and_trim) の unit test (#158)。
-  # header は Qt 不要 (stdlib のみ)。
+  # poi_editor_helpers.hpp の純関数の unit test。try_parse_finite_double / split_and_trim (#158)
+  # に加え、未保存編集ガードの decide_config_reload_guard / should_confirm_overwrite (#399) を含む。
+  # header は Qt/ROS 非依存 (stdlib + config_path_update_policy.hpp のみ)。
   ament_auto_add_gtest(test_poi_editor_helpers
     test/test_poi_editor_helpers.cpp
   )

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -115,6 +115,27 @@ protected:
   // rebuild + flag クリアされる。
   bool suppress_config_callback_update_ = false;
 
+  // 未保存編集ガード (#399)。以下 3 メンバは全て UI (Qt メイン) スレッド上でのみ触るため
+  // ロック不要 (TableChanged/New/Copy/Delete/RowMoved/SaveButton/ConfigPathCallback の
+  // queued lambda はいずれも UI スレッドで実行される)。
+  //
+  // ユーザーがセルを編集 / 行を追加削除移動したことを示す dirty フラグ。UpdatePoiTable
+  // (全再構築 = サーバ状態と一致) 末尾と SaveButton 成功直後に clear する。外部で
+  // config_path が再 publish された時、これが true なら再構築前に確認ダイアログを出す。
+  bool table_dirty_ = false;
+
+  // 外部変更検出 (SaveButton) のための baseline スナップショット。UpdatePoiTable 末尾で
+  // テーブルの元データに対応する config ファイル (FileComboBox->itemText(0)) を全読みして
+  // {path, content} を保存する。SaveButton 成功書き込み直後は書き込んだ内容と保存先 path で
+  // 更新する。読めない場合は両方 clear = 比較不能 (ガード無効 = 従来挙動)。
+  std::string baseline_path_;
+  std::string baseline_content_;
+
+  // ConfigPathCallback の確認ダイアログ表示中フラグ (#399)。QMessageBox のネストイベント
+  // ループ中に後続の queued lambda が走って dialog が積み重なるのを防ぐ (dialog 中に届いた
+  // config_path イベントは drop する。再読込を選べば最新状態が fetch されるので欠損しない)。
+  bool config_dialog_open_ = false;
+
   // Functions
   void InitConfigs(std::string map_name);
   void UpdatePoiTable();

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include "mapoi_rviz_plugins/config_path_update_policy.hpp"
+
 namespace mapoi_rviz_plugins::detail
 {
 
@@ -189,6 +191,69 @@ inline TagExclusivityResult check_tag_exclusivity(const std::vector<std::string>
   result.waypoint_landmark_conflict = has_waypoint && has_landmark;
   result.pause_landmark_conflict = has_pause && has_landmark;
   return result;
+}
+
+// PoiEditorPanel::ConfigPathCallback の未保存編集ガード判定 (#399)。
+// 外部で mapoi/config_path が再 publish された時に、テーブルを無条件で全再構築すると
+// 未保存のセル編集が黙って消える。suppression 適用後の action・dirty フラグ・dialog 表示中
+// フラグの 3 つから、UI が「そのまま再構築 / 確認ダイアログ / イベント破棄」のいずれを
+// 取るべきかを判定する純関数。Qt 非依存 (callback 側が結果を QMessageBox 表示へ写像する)。
+enum class ConfigReloadGuardDecision
+{
+  kProceed,   // 従来通り再構築 (Noop なら何もしない、それ以外は InitConfigs/UpdatePoiTable)
+  kAskUser,   // 未保存編集ありのため確認ダイアログを出す
+  kDrop,      // dialog 表示中に届いたイベントは破棄 (再入・dialog 積み重ね防止)
+};
+
+// action    : suppression 適用後の ConfigPathUpdateAction (Noop = suppress 中 or 更新不要)
+// table_dirty: UI スレッド上のユーザー編集有無 (未保存編集ガードの主軸)
+// dialog_open: 既に確認ダイアログを表示中か (QMessageBox のネストイベントループ中に
+//              後続 queued lambda が走って dialog が積み重なるのを防ぐ)
+inline ConfigReloadGuardDecision decide_config_reload_guard(
+  ConfigPathUpdateAction action,
+  bool table_dirty,
+  bool dialog_open)
+{
+  // 再構築対象が無い (Noop = suppress 中 or 同一 map で更新不要) なら dirty でも何もしない。
+  // Noop は table を触らないので未保存編集は消えない。
+  if (action == ConfigPathUpdateAction::Noop) {
+    return ConfigReloadGuardDecision::kProceed;
+  }
+  // dialog 表示中に届いたイベントは破棄する。ユーザーが「再読込」を選べばその時点の
+  // 最新状態が fetch されるため drop で欠損しない (再入防止)。
+  if (dialog_open) {
+    return ConfigReloadGuardDecision::kDrop;
+  }
+  // 未保存編集がある状態での外部変更は、破棄可否をユーザーに確認する。
+  if (table_dirty) {
+    return ConfigReloadGuardDecision::kAskUser;
+  }
+  // dirty でなければ従来通り再構築 (サーバ状態に追従)。
+  return ConfigReloadGuardDecision::kProceed;
+}
+
+// PoiEditorPanel::SaveButton の外部変更検出判定 (#399)。保存先ファイルが baseline (最後に
+// テーブルへ読み込んだ / 保存した時点の内容) と食い違う場合に上書き確認を出すべきかを返す。
+// WebUI の expected_version 楽観ロック相当のクライアント側実装で、config_version の厳密共有は
+// 不要で内容比較で目的を達せられる。
+//
+// PR #413 review (low: itemText(0)/currentText 非対称) を踏まえ、比較は **保存先 path**
+// (currentText 由来) が baseline_path と一致する時のみ行う。FileComboBox「the other」で
+// 別ファイルを保存先に指定した場合は基準を持たないため比較しない (誤った基準ファイルとの
+// 比較を避ける)。baseline_content が空 (読めなかった等) の場合もガード無効化 = 従来挙動。
+inline bool should_confirm_overwrite(
+  const std::string & save_path,
+  const std::string & baseline_path,
+  const std::string & baseline_content,
+  const std::string & current_content)
+{
+  if (save_path != baseline_path) {
+    return false;  // 保存先が baseline と別 path: 比較不能 (基準なし)
+  }
+  if (baseline_content.empty()) {
+    return false;  // baseline を読めなかった: ガード無効 (従来挙動)
+  }
+  return baseline_content != current_content;  // path 一致 && baseline 非空 && 内容不一致
 }
 
 }  // namespace mapoi_rviz_plugins::detail

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -459,17 +459,23 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
 
   std::filesystem::path resolved_p(resolved_path);
   std::string map_name = resolved_p.parent_path().filename().string();
-  const auto base_action = detail::decide_poi_editor_config_path_action(
-    current_map_, map_name, config_path_);
-  config_path_ = resolved_path;
-  current_map_ = map_name;
 
   // 同じ map で path も同じ場合 (= save 後の reload_map_info で再 publish される flow)
   // でも POI 内容が変わっている可能性があるため UpdatePoiTable で table を再 fetch する (#135)。
   // map 切替 / 初回受信時は MapComboBox 同期 + FileComboBox 再構築も必要なので InitConfigs を呼ぶ。
   // 自分自身が save 直後 (suppress_config_callback_update_) は 1.5 秒の SAVED! feedback を
   // 守るため UpdatePoiTable を skip する。旧挙動と同じく queued lambda 実行時の flag を見る。
-  QMetaObject::invokeMethod(this, [this, map_name, base_action]() {
+  //
+  // メンバ更新 (current_map_ / config_path_) と action 判定は queued lambda 内 (UI スレッド)
+  // で行う (#399, PR #414 review high)。ROS executor スレッドでの読み書きを無くして UI スレッド
+  // 所有の規約 (PR #412 と同じ) に揃えるのに加え、lambda は Qt イベントキューの FIFO で
+  // イベント順に適用されるため、確認ダイアログのネストイベントループ中に後続イベントの
+  // lambda が走ってもメンバは常に最新へ進む (Yes 時の最新メンバ再構築とセットで機能する)。
+  QMetaObject::invokeMethod(this, [this, resolved_path, map_name]() {
+    const auto base_action = detail::decide_poi_editor_config_path_action(
+      current_map_, map_name, config_path_);
+    config_path_ = resolved_path;
+    current_map_ = map_name;
     const auto action = detail::apply_poi_editor_content_update_suppression(
       base_action, suppress_config_callback_update_);
 
@@ -495,16 +501,24 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
       config_dialog_open_ = false;
       if (answer != QMessageBox::Yes) {
-        // 「編集を継続」: 再構築を skip してテーブルを温存する。current_map_ / config_path_
-        // メンバは既に (queued lambda に入る前に) 最新値へ更新済みのため、表示中の table は
-        // その map/path に対して古くなる。次の SaveButton では baseline 比較ガード
+        // 「編集を継続」: 再構築を skip してテーブルを温存する。InitConfigs を呼ばないため
+        // FileComboBox とテーブルは旧 map/path 側で「一貫して」残り、保存も旧 path へ正しく
+        // 対応する (メンバ current_map_ / config_path_ だけが最新へ進む)。次の外部イベントでは
+        // dirty が立ったままなので再度確認され、SaveButton では baseline 比較ガード
         // (should_confirm_overwrite) が外部変更を再検出して上書き確認を出す。
         return;
       }
-      // 「再読込」: fall through して従来通り再構築する (未保存編集は破棄)。
+      // 「再読込」: dialog 表示中に後続イベントが kDrop で破棄されていても、メンバは
+      // 各イベントの lambda (FIFO) で常に最新へ更新済み。キャプチャした map_name/action で
+      // 部分再構築すると MapComboBox / FileComboBox とテーブルが食い違うため (PR #414 review
+      // high)、最新メンバから full reinit する (InitConfigs は FileComboBox 再構築 +
+      // UpdatePoiTable まで行い、dirty / baseline もそこでリセットされる)。
+      InitConfigs(current_map_);
+      return;
     }
 
-    // kProceed (dirty でない / Noop) または kAskUser で「再読込」を選んだ場合: 従来通り。
+    // kProceed (dirty でない / Noop): 従来通りキャプチャ値で dispatch する (dialog を挟まない
+    // ため staleness は生じない。連続イベントも FIFO で各 lambda が順に適用され最後が勝つ)。
     if (action == detail::ConfigPathUpdateAction::ReinitializeMap) {
       InitConfigs(map_name);
     } else if (action == detail::ConfigPathUpdateAction::RefreshCurrentMap) {
@@ -762,6 +776,13 @@ void PoiEditorPanel::UpdatePoiTable()
         baseline_path_ = base_path;
         baseline_content_ = ss.str();
       }
+    }
+    if (baseline_path_.empty() && !config_path_.empty()) {
+      // config を把握しているのに baseline を読めなかった場合のみ WARN する (config 未取得で
+      // itemText(0) が "the other" の場合はガード無効が正常なのでログしない)。
+      // ガード無効化 (= 上書き確認が出ない) の切り分け用 (PR #414 review low)。
+      RCLCPP_WARN(LOGGER, "Failed to read baseline config for overwrite guard: %s",
+                  base_path.c_str());
     }
   }
 }

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -4,6 +4,7 @@
 #include <class_loader/class_loader.hpp>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 
 #include <QFileDialog>
 #include <QStandardPaths>
@@ -345,6 +346,10 @@ void PoiEditorPanel::TableChanged(int row, int column)
 {
   if(is_table_color_){
     ui_->PoiTable->item(row, column)->setBackground(Qt::green);
+    // ユーザー編集の dirty マーク (#399)。UpdatePoiTable / TagFilterChanged の再構築中は
+    // is_table_color_=false で setItem 由来の cellChanged が飛ぶため、既存の green 着色ガードに
+    // 相乗りしてユーザー編集だけを拾う (再構築由来の cellChanged では dirty を立てない)。
+    table_dirty_ = true;
   }
   ui_->SaveButton->setText("save");
   ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
@@ -362,6 +367,8 @@ void PoiEditorPanel::NewButton()
   ui_->PoiTable->setItem(new_row, kColTolerance, new QTableWidgetItem("0.5, 0.7854"));  // ≒ π/4 rad
   ui_->PoiTable->setItem(new_row, kColTags, new QTableWidgetItem(""));
   ui_->PoiTable->setItem(new_row, kColDescription, new QTableWidgetItem(""));
+  // insertRow / setItem は cellChanged を確実には発火しないため dirty を明示 set (#399)。
+  table_dirty_ = true;
   UpdatePoiCount();
 }
 
@@ -376,6 +383,8 @@ void PoiEditorPanel::CopyButton()
     QString txt = item ? item->text() : "";
     ui_->PoiTable->setItem(new_row, col, new QTableWidgetItem(txt));
   }
+  // insertRow による行複製は cellChanged を確実には発火しないため dirty を明示 set (#399)。
+  table_dirty_ = true;
   UpdatePoiCount();
 }
 
@@ -383,6 +392,8 @@ void PoiEditorPanel::DeleteButton()
 {
   int current_row = ui_->PoiTable->currentRow();
   ui_->PoiTable->removeRow(current_row);
+  // removeRow は cellChanged を発火しないため dirty を明示 set (#399)。
+  table_dirty_ = true;
   ui_->SaveButton->setText("save");
   ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
   UpdatePoiCount();
@@ -395,6 +406,8 @@ void PoiEditorPanel::RowMoved(int logicalIndex, int oldVisualIndex, int newVisua
   for (int col = 0; col < numCols; col++){
     ui_->PoiTable->item(logicalIndex, col)->setBackground(Qt::green);
   }
+  // sectionMoved は cellChanged を発火しないため dirty を明示 set (#399)。
+  table_dirty_ = true;
   ui_->SaveButton->setText("save");
   ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
 }
@@ -459,6 +472,39 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
   QMetaObject::invokeMethod(this, [this, map_name, base_action]() {
     const auto action = detail::apply_poi_editor_content_update_suppression(
       base_action, suppress_config_callback_update_);
+
+    // 未保存編集ガード (#399)。suppression 適用後の action・dirty・dialog 表示中フラグから
+    // 再構築の可否を純関数で判定する。callback はこの判定を QMessageBox 表示へ写像するだけ。
+    const auto guard = detail::decide_config_reload_guard(
+      action, table_dirty_, config_dialog_open_);
+
+    if (guard == detail::ConfigReloadGuardDecision::kDrop) {
+      // dialog 表示中に届いたイベントは破棄する (QMessageBox のネストイベントループ中に
+      // 後続 queued lambda が積み重なって dialog が重なるのを防ぐ)。ユーザーが「再読込」を
+      // 選べばその時点の最新状態が fetch されるため drop で欠損しない。
+      return;
+    }
+    if (guard == detail::ConfigReloadGuardDecision::kAskUser) {
+      // 未保存編集がある状態で外部変更を検出。破棄可否をユーザーに確認する。
+      // dialog 表示中に届く config_path イベントは config_dialog_open_ で drop させる。
+      config_dialog_open_ = true;
+      const auto answer = QMessageBox::question(
+        this, tr("External Change Detected"),
+        tr("The configuration was changed externally. Reload?\n"
+           "(Unsaved edits will be discarded.)"),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+      config_dialog_open_ = false;
+      if (answer != QMessageBox::Yes) {
+        // 「編集を継続」: 再構築を skip してテーブルを温存する。current_map_ / config_path_
+        // メンバは既に (queued lambda に入る前に) 最新値へ更新済みのため、表示中の table は
+        // その map/path に対して古くなる。次の SaveButton では baseline 比較ガード
+        // (should_confirm_overwrite) が外部変更を再検出して上書き確認を出す。
+        return;
+      }
+      // 「再読込」: fall through して従来通り再構築する (未保存編集は破棄)。
+    }
+
+    // kProceed (dirty でない / Noop) または kAskUser で「再読込」を選んだ場合: 従来通り。
     if (action == detail::ConfigPathUpdateAction::ReinitializeMap) {
       InitConfigs(map_name);
     } else if (action == detail::ConfigPathUpdateAction::RefreshCurrentMap) {
@@ -695,6 +741,29 @@ void PoiEditorPanel::UpdatePoiTable()
   // green stylesheet が残ったままになる症状 (issue #77 症状 2) を明示リセットで防ぐ。
   ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
   UpdatePoiCount();
+
+  // 全再構築 = サーバ状態と一致した時点なので dirty をクリアする (#399)。
+  table_dirty_ = false;
+
+  // 外部変更検出 (SaveButton) の baseline スナップショットを取り直す (#399)。
+  // テーブルの元データに対応する config ファイルは FileComboBox->itemText(0) (= config_path_
+  // 由来。SaveButton の LoadFile が読む path と同じ)。std::ifstream で全読みして {path, content}
+  // を保存する。読めない場合は両方 clear = 比較不能 (should_confirm_overwrite がガードを無効化
+  // = 従来挙動になる)。
+  baseline_path_.clear();
+  baseline_content_.clear();
+  if (ui_->FileComboBox->count() > 0) {
+    const std::string base_path = ui_->FileComboBox->itemText(0).toStdString();
+    std::ifstream base_ifs(base_path, std::ios::binary);
+    if (base_ifs) {
+      std::stringstream ss;
+      ss << base_ifs.rdbuf();
+      if (base_ifs.good() || base_ifs.eof()) {
+        baseline_path_ = base_path;
+        baseline_content_ = ss.str();
+      }
+    }
+  }
 }
 
 double PoiEditorPanel::calcYaw(geometry_msgs::msg::Pose pose)

--- a/mapoi_rviz_plugins/src/poi_editor_save.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_save.cpp
@@ -5,6 +5,7 @@
 #include "mapoi_rviz_plugins/poi_editor_helpers.hpp"
 
 #include <fstream>
+#include <sstream>
 
 #include <QTimer>
 
@@ -43,6 +44,35 @@ void PoiEditorPanel::SaveButton()
   // Validate before saving
   if (!ValidatePois()) {
     return;
+  }
+
+  // 外部変更検出 (#399)。保存先ファイルが baseline (最後にテーブルへ読み込んだ / 保存した
+  // 時点の内容) から外部で変更されていたら上書き確認を挟む。WebUI の expected_version
+  // 楽観ロック相当のクライアント側実装 (config_version の厳密共有は不要で内容比較で足りる)。
+  //
+  // 比較は保存先 path (currentText) を基準にする。PR #413 review (low: itemText(0)/currentText
+  // 非対称) を踏まえ、FileComboBox「the other」で別ファイルを保存先に選んだ場合は baseline_path_
+  // と一致せず、should_confirm_overwrite が false を返して比較しない (誤った基準ファイルとの
+  // 比較を避ける)。baseline を読めていない場合もガード無効 = 従来挙動。
+  const std::string save_target_path = ui_->FileComboBox->currentText().toStdString();
+  if (save_target_path == baseline_path_ && !baseline_content_.empty()) {
+    std::string current_disk_content;
+    std::ifstream cur_ifs(save_target_path, std::ios::binary);
+    if (cur_ifs) {
+      std::stringstream ss;
+      ss << cur_ifs.rdbuf();
+      current_disk_content = ss.str();
+    }
+    if (detail::should_confirm_overwrite(
+          save_target_path, baseline_path_, baseline_content_, current_disk_content)) {
+      const auto answer = QMessageBox::question(
+        this, tr("External Change Detected"),
+        tr("The destination configuration file was changed externally. Overwrite?"),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+      if (answer != QMessageBox::Yes) {
+        return;  // キャンセル: 上書きしない
+      }
+    }
   }
 
   int numRows = ui_->PoiTable->rowCount();
@@ -124,6 +154,16 @@ void PoiEditorPanel::SaveButton()
 
   ui_->SaveButton->setText("SAVED!");
   ui_->SaveButton->setStyleSheet("QPushButton {background-color: green; color: black;}");
+
+  // 保存成功: 未保存編集ガードの状態を更新する (#399)。
+  // - dirty clear は書き込み直後に行う (1.5 秒後の UpdatePoiTable を待たず、その間に届く
+  //   config_path 再着信で ConfigPathCallback が確認ダイアログを出さないようにする)。
+  // - baseline も書き込んだ内容 (out.c_str()) と保存先 path で更新する。1.5 秒後の
+  //   UpdatePoiTable が itemText(0) から取り直す baseline と実質同じだが、それを待たずに
+  //   直後の save 連打や外部変更検出が正しい基準を持てるようにここでも更新する。
+  table_dirty_ = false;
+  baseline_path_ = save_path;
+  baseline_content_ = out.c_str();
 
   if (!reload_map_info_client_->wait_for_service(3s)) {
     RCLCPP_ERROR(LOGGER, "mapoi/reload_map_info service not available after 3s timeout.");

--- a/mapoi_rviz_plugins/test/test_poi_editor_helpers.cpp
+++ b/mapoi_rviz_plugins/test/test_poi_editor_helpers.cpp
@@ -6,6 +6,12 @@
 using mapoi_rviz_plugins::detail::split_and_trim;
 using mapoi_rviz_plugins::detail::try_parse_finite_double;
 
+// 未保存編集ガード判定 (#399)
+using mapoi_rviz_plugins::detail::ConfigPathUpdateAction;
+using mapoi_rviz_plugins::detail::ConfigReloadGuardDecision;
+using mapoi_rviz_plugins::detail::decide_config_reload_guard;
+using mapoi_rviz_plugins::detail::should_confirm_overwrite;
+
 // --- split_and_trim ---
 
 TEST(SplitAndTrim, BasicTwoParts)
@@ -123,4 +129,124 @@ TEST(TryParseFiniteDouble, AllowsTrailingWhitespace)
   double out = 0.0;
   EXPECT_TRUE(try_parse_finite_double("3.14 ", out));
   EXPECT_DOUBLE_EQ(out, 3.14);
+}
+
+// --- decide_config_reload_guard (#399) ---
+//
+// ConfigPathCallback は外部 config_path 再 publish 時に、この判定を QMessageBox 表示 /
+// 再構築 / drop へ写像するだけ。dirty×action×dialog_open の分岐表をここで pin し、
+// 未保存編集を黙って捨てる回帰 (dirty 判定の抜け・drop 条件の反転等) を安く捕える。
+
+TEST(DecideConfigReloadGuard, NotDirtyProceedsForRefresh)
+{
+  // 未保存編集なし: 従来通り再構築 (サーバ状態に追従)。
+  EXPECT_EQ(
+    decide_config_reload_guard(
+      ConfigPathUpdateAction::RefreshCurrentMap, false, false),
+    ConfigReloadGuardDecision::kProceed);
+}
+
+TEST(DecideConfigReloadGuard, NotDirtyProceedsForReinitialize)
+{
+  EXPECT_EQ(
+    decide_config_reload_guard(
+      ConfigPathUpdateAction::ReinitializeMap, false, false),
+    ConfigReloadGuardDecision::kProceed);
+}
+
+TEST(DecideConfigReloadGuard, DirtyRefreshAsksUser)
+{
+  // 未保存編集あり + 再構築対象あり: 破棄可否を確認する。
+  EXPECT_EQ(
+    decide_config_reload_guard(
+      ConfigPathUpdateAction::RefreshCurrentMap, true, false),
+    ConfigReloadGuardDecision::kAskUser);
+}
+
+TEST(DecideConfigReloadGuard, DirtyReinitializeAsksUser)
+{
+  // map 切替でも未保存編集があれば確認する (Reinitialize も table を捨てるため)。
+  EXPECT_EQ(
+    decide_config_reload_guard(
+      ConfigPathUpdateAction::ReinitializeMap, true, false),
+    ConfigReloadGuardDecision::kAskUser);
+}
+
+TEST(DecideConfigReloadGuard, NoopProceedsEvenWhenDirty)
+{
+  // Noop (suppress 中 or 更新不要) は table を触らないため dirty でも確認不要。
+  EXPECT_EQ(
+    decide_config_reload_guard(
+      ConfigPathUpdateAction::Noop, true, false),
+    ConfigReloadGuardDecision::kProceed);
+}
+
+TEST(DecideConfigReloadGuard, DialogOpenDropsEvent)
+{
+  // dialog 表示中に届いたイベントは破棄する (dialog 積み重ね防止)。dirty でも drop。
+  EXPECT_EQ(
+    decide_config_reload_guard(
+      ConfigPathUpdateAction::RefreshCurrentMap, true, true),
+    ConfigReloadGuardDecision::kDrop);
+}
+
+TEST(DecideConfigReloadGuard, DialogOpenDropsEvenWhenNotDirty)
+{
+  // dirty でなくても dialog 表示中の再構築 (Refresh/Reinit) は drop する
+  // (ネストイベントループ中の再入を一切許さない)。
+  EXPECT_EQ(
+    decide_config_reload_guard(
+      ConfigPathUpdateAction::ReinitializeMap, false, true),
+    ConfigReloadGuardDecision::kDrop);
+}
+
+TEST(DecideConfigReloadGuard, NoopTakesPrecedenceOverDialogOpen)
+{
+  // Noop は最優先で Proceed (table を触らないので dialog 中でも drop 不要 = 無害)。
+  EXPECT_EQ(
+    decide_config_reload_guard(
+      ConfigPathUpdateAction::Noop, true, true),
+    ConfigReloadGuardDecision::kProceed);
+}
+
+// --- should_confirm_overwrite (#399) ---
+
+TEST(ShouldConfirmOverwrite, ContentDiffersConfirms)
+{
+  // path 一致 && baseline 非空 && 内容不一致: 上書き確認が必要。
+  EXPECT_TRUE(should_confirm_overwrite(
+    "/maps/mapA/mapoi_config.yaml", "/maps/mapA/mapoi_config.yaml",
+    "poi: [old]", "poi: [changed_externally]"));
+}
+
+TEST(ShouldConfirmOverwrite, ContentMatchesNoConfirm)
+{
+  // 内容一致: 外部変更なし = 確認不要。
+  EXPECT_FALSE(should_confirm_overwrite(
+    "/maps/mapA/mapoi_config.yaml", "/maps/mapA/mapoi_config.yaml",
+    "poi: [same]", "poi: [same]"));
+}
+
+TEST(ShouldConfirmOverwrite, DifferentPathDoesNotCompare)
+{
+  // 保存先が baseline と別 path (FileComboBox「the other」で別ファイル指定): 比較しない。
+  // 内容が違っても基準を持たないファイルとの比較は無意味なので false。
+  EXPECT_FALSE(should_confirm_overwrite(
+    "/maps/mapB/other.yaml", "/maps/mapA/mapoi_config.yaml",
+    "poi: [baseline_of_A]", "poi: [content_of_B]"));
+}
+
+TEST(ShouldConfirmOverwrite, EmptyBaselineDisablesGuard)
+{
+  // baseline を読めなかった (空): ガード無効 = 従来挙動 (無条件上書き)。
+  EXPECT_FALSE(should_confirm_overwrite(
+    "/maps/mapA/mapoi_config.yaml", "/maps/mapA/mapoi_config.yaml",
+    "", "poi: [anything_on_disk]"));
+}
+
+TEST(ShouldConfirmOverwrite, EmptyBaselinePathDoesNotMatchNonEmptySave)
+{
+  // baseline 未取得 (path も空) の状態で保存先を指定 → path 不一致で比較しない。
+  EXPECT_FALSE(should_confirm_overwrite(
+    "/maps/mapA/mapoi_config.yaml", "", "", "poi: [x]"));
 }


### PR DESCRIPTION
Closes #399

## 目的

他クライアント (WebUI / 別 RViz / 地図切替) の保存で `mapoi/config_path` が再 publish されると、PoiEditor は無条件にテーブルを全再構築し**未保存のセル編集が黙って消えていた**。また SaveButton は外部変更を検出せず即上書きするため相互上書き事故も起こり得た (WebUI 側は dirty tracking + 楽観ロックで多重防御済みの非対称)。

## 変更

- **dirty フラグ** (`table_dirty_`): TableChanged (is_table_color_ ガードで再構築由来の cellChanged を除外) / New / Copy / Delete / RowMoved で set、UpdatePoiTable 末尾と保存成功直後に clear
- **再構築ガード**: ConfigPathCallback で dirty かつ再構築対象ありなら QMessageBox で「再読込 (編集破棄) / 編集継続」を確認。dialog 表示中の後続イベントは drop (再入防止)。suppression (自己保存後 1.5 秒) 適用後の action を判定入力にするため既存フロー不変
- **外部変更検出**: SaveButton で保存先 path が baseline (最後に読み込み/保存した時点の内容) と一致する場合のみ内容比較し、外部変更検出時は上書き確認。「the other」で別ファイル指定時は基準を持たないため比較しない (PR #413 review の itemText(0)/currentText 非対称を踏まえた設計)。保存成功直後に baseline を書き込み内容で更新
- **判定の純関数化 + gtest 13 件** (PR #413 review のテスト指摘を反映): `decide_config_reload_guard` (dirty×action×dialog_open の分岐表) と `should_confirm_overwrite` を poi_editor_helpers.hpp に切り出し、callback / SaveButton は結果を QMessageBox へ写像するだけの構造

## 軽量性

- 新規購読ゼロ・周期処理ゼロ。追加コストは外部変更イベント時 / 保存時の単発ファイル読みのみ

## 検証

- humble / jazzy 両 Docker で colcon build 通過、mapoi_rviz_plugins の gtest 49 ケース (新規 13 件含む) 全パス
