### PR TITLE
perf(rviz): ConfigPathCallback に内容 diff ガードを追加 (#403)

### DIFF
--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/config_path_update_policy.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/config_path_update_policy.hpp
@@ -2,6 +2,7 @@
 // Qt / ROS 依存を持たせず、Panel callback はこの判定結果を UI 更新関数へ写像するだけにする。
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 namespace mapoi_rviz_plugins::detail
@@ -42,6 +43,30 @@ inline ConfigPathUpdateAction decide_mapoi_panel_config_path_action(
   return current_map != new_map
     ? ConfigPathUpdateAction::ReinitializeMap
     : ConfigPathUpdateAction::RefreshCurrentMap;
+}
+
+// 内容 diff ガード (#403)。publisher (mapoi_rviz2_publisher の path+mtime dedup) と同型の
+// 判定を両パネルで共有する。RefreshCurrentMap のみ dedup 対象:
+//   - ReinitializeMap は map 切替 = path が必ず変わるため dedup 不成立 (素通し)
+//   - stat 失敗 (stat_ok=false) は dedup 不能として従来挙動 (素通し) — publisher と同じ方針
+//   - path も mtime も前回と同一 → Noop (再 fetch / 再構築を抑制)
+// mtime が変わった場合は従来通り再取得する (save 後の reload_map_info による同一 path
+// 再 publish で内容が変わる flow (#135) を壊さない)。
+inline ConfigPathUpdateAction apply_config_content_dedup(
+  ConfigPathUpdateAction action, bool stat_ok,
+  const std::string & path, std::filesystem::file_time_type mtime,
+  const std::string & last_path, std::filesystem::file_time_type last_mtime)
+{
+  if (action != ConfigPathUpdateAction::RefreshCurrentMap) {
+    return action;  // ReinitializeMap / Noop は dedup 対象外 (素通し)
+  }
+  if (!stat_ok) {
+    return action;  // stat 失敗: dedup 不能として従来挙動 (素通し)
+  }
+  if (path == last_path && mtime == last_mtime) {
+    return ConfigPathUpdateAction::Noop;  // path も mtime も不変 → 再 fetch 不要
+  }
+  return action;  // mtime が変わった = 内容が変わった可能性あり → 従来通り再取得
 }
 
 }  // namespace mapoi_rviz_plugins::detail

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
@@ -2,6 +2,7 @@
 
 #ifndef Q_MOC_RUN
 #include <rclcpp/rclcpp.hpp>
+#include <filesystem>
 #endif
 
 #include <QTimer>
@@ -86,6 +87,12 @@ protected:
 
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr config_path_sub_;
   void ConfigPathCallback(std_msgs::msg::String::SharedPtr msg);
+
+  // 内容 diff ガード (#403)。直前に処理した config_path イベントの path と mtime を保持し、
+  // path も mtime も変わっていない再 publish (= 内容変化なし) を Noop に落とす。
+  // UI (Qt メイン) スレッド上でのみ読み書きする (queued lambda 内、PR #412/#414 の規約と同じ)。
+  std::string last_seen_config_path_;
+  std::filesystem::file_time_type last_seen_config_mtime_{};
 
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr nav_status_sub_;
   void NavStatusCallback(std_msgs::msg::String::SharedPtr msg);

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -136,6 +136,12 @@ protected:
   // config_path イベントは drop する。再読込を選べば最新状態が fetch されるので欠損しない)。
   bool config_dialog_open_ = false;
 
+  // 内容 diff ガード (#403)。直前に処理した config_path イベントの path と mtime を保持し、
+  // path も mtime も変わっていない再 publish (= 内容変化なし) を Noop に落とす。
+  // UI (Qt メイン) スレッド上でのみ読み書きする (#399 の table_dirty_ 等と同じ規約)。
+  std::string last_seen_config_path_;
+  std::filesystem::file_time_type last_seen_config_mtime_{};
+
   // Functions
   void InitConfigs(std::string map_name);
   void UpdatePoiTable();

--- a/mapoi_rviz_plugins/src/mapoi_panel_config.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_config.cpp
@@ -13,22 +13,46 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("mapoi_rviz_plugins.mapo
 
 void MapoiPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
 {
-  std::filesystem::path config_path(msg->data);
+  // map 名の抽出は ROS スレッドで行ってよい (std::filesystem::path は const 操作のみ)。
+  // action 判定 / current_map_ 更新 / dedup 判定 / last_seen_* 更新は queued lambda 内
+  // (UI スレッド) で行う。理由: UI スレッド所有規約 (PR #412/#414 と同じ) に加え、lambda は
+  // Qt イベントキューの FIFO で適用されるため、連続イベントでもメンバは常に最新へ進む。
+  const std::string path = msg->data;
+  std::filesystem::path config_path(path);
   std::string map_name = config_path.parent_path().filename().string();
-  const auto action = detail::decide_mapoi_panel_config_path_action(current_map_, map_name);
-  current_map_ = map_name;
 
   // 同じ map で path も同じ場合 (= save 後の reload_map_info で再 publish される flow) でも
   // POI / route list が変わっている可能性があるため Nav2GoalComboBox / MapoiRouteComboBox を
   // 再 fetch する (#135)。map 切替時は highlight クリア + MapComboBox 同期も必要なので
   // SetMapComboBox を呼ぶ。
-  QMetaObject::invokeMethod(this, [this, map_name, action]() {
+  QMetaObject::invokeMethod(this, [this, path, map_name]() {
+    const auto base_action = detail::decide_mapoi_panel_config_path_action(current_map_, map_name);
+    current_map_ = map_name;
+
+    // 内容 diff ガード (#403): Refresh かつ path/mtime 不変の再 publish を Noop に落とす。
+    // stat 失敗は dedup 不能として従来挙動 (素通し) — publisher と同じ方針。
+    std::error_code mtime_ec;
+    const auto mtime = std::filesystem::last_write_time(path, mtime_ec);
+    const auto action = detail::apply_config_content_dedup(
+      base_action, !mtime_ec,
+      path, mtime,
+      last_seen_config_path_, last_seen_config_mtime_);
+
+    // dedup で Noop にならなかった場合 = イベントを処理する場合に last_seen_* を更新する。
+    if (action != detail::ConfigPathUpdateAction::Noop) {
+      last_seen_config_path_ = path;
+      if (!mtime_ec) {
+        last_seen_config_mtime_ = mtime;
+      }
+    }
+
     if (action == detail::ConfigPathUpdateAction::ReinitializeMap) {
       SetMapComboBox(map_name);
-    } else {
+    } else if (action == detail::ConfigPathUpdateAction::RefreshCurrentMap) {
       SetNav2GoalComboBox();
       SetMapoiRouteComboBox();
     }
+    // Noop: 再 fetch せずスキップ
   }, Qt::QueuedConnection);
 }
 

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -476,8 +476,30 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
       current_map_, map_name, config_path_);
     config_path_ = resolved_path;
     current_map_ = map_name;
-    const auto action = detail::apply_poi_editor_content_update_suppression(
+    const auto suppressed = detail::apply_poi_editor_content_update_suppression(
       base_action, suppress_config_callback_update_);
+
+    // 内容 diff ガード (#403): ゲート適用順 suppression → dedup → dirty guard。
+    // suppression が Noop にした場合は dedup を経由せず kProceed になるのが正しい
+    // (suppression は Save 直後の SAVED! 保護で dedup と目的が異なる)。
+    // dedup が Noop にした場合 = 内容不変の再 publish。dirty でも確認ダイアログを出さない
+    // (変化が無いのに編集破棄を問わない)。
+    std::error_code mtime_ec;
+    const auto mtime = std::filesystem::last_write_time(resolved_path, mtime_ec);
+    const auto action = detail::apply_config_content_dedup(
+      suppressed, !mtime_ec,
+      resolved_path, mtime,
+      last_seen_config_path_, last_seen_config_mtime_);
+
+    // dedup で Noop にならなかった場合 = イベントを処理する場合に last_seen_* を更新する。
+    // 更新タイミングは dirty guard (AskUser) の前: No でも last_seen を進めることで、同一内容
+    // の再 publish で再度ダイアログを出さない。実変更 (mtime 変化) なら再度尋ねる。
+    if (action != detail::ConfigPathUpdateAction::Noop) {
+      last_seen_config_path_ = resolved_path;
+      if (!mtime_ec) {
+        last_seen_config_mtime_ = mtime;
+      }
+    }
 
     // 未保存編集ガード (#399)。suppression 適用後の action・dirty・dialog 表示中フラグから
     // 再構築の可否を純関数で判定する。callback はこの判定を QMessageBox 表示へ写像するだけ。

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -480,8 +480,9 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
       base_action, suppress_config_callback_update_);
 
     // 内容 diff ガード (#403): ゲート適用順 suppression → dedup → dirty guard。
-    // suppression が Noop にした場合は dedup を経由せず kProceed になるのが正しい
-    // (suppression は Save 直後の SAVED! 保護で dedup と目的が異なる)。
+    // suppression が Noop にした場合、dedup は Noop 入力をそのまま素通しし (last_seen も
+    // 更新されない)、guard は kProceed → dispatch は何もしない。suppression (Save 直後の
+    // SAVED! 保護) と dedup (内容不変の抑制) は目的が異なるが、この合成で両立する。
     // dedup が Noop にした場合 = 内容不変の再 publish。dirty でも確認ダイアログを出さない
     // (変化が無いのに編集破棄を問わない)。
     std::error_code mtime_ec;

--- a/mapoi_rviz_plugins/test/test_config_path_update_policy.cpp
+++ b/mapoi_rviz_plugins/test/test_config_path_update_policy.cpp
@@ -5,8 +5,11 @@
 // RefreshCurrentMap / Noop) を UI 更新関数 (InitConfigs / UpdatePoiTable /
 // SetMapComboBox 等) へ写像するだけ。判定そのものは Qt / ROS 非依存の純関数なので、
 // 分岐表をここで pin し、リファクタで条件を踏み外す回帰 (`!=`↔`==` 反転、抑制対象の
-// 取り違え等) を安く捕える。header は <string> のみ依存。
+// 取り違え等) を安く捕える。header は <string> と <filesystem> のみ依存 (#403 で
+// mtime dedup の file_time_type が加わった)。
 #include <gtest/gtest.h>
+
+#include <chrono>
 
 #include "mapoi_rviz_plugins/config_path_update_policy.hpp"
 
@@ -14,6 +17,7 @@ using mapoi_rviz_plugins::detail::ConfigPathUpdateAction;
 using mapoi_rviz_plugins::detail::decide_poi_editor_config_path_action;
 using mapoi_rviz_plugins::detail::apply_poi_editor_content_update_suppression;
 using mapoi_rviz_plugins::detail::decide_mapoi_panel_config_path_action;
+using mapoi_rviz_plugins::detail::apply_config_content_dedup;
 
 // --- decide_poi_editor_config_path_action ---
 
@@ -83,4 +87,96 @@ TEST(DecideMapoiPanelConfigPathAction, SameMapRefreshes)
   EXPECT_EQ(
     decide_mapoi_panel_config_path_action("mapA", "mapA"),
     ConfigPathUpdateAction::RefreshCurrentMap);
+}
+
+// --- apply_config_content_dedup (#403) ---
+
+namespace
+{
+// テスト用の file_time_type 定数を作るヘルパー。epoch + offset の duration 構築にする
+// (clock::from_sys は C++20 API のため、humble の C++17 ビルドでは使えない)。
+std::filesystem::file_time_type make_mtime(int offset_sec)
+{
+  return std::filesystem::file_time_type{} + std::chrono::seconds(offset_sec);
+}
+}  // namespace
+
+TEST(ApplyConfigContentDedup, RefreshSamePathAndMtimeBecomesNoop)
+{
+  // path も mtime も前回と同一 → 内容変化なし → Noop に落とす。
+  const auto t = make_mtime(1000);
+  EXPECT_EQ(
+    apply_config_content_dedup(
+      ConfigPathUpdateAction::RefreshCurrentMap,
+      /*stat_ok=*/true,
+      "/maps/mapA/mapoi_config.yaml", t,
+      "/maps/mapA/mapoi_config.yaml", t),
+    ConfigPathUpdateAction::Noop);
+}
+
+TEST(ApplyConfigContentDedup, RefreshDifferentMtimePassesThrough)
+{
+  // mtime が変わった = save 後の reload_map_info による内容変更 (#135 flow)。従来通り再取得。
+  const auto t_old = make_mtime(1000);
+  const auto t_new = make_mtime(2000);
+  EXPECT_EQ(
+    apply_config_content_dedup(
+      ConfigPathUpdateAction::RefreshCurrentMap,
+      /*stat_ok=*/true,
+      "/maps/mapA/mapoi_config.yaml", t_new,
+      "/maps/mapA/mapoi_config.yaml", t_old),
+    ConfigPathUpdateAction::RefreshCurrentMap);
+}
+
+TEST(ApplyConfigContentDedup, RefreshDifferentPathPassesThrough)
+{
+  // path が変わった場合 (decide_* 側で ReinitializeMap になるはずだが、RefreshCurrentMap で
+  // 来ても path 不一致なので素通しにする — dedup は同一 path 前提)。
+  const auto t = make_mtime(1000);
+  EXPECT_EQ(
+    apply_config_content_dedup(
+      ConfigPathUpdateAction::RefreshCurrentMap,
+      /*stat_ok=*/true,
+      "/maps/mapA/mapoi_config.yaml", t,
+      "/maps/mapB/mapoi_config.yaml", t),
+    ConfigPathUpdateAction::RefreshCurrentMap);
+}
+
+TEST(ApplyConfigContentDedup, RefreshStatFailurePassesThrough)
+{
+  // stat 失敗 (stat_ok=false) は dedup 不能として素通し — publisher と同じ方針。
+  const auto t = make_mtime(1000);
+  EXPECT_EQ(
+    apply_config_content_dedup(
+      ConfigPathUpdateAction::RefreshCurrentMap,
+      /*stat_ok=*/false,
+      "/maps/mapA/mapoi_config.yaml", t,
+      "/maps/mapA/mapoi_config.yaml", t),
+    ConfigPathUpdateAction::RefreshCurrentMap);
+}
+
+TEST(ApplyConfigContentDedup, ReinitializeAlwaysPassesThrough)
+{
+  // ReinitializeMap は map 切替 = dedup 対象外。mtime が同一でも素通し。
+  const auto t = make_mtime(1000);
+  EXPECT_EQ(
+    apply_config_content_dedup(
+      ConfigPathUpdateAction::ReinitializeMap,
+      /*stat_ok=*/true,
+      "/maps/mapA/mapoi_config.yaml", t,
+      "/maps/mapA/mapoi_config.yaml", t),
+    ConfigPathUpdateAction::ReinitializeMap);
+}
+
+TEST(ApplyConfigContentDedup, NoopInputRemainsNoop)
+{
+  // 上流 (suppression 等) が既に Noop にした場合はそのまま Noop を返す。
+  const auto t = make_mtime(1000);
+  EXPECT_EQ(
+    apply_config_content_dedup(
+      ConfigPathUpdateAction::Noop,
+      /*stat_ok=*/true,
+      "/maps/mapA/mapoi_config.yaml", t,
+      "/maps/mapB/mapoi_config.yaml", t),  // path が違っても Noop は素通し
+    ConfigPathUpdateAction::Noop);
 }


### PR DESCRIPTION
Closes #403

## 目的

両パネルの ConfigPathCallback は map 名比較のみで再取得へ分岐するため、同一 map への他クライアント save/reload の度に UI スレッドの blocking service 再 fetch + フル再構築 (ComboBox 全再追加 / QTableWidget 全 re-new) が発生していた。publisher (`mapoi_rviz2_publisher`) が実装済みの path+mtime dedup と同型のガードを両パネルで共有する。

## 変更

- **純関数** `apply_config_content_dedup` を `config_path_update_policy.hpp` に追加 (#169 の「純関数切り出し + 両パネル共有」パターン踏襲)。RefreshCurrentMap のみ dedup 対象で、**mtime が変わった場合は従来通り再取得** (save 後の reload_map_info flow #135 を壊さない)。stat 失敗は素通し (publisher と同じ方針)。gtest 6 ケース追加
- **Editor 側**: ゲート適用順は suppression → dedup → dirty guard (#399)。内容不変の再 publish は dirty でも確認ダイアログを出さない (変化が無いのに編集破棄を問わない)。last_seen の更新は dirty guard の前 (No 選択でも同一内容の再 publish で再度ダイアログを出さない)
- **Panel 側**: dedup 追加とあわせ、PR #414 と同じ UI スレッド化 (action 判定・current_map_ 更新を queued lambda 内へ) を適用し、スレッド所有規約を両パネルで統一
- 追加コストはイベント時 1 回の mtime stat のみ (新規購読・周期処理なし)

## 検証

- humble / jazzy 両 Docker で colcon build 通過、mapoi_rviz_plugins の gtest 55 ケース (新規 6 件) 全パス
- テストヘルパーの file_time_type 構築は epoch+duration 方式 (C++17 互換。clock::from_sys は C++20 のため不使用)