### PR TITLE
refactor(rviz): Panel の config/ComboBox 系を別 TU へ分割 (#397)

### DIFF
--- a/mapoi_rviz_plugins/CMakeLists.txt
+++ b/mapoi_rviz_plugins/CMakeLists.txt
@@ -21,6 +21,7 @@ qt5_wrap_ui(UIC_FILES
 )
 set(SOURCE_FILES
   src/mapoi_panel.cpp
+  src/mapoi_panel_config.cpp
   src/mapoi_panel_nav_status.cpp
   src/poi_editor.cpp
   src/poi_editor_save.cpp

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -1,10 +1,9 @@
 #include "mapoi_rviz_plugins/mapoi_panel.hpp"
 #include <class_loader/class_loader.hpp>
-#include <filesystem>
-#include <set>
 
-#include "mapoi_rviz_plugins/config_path_update_policy.hpp"
 #include "ui_mapoi_panel.h"
+// ConfigPathCallback / SetMapComboBox / SetNav2GoalComboBox / SetMapoiRouteComboBox は
+// mapoi_panel_config.cpp (#397 step 1) へ移動。
 
 using namespace std::chrono_literals;
 
@@ -337,128 +336,6 @@ void MapoiPanel::StopButton()
   ui_->NavStatusLabel->setText(QString::fromStdString("走行キャンセル"));
   RCLCPP_INFO(LOGGER, "The robot was stopped");
 }
-
-void MapoiPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
-{
-  std::filesystem::path config_path(msg->data);
-  std::string map_name = config_path.parent_path().filename().string();
-  const auto action = detail::decide_mapoi_panel_config_path_action(current_map_, map_name);
-  current_map_ = map_name;
-
-  // 同じ map で path も同じ場合 (= save 後の reload_map_info で再 publish される flow) でも
-  // POI / route list が変わっている可能性があるため Nav2GoalComboBox / MapoiRouteComboBox を
-  // 再 fetch する (#135)。map 切替時は highlight クリア + MapComboBox 同期も必要なので
-  // SetMapComboBox を呼ぶ。
-  QMetaObject::invokeMethod(this, [this, map_name, action]() {
-    if (action == detail::ConfigPathUpdateAction::ReinitializeMap) {
-      SetMapComboBox(map_name);
-    } else {
-      SetNav2GoalComboBox();
-      SetMapoiRouteComboBox();
-    }
-  }, Qt::QueuedConnection);
-}
-
-void MapoiPanel::SetMapComboBox(std::string map_name)
-{
-  highlighted_goal_name_.clear();
-  highlighted_route_poi_names_.clear();
-  PublishHighlightPois();
-
-  int i = 0;
-  for(const auto & map : map_name_list_){
-    if(map == map_name){
-      ui_->MapComboBox->setCurrentIndex(i);
-      SetNav2GoalComboBox();
-      SetMapoiRouteComboBox();
-      return;
-    }
-    i++;
-  }
-  i = 0;
-  for(const auto & map : map_name_list_){
-    RCLCPP_ERROR_STREAM(LOGGER, "map" << i << " : " << map << " correctly");
-    i++;
-  }
-  RCLCPP_ERROR_STREAM(LOGGER, "Couldn't get " << map_name << " correctly");
-}
-
-void MapoiPanel::SetNav2GoalComboBox()
-{
-  // 再構築前に現在 selection を保存し、同名項目があれば復元する (#135 副作用対応)。
-  // 他クライアント save (POI 追加 / pose 変更など) の reload で goal 選択が消えるのを防ぐ。
-  // 削除 / 名前変更で同名項目が消えた場合は currentIndex 0 (default) に fallback。
-  QString prev_selection = ui_->Nav2GoalComboBox->currentText();
-
-  auto request_gtp = std::make_shared<mapoi_interfaces::srv::GetPoisInfo::Request>();
-
-  if (!get_pois_info_client_->wait_for_service(3s)) {
-    RCLCPP_ERROR(LOGGER, "mapoi/get_pois_info service not available after 3s timeout.");
-    return;
-  }
-
-  auto result_get_pois_info = get_pois_info_client_->async_send_request(request_gtp);
-  if(rclcpp::spin_until_future_complete(service_node_, result_get_pois_info) == rclcpp::FutureReturnCode::SUCCESS)
-  {
-
-    auto pois_all = result_get_pois_info.get()->pois_list;
-    ui_->Nav2GoalComboBox->clear();
-    pois_.clear();
-
-    for(const auto & p : pois_all){
-      bool is_waypoint = false;
-      bool is_landmark = false;
-      for(const auto & tag : p.tags){
-        if(tag == "waypoint") is_waypoint = true;
-        else if(tag == "landmark") is_landmark = true;
-      }
-      // waypoint+landmark 併用は意味矛盾だが万一 config に混入しても candidate には載せない (#85)。
-      if(is_waypoint && !is_landmark){
-        pois_.push_back(p);
-        ui_->Nav2GoalComboBox->addItem(QString::fromStdString(p.name));
-      }
-    }
-    int idx = ui_->Nav2GoalComboBox->findText(prev_selection);
-    if (idx >= 0) {
-      ui_->Nav2GoalComboBox->setCurrentIndex(idx);
-    }
-    goal_combobox_ind_ = ui_->Nav2GoalComboBox->currentIndex();
-  }else{
-    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/get_pois_info");
-  }
-}
-
-void MapoiPanel::SetMapoiRouteComboBox()
-{
-  // 再構築前に現在 selection を保存し、同名項目があれば復元する (#135 副作用対応)。
-  // 他クライアント save (route 追加 / 内容変更) の reload で route 選択が消えるのを防ぐ。
-  QString prev_selection = ui_->MapoiRouteComboBox->currentText();
-
-  if (!get_routes_info_client_->wait_for_service(3s)) {
-    RCLCPP_ERROR(LOGGER, "mapoi/get_routes_info service not available after 3s timeout.");
-    return;
-  }
-
-  auto request = std::make_shared<mapoi_interfaces::srv::GetRoutesInfo::Request>();
-  auto result = get_routes_info_client_->async_send_request(request);
-  if(rclcpp::spin_until_future_complete(service_node_, result) == rclcpp::FutureReturnCode::SUCCESS)
-  {
-    ui_->MapoiRouteComboBox->clear();
-    ui_->MapoiRouteComboBox->addItem(QString::fromStdString("(なし)"));
-    route_name_list_ = result.get()->routes_list;
-    for(const auto & route : route_name_list_){
-      ui_->MapoiRouteComboBox->addItem(QString::fromStdString(route));
-    }
-    int idx = ui_->MapoiRouteComboBox->findText(prev_selection);
-    if (idx >= 0) {
-      ui_->MapoiRouteComboBox->setCurrentIndex(idx);
-    }
-    route_combobox_ind_ = ui_->MapoiRouteComboBox->currentIndex();
-  }else{
-    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/get_routes_info");
-  }
-}
-
 
 void MapoiPanel::BackendStatusCallback(
   mapoi_interfaces::msg::NavigationBackendStatus::SharedPtr msg)

--- a/mapoi_rviz_plugins/src/mapoi_panel_config.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_config.cpp
@@ -1,0 +1,135 @@
+// MapoiPanel の config/ComboBox 系メソッド定義 (#397 step 1 で mapoi_panel.cpp から別 TU へ分離)。
+// ConfigPathCallback / SetMapComboBox / SetNav2GoalComboBox / SetMapoiRouteComboBox を収録。
+#include "mapoi_rviz_plugins/mapoi_panel.hpp"
+#include "mapoi_rviz_plugins/config_path_update_policy.hpp"
+#include <filesystem>
+#include "ui_mapoi_panel.h"
+
+using namespace std::chrono_literals;
+
+namespace mapoi_rviz_plugins
+{
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("mapoi_rviz_plugins.mapoi_panel");
+
+void MapoiPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
+{
+  std::filesystem::path config_path(msg->data);
+  std::string map_name = config_path.parent_path().filename().string();
+  const auto action = detail::decide_mapoi_panel_config_path_action(current_map_, map_name);
+  current_map_ = map_name;
+
+  // 同じ map で path も同じ場合 (= save 後の reload_map_info で再 publish される flow) でも
+  // POI / route list が変わっている可能性があるため Nav2GoalComboBox / MapoiRouteComboBox を
+  // 再 fetch する (#135)。map 切替時は highlight クリア + MapComboBox 同期も必要なので
+  // SetMapComboBox を呼ぶ。
+  QMetaObject::invokeMethod(this, [this, map_name, action]() {
+    if (action == detail::ConfigPathUpdateAction::ReinitializeMap) {
+      SetMapComboBox(map_name);
+    } else {
+      SetNav2GoalComboBox();
+      SetMapoiRouteComboBox();
+    }
+  }, Qt::QueuedConnection);
+}
+
+void MapoiPanel::SetMapComboBox(std::string map_name)
+{
+  highlighted_goal_name_.clear();
+  highlighted_route_poi_names_.clear();
+  PublishHighlightPois();
+
+  int i = 0;
+  for(const auto & map : map_name_list_){
+    if(map == map_name){
+      ui_->MapComboBox->setCurrentIndex(i);
+      SetNav2GoalComboBox();
+      SetMapoiRouteComboBox();
+      return;
+    }
+    i++;
+  }
+  i = 0;
+  for(const auto & map : map_name_list_){
+    RCLCPP_ERROR_STREAM(LOGGER, "map" << i << " : " << map << " correctly");
+    i++;
+  }
+  RCLCPP_ERROR_STREAM(LOGGER, "Couldn't get " << map_name << " correctly");
+}
+
+void MapoiPanel::SetNav2GoalComboBox()
+{
+  // 再構築前に現在 selection を保存し、同名項目があれば復元する (#135 副作用対応)。
+  // 他クライアント save (POI 追加 / pose 変更など) の reload で goal 選択が消えるのを防ぐ。
+  // 削除 / 名前変更で同名項目が消えた場合は currentIndex 0 (default) に fallback。
+  QString prev_selection = ui_->Nav2GoalComboBox->currentText();
+
+  auto request_gtp = std::make_shared<mapoi_interfaces::srv::GetPoisInfo::Request>();
+
+  if (!get_pois_info_client_->wait_for_service(3s)) {
+    RCLCPP_ERROR(LOGGER, "mapoi/get_pois_info service not available after 3s timeout.");
+    return;
+  }
+
+  auto result_get_pois_info = get_pois_info_client_->async_send_request(request_gtp);
+  if(rclcpp::spin_until_future_complete(service_node_, result_get_pois_info) == rclcpp::FutureReturnCode::SUCCESS)
+  {
+
+    auto pois_all = result_get_pois_info.get()->pois_list;
+    ui_->Nav2GoalComboBox->clear();
+    pois_.clear();
+
+    for(const auto & p : pois_all){
+      bool is_waypoint = false;
+      bool is_landmark = false;
+      for(const auto & tag : p.tags){
+        if(tag == "waypoint") is_waypoint = true;
+        else if(tag == "landmark") is_landmark = true;
+      }
+      // waypoint+landmark 併用は意味矛盾だが万一 config に混入しても candidate には載せない (#85)。
+      if(is_waypoint && !is_landmark){
+        pois_.push_back(p);
+        ui_->Nav2GoalComboBox->addItem(QString::fromStdString(p.name));
+      }
+    }
+    int idx = ui_->Nav2GoalComboBox->findText(prev_selection);
+    if (idx >= 0) {
+      ui_->Nav2GoalComboBox->setCurrentIndex(idx);
+    }
+    goal_combobox_ind_ = ui_->Nav2GoalComboBox->currentIndex();
+  }else{
+    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/get_pois_info");
+  }
+}
+
+void MapoiPanel::SetMapoiRouteComboBox()
+{
+  // 再構築前に現在 selection を保存し、同名項目があれば復元する (#135 副作用対応)。
+  // 他クライアント save (route 追加 / 内容変更) の reload で route 選択が消えるのを防ぐ。
+  QString prev_selection = ui_->MapoiRouteComboBox->currentText();
+
+  if (!get_routes_info_client_->wait_for_service(3s)) {
+    RCLCPP_ERROR(LOGGER, "mapoi/get_routes_info service not available after 3s timeout.");
+    return;
+  }
+
+  auto request = std::make_shared<mapoi_interfaces::srv::GetRoutesInfo::Request>();
+  auto result = get_routes_info_client_->async_send_request(request);
+  if(rclcpp::spin_until_future_complete(service_node_, result) == rclcpp::FutureReturnCode::SUCCESS)
+  {
+    ui_->MapoiRouteComboBox->clear();
+    ui_->MapoiRouteComboBox->addItem(QString::fromStdString("(なし)"));
+    route_name_list_ = result.get()->routes_list;
+    for(const auto & route : route_name_list_){
+      ui_->MapoiRouteComboBox->addItem(QString::fromStdString(route));
+    }
+    int idx = ui_->MapoiRouteComboBox->findText(prev_selection);
+    if (idx >= 0) {
+      ui_->MapoiRouteComboBox->setCurrentIndex(idx);
+    }
+    route_combobox_ind_ = ui_->MapoiRouteComboBox->currentIndex();
+  }else{
+    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/get_routes_info");
+  }
+}
+
+}  // namespace mapoi_rviz_plugins


### PR DESCRIPTION
## 目的

#397 step 1。`mapoi_panel.cpp` の config/ComboBox 系 4 メソッド (`ConfigPathCallback` / `SetMapComboBox` / `SetNav2GoalComboBox` / `SetMapoiRouteComboBox`、計 約 120 行) を専用 TU `mapoi_panel_config.cpp` へ behavior-preserving に分割する。#403 (ConfigPathCallback の内容 diff ガード) の Panel 側変更をこの TU に閉じるための先行分割 (#397 の step↔機能対応表参照)。

## 変更

- `mapoi_panel_config.cpp` (新規 135 行): 4 メソッドをコメント含め一字一句そのまま移動。LOGGER は同名再定義でログ出力先不変 (#408/#413 と同じ構成)
- `mapoi_panel.cpp`: 当該定義を削除し分割先コメントを残す。移動で未使用になった include (`<filesystem>` / `config_path_update_policy.hpp`) と元々未使用だった `<set>` を削除 (使用有無は Grep で確認)
- `CMakeLists.txt`: SOURCE_FILES に 1 行追加。ヘッダ変更なし

## 検証

- humble / jazzy 両 Docker で colcon build 通過、gtest 49 ケース全パス
- 4 メソッドの定義はそれぞれ新 TU の 1 箇所のみ (Grep 確認)、挙動変更なし