### PR TITLE
refactor(rviz): backend status 系を別 TU へ分割 (#397)

### DIFF
--- a/mapoi_rviz_plugins/CMakeLists.txt
+++ b/mapoi_rviz_plugins/CMakeLists.txt
@@ -22,6 +22,7 @@ qt5_wrap_ui(UIC_FILES
 set(SOURCE_FILES
   src/mapoi_panel.cpp
   src/mapoi_panel_config.cpp
+  src/mapoi_panel_backend_status.cpp
   src/mapoi_panel_nav_status.cpp
   src/poi_editor.cpp
   src/poi_editor_save.cpp

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -337,58 +337,8 @@ void MapoiPanel::StopButton()
   RCLCPP_INFO(LOGGER, "The robot was stopped");
 }
 
-void MapoiPanel::BackendStatusCallback(
-  mapoi_interfaces::msg::NavigationBackendStatus::SharedPtr msg)
-{
-  // RViz panel 側でも backend_ready を見て操作ボタンを gate する (#198, #205 minimal)。
-  // backend_status 不在 (旧 mapoi_nav_server build (#208 以前 backend_status contract 未実装、#204 で nav2_bridge へ rename) / panel 単独起動) では callback が呼ばれず、
-  // navigation 軸は初期値 (true = enable) を使い続ける。
-  nav_backend_status_received_ = true;
-  last_navigation_backend_ready_ = msg->backend_ready;
-  QMetaObject::invokeMethod(this, [this]() {
-    UpdateNavButtonsEnabled();
-  }, Qt::QueuedConnection);
-}
-
-void MapoiPanel::LocalizationBackendStatusCallback(
-  mapoi_interfaces::msg::LocalizationBackendStatus::SharedPtr msg)
-{
-  // localization bridge の readiness で LocalizationButton を gate する (#209)。
-  // 受信前は last_localization_backend_ready_ が初期値 true のままで、互換的に enable のまま。
-  localization_backend_status_received_ = true;
-  last_localization_backend_ready_ = msg->backend_ready;
-  QMetaObject::invokeMethod(this, [this]() {
-    UpdateNavButtonsEnabled();
-  }, Qt::QueuedConnection);
-}
-
-void MapoiPanel::UpdateNavButtonsEnabled()
-{
-  // Qt main thread で呼ぶこと (BackendStatusCallback / LocalizationBackendStatusCallback /
-  // liveliness event_callback から QueuedConnection 経由で invoke される)。
-  // 2 軸の minimal 仕様 (#209): navigation 操作 UI と MapComboBox は navigation backend、
-  // LocalizationButton は localization backend で gate する。MapComboBox は Nav2 LoadMap +
-  // AMCL initial pose の両方を必要とするが、Nav2 LoadMap が走らないと localization 側に意味のある
-  // initial pose を送れないので最低限 navigation_ready を要求する。両方を AND する厳格化は
-  // future work で UX 検討する。
-  // Staleness gating (#208): 受信前 (`*_received_` false) は alive 判定をバイパスして
-  // `last_*_backend_ready_` の初期値 (true) を使う = 旧 mapoi_nav_server build (#204 で nav2_bridge へ rename) / panel 単独起動の後方互換。
-  // 受信後は MANUAL_BY_TOPIC liveliness で得た `*_alive_` flag と AND し、bridge 死亡時に
-  // 自動 disable する。
-  const bool nav_ready = nav_backend_status_received_
-    ? (last_navigation_backend_ready_ && nav_backend_alive_)
-    : last_navigation_backend_ready_;
-  const bool loc_ready = localization_backend_status_received_
-    ? (last_localization_backend_ready_ && localization_backend_alive_)
-    : last_localization_backend_ready_;
-  ui_->LocalizationButton->setEnabled(loc_ready);
-  ui_->RunGoalButton->setEnabled(nav_ready);
-  ui_->RunRouteButton->setEnabled(nav_ready);
-  ui_->PauseButton->setEnabled(nav_ready);
-  ui_->ResumeButton->setEnabled(nav_ready);
-  ui_->StopButton->setEnabled(nav_ready);
-  ui_->MapComboBox->setEnabled(nav_ready);
-}
+// BackendStatusCallback / LocalizationBackendStatusCallback / UpdateNavButtonsEnabled は
+// mapoi_panel_backend_status.cpp (#397 step 2) へ移動。
 
 void MapoiPanel::PublishHighlightPois()
 {

--- a/mapoi_rviz_plugins/src/mapoi_panel_backend_status.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_backend_status.cpp
@@ -1,0 +1,63 @@
+// MapoiPanel の backend 接続状態系メソッド定義 (#397 step 2 で mapoi_panel.cpp から別 TU へ分離)。
+// BackendStatusCallback / LocalizationBackendStatusCallback / UpdateNavButtonsEnabled を収録。
+// バックエンド接続状態バッジ実装 (#400) の直前分割として実施。
+#include "mapoi_rviz_plugins/mapoi_panel.hpp"
+#include "ui_mapoi_panel.h"
+
+namespace mapoi_rviz_plugins
+{
+
+void MapoiPanel::BackendStatusCallback(
+  mapoi_interfaces::msg::NavigationBackendStatus::SharedPtr msg)
+{
+  // RViz panel 側でも backend_ready を見て操作ボタンを gate する (#198, #205 minimal)。
+  // backend_status 不在 (旧 mapoi_nav_server build (#208 以前 backend_status contract 未実装、#204 で nav2_bridge へ rename) / panel 単独起動) では callback が呼ばれず、
+  // navigation 軸は初期値 (true = enable) を使い続ける。
+  nav_backend_status_received_ = true;
+  last_navigation_backend_ready_ = msg->backend_ready;
+  QMetaObject::invokeMethod(this, [this]() {
+    UpdateNavButtonsEnabled();
+  }, Qt::QueuedConnection);
+}
+
+void MapoiPanel::LocalizationBackendStatusCallback(
+  mapoi_interfaces::msg::LocalizationBackendStatus::SharedPtr msg)
+{
+  // localization bridge の readiness で LocalizationButton を gate する (#209)。
+  // 受信前は last_localization_backend_ready_ が初期値 true のままで、互換的に enable のまま。
+  localization_backend_status_received_ = true;
+  last_localization_backend_ready_ = msg->backend_ready;
+  QMetaObject::invokeMethod(this, [this]() {
+    UpdateNavButtonsEnabled();
+  }, Qt::QueuedConnection);
+}
+
+void MapoiPanel::UpdateNavButtonsEnabled()
+{
+  // Qt main thread で呼ぶこと (BackendStatusCallback / LocalizationBackendStatusCallback /
+  // liveliness event_callback から QueuedConnection 経由で invoke される)。
+  // 2 軸の minimal 仕様 (#209): navigation 操作 UI と MapComboBox は navigation backend、
+  // LocalizationButton は localization backend で gate する。MapComboBox は Nav2 LoadMap +
+  // AMCL initial pose の両方を必要とするが、Nav2 LoadMap が走らないと localization 側に意味のある
+  // initial pose を送れないので最低限 navigation_ready を要求する。両方を AND する厳格化は
+  // future work で UX 検討する。
+  // Staleness gating (#208): 受信前 (`*_received_` false) は alive 判定をバイパスして
+  // `last_*_backend_ready_` の初期値 (true) を使う = 旧 mapoi_nav_server build (#204 で nav2_bridge へ rename) / panel 単独起動の後方互換。
+  // 受信後は MANUAL_BY_TOPIC liveliness で得た `*_alive_` flag と AND し、bridge 死亡時に
+  // 自動 disable する。
+  const bool nav_ready = nav_backend_status_received_
+    ? (last_navigation_backend_ready_ && nav_backend_alive_)
+    : last_navigation_backend_ready_;
+  const bool loc_ready = localization_backend_status_received_
+    ? (last_localization_backend_ready_ && localization_backend_alive_)
+    : last_localization_backend_ready_;
+  ui_->LocalizationButton->setEnabled(loc_ready);
+  ui_->RunGoalButton->setEnabled(nav_ready);
+  ui_->RunRouteButton->setEnabled(nav_ready);
+  ui_->PauseButton->setEnabled(nav_ready);
+  ui_->ResumeButton->setEnabled(nav_ready);
+  ui_->StopButton->setEnabled(nav_ready);
+  ui_->MapComboBox->setEnabled(nav_ready);
+}
+
+}  // namespace mapoi_rviz_plugins


### PR DESCRIPTION
## 目的

#397 step 2。`mapoi_panel.cpp` の backend 接続状態系 3 メソッド (`BackendStatusCallback` / `LocalizationBackendStatusCallback` / `UpdateNavButtonsEnabled`、計 52 行) を専用 TU `mapoi_panel_backend_status.cpp` へ behavior-preserving に分割する。バックエンド接続状態バッジ (#400) の直前の just-in-time 分割 (#397 の step↔機能対応表参照)。

## 変更

- `mapoi_panel_backend_status.cpp` (新規 63 行): 3 メソッドをコメント含め一字一句そのまま移動 (LOGGER 不使用のため logger 定義なし、#408 と同構成)
- onInitialize 内の liveliness lambda (nav_sub_opts / loc_sub_opts) は宣言参照のみのため mapoi_panel.cpp に残置 (issue #397 記載の通り)
- `mapoi_panel.cpp`: 当該定義を削除し分割先コメントを残す。ヘッダ変更なし
- `CMakeLists.txt`: SOURCE_FILES に 1 行追加

## 検証

- humble / jazzy 両 Docker で colcon build 通過、gtest 全パス
- 3 メソッドの定義は新 TU の各 1 箇所のみ、bind/lambda 参照は mapoi_panel.cpp に残存 (Grep 確認)。挙動変更なし