### PR TITLE
feat(rviz): バックエンド接続状態バッジを追加 (#400)

### DIFF
--- a/mapoi_rviz_plugins/CMakeLists.txt
+++ b/mapoi_rviz_plugins/CMakeLists.txt
@@ -51,6 +51,11 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_poi_editor_validation
     test/test_poi_editor_validation.cpp
   )
+  # mapoi_panel_helpers.hpp の build_backend_badge_text (#400) の unit test。バッジ表示規則と
+  # 「切断時に stale reason を出さない」契約を pin する。header は <string> のみ依存。
+  ament_auto_add_gtest(test_mapoi_panel_helpers
+    test/test_mapoi_panel_helpers.cpp
+  )
 endif()
 
 # 将来のROS 2（Kilted Kaiju以降）と互換性を持たせるため

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
@@ -125,6 +125,7 @@ protected:
   void BackendStatusCallback(mapoi_interfaces::msg::NavigationBackendStatus::SharedPtr msg);
   // backend_status 不在 (contract 未実装の bridge build / editor 構成) では callback が呼ばれず、初期値
   // (true = enable) のままで後方互換を保つ。Minimal contract なので per-capability gate は持たない。
+  // 以下のメンバはすべて UI (Qt メイン) スレッド所有 (#400: queued lambda 内でのみ読み書きする)。
   bool last_navigation_backend_ready_ {true};
   // 一度でも navigation backend_status を受信したか。受信実績なし = 旧 mapoi_nav_server build (#208 以前 contract 未実装、#204 で rename)
   // / editor 構成として enable のまま (後方互換)。受信実績ありの publisher が liveliness lost
@@ -133,6 +134,8 @@ protected:
   // MANUAL_BY_TOPIC liveliness (#208) で publisher 生存を track。subscription event_callback
   // が `alive_count > 0` で更新する。`*_received_` と AND して、未受信は alive 判定をバイパス。
   bool nav_backend_alive_ {false};
+  // backend_ready=false 時に bridge が設定する reason 文字列 (#400)。UI スレッド所有。
+  std::string last_navigation_reason_;
 
   // Localization backend readiness subscribe (#209): mapoi_amcl_localization_bridge (or any
   // custom localization bridge) が publish する readiness で LocalizationButton を gate する。
@@ -142,9 +145,12 @@ protected:
     localization_backend_status_sub_;
   void LocalizationBackendStatusCallback(
     mapoi_interfaces::msg::LocalizationBackendStatus::SharedPtr msg);
+  // 以下のメンバはすべて UI (Qt メイン) スレッド所有 (#400: queued lambda 内でのみ読み書きする)。
   bool last_localization_backend_ready_ {true};
   bool localization_backend_status_received_ {false};
   bool localization_backend_alive_ {false};
+  // backend_ready=false 時に bridge が設定する reason 文字列 (#400)。UI スレッド所有。
+  std::string last_localization_reason_;
 
   // navigation_ready / localization_ready の最新値を保持し、両 callback / liveliness event から
   // 共通の UpdateNavButtonsEnabled を呼び出す。LocalizationButton は localization、それ以外の

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel_helpers.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel_helpers.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+
+namespace mapoi_rviz_plugins::detail
+{
+
+// バックエンド接続状態バッジの表示文字列を組み立てる純関数 (#400、PR #419 review で
+// UpdateNavButtonsEnabled から切り出し)。表示規則 (Nav / Loc 共通):
+//   - received == false → 空文字 (contract 未実装 publisher / 旧構成では UI 不変の後方互換)
+//   - received && !alive → "<prefix>: 切断 (bridge 停止)" — liveliness lost。保持中の reason は
+//     死亡直前の stale 値のため表示しない (issue #400 の要件)
+//   - alive && ready → "<prefix>: 接続"
+//   - alive && !ready → "<prefix>: 未準備 (<reason>)" (reason 空なら括弧ごと省略)
+// Qt / ROS 非依存 (呼び出し側が QString へ変換して QLabel に載せる)。gtest で分岐表を pin する。
+inline std::string build_backend_badge_text(
+  const std::string & prefix, bool received, bool alive, bool ready,
+  const std::string & reason)
+{
+  if (!received) {
+    return "";
+  }
+  if (!alive) {
+    return prefix + ": 切断 (bridge 停止)";
+  }
+  if (ready) {
+    return prefix + ": 接続";
+  }
+  if (!reason.empty()) {
+    return prefix + ": 未準備 (" + reason + ")";
+  }
+  return prefix + ": 未準備";
+}
+
+}  // namespace mapoi_rviz_plugins::detail

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -130,8 +130,10 @@ void MapoiPanel::onInitialize()
   rclcpp::SubscriptionOptions nav_sub_opts;
   nav_sub_opts.event_callbacks.liveliness_callback =
     [this](rclcpp::QOSLivelinessChangedInfo & event) {
-      nav_backend_alive_ = event.alive_count > 0;
-      QMetaObject::invokeMethod(this, [this]() {
+      // #400 スレッド規約: alive_count を値キャプチャし、メンバ更新は UI スレッド (lambda 内) で行う。
+      const bool alive = event.alive_count > 0;
+      QMetaObject::invokeMethod(this, [this, alive]() {
+        nav_backend_alive_ = alive;
         UpdateNavButtonsEnabled();
       }, Qt::QueuedConnection);
     };
@@ -143,8 +145,10 @@ void MapoiPanel::onInitialize()
   rclcpp::SubscriptionOptions loc_sub_opts;
   loc_sub_opts.event_callbacks.liveliness_callback =
     [this](rclcpp::QOSLivelinessChangedInfo & event) {
-      localization_backend_alive_ = event.alive_count > 0;
-      QMetaObject::invokeMethod(this, [this]() {
+      // #400 スレッド規約: alive_count を値キャプチャし、メンバ更新は UI スレッド (lambda 内) で行う。
+      const bool alive = event.alive_count > 0;
+      QMetaObject::invokeMethod(this, [this, alive]() {
+        localization_backend_alive_ = alive;
         UpdateNavButtonsEnabled();
       }, Qt::QueuedConnection);
     };

--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -134,6 +134,11 @@ void MapoiPanel::onInitialize()
       const bool alive = event.alive_count > 0;
       QMetaObject::invokeMethod(this, [this, alive]() {
         nav_backend_alive_ = alive;
+        if (!alive) {
+          // 死亡直前の reason は stale なため破棄する。再接続直後に新 status 到達前の窓で
+          // 古い reason 付き「未準備」が一瞬出るのを防ぐ (PR #419 review low)。
+          last_navigation_reason_.clear();
+        }
         UpdateNavButtonsEnabled();
       }, Qt::QueuedConnection);
     };
@@ -149,6 +154,10 @@ void MapoiPanel::onInitialize()
       const bool alive = event.alive_count > 0;
       QMetaObject::invokeMethod(this, [this, alive]() {
         localization_backend_alive_ = alive;
+        if (!alive) {
+          // stale reason の破棄 (nav 側と同じ理由、PR #419 review low)。
+          last_localization_reason_.clear();
+        }
         UpdateNavButtonsEnabled();
       }, Qt::QueuedConnection);
     };

--- a/mapoi_rviz_plugins/src/mapoi_panel_backend_status.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_backend_status.cpp
@@ -2,6 +2,7 @@
 // BackendStatusCallback / LocalizationBackendStatusCallback / UpdateNavButtonsEnabled を収録。
 // バックエンド接続状態バッジ実装 (#400) の直前分割として実施。
 #include "mapoi_rviz_plugins/mapoi_panel.hpp"
+#include "mapoi_rviz_plugins/mapoi_panel_helpers.hpp"
 #include "ui_mapoi_panel.h"
 
 namespace mapoi_rviz_plugins
@@ -19,6 +20,10 @@ void MapoiPanel::BackendStatusCallback(
   std::string reason = msg->reason;
   QMetaObject::invokeMethod(this, [this, ready, reason]() {
     nav_backend_status_received_ = true;
+    // MANUAL_BY_TOPIC では publish 自体が liveliness assert なので、msg 受信は publisher 生存の
+    // 直接証拠として alive も立てる (PR #419 review high)。初回受信〜liveliness イベント到達までの
+    // 窓で「切断」誤表示とボタンの一時 disable が起きるのを防ぐ。lost イベントで false に戻る。
+    nav_backend_alive_ = true;
     last_navigation_backend_ready_ = ready;
     last_navigation_reason_ = std::move(reason);
     UpdateNavButtonsEnabled();
@@ -35,6 +40,8 @@ void MapoiPanel::LocalizationBackendStatusCallback(
   std::string reason = msg->reason;
   QMetaObject::invokeMethod(this, [this, ready, reason]() {
     localization_backend_status_received_ = true;
+    // msg 受信 = 生存の直接証拠として alive も立てる (nav 側と同じ理由、PR #419 review high)。
+    localization_backend_alive_ = true;
     last_localization_backend_ready_ = ready;
     last_localization_reason_ = std::move(reason);
     UpdateNavButtonsEnabled();
@@ -69,41 +76,21 @@ void MapoiPanel::UpdateNavButtonsEnabled()
   ui_->MapComboBox->setEnabled(nav_ready);
 
   // #400: バックエンド接続状態バッジ更新 (値変化時のみ setText)。
-  // 表示規則 (Nav / Loc 共通):
-  //   *_received_ == false → 空文字 (contract 未実装 publisher / 後方互換状態)
-  //   received && !*_alive_ → "切断 (bridge 停止)" — liveliness lost。stale reason は表示しない
-  //   alive && ready        → "接続"
-  //   alive && !ready       → "未準備 (<reason>)" (reason 空なら括弧ごと省略)
-  auto build_badge = [](const char * prefix, bool received, bool alive, bool ready,
-                        const std::string & reason) -> QString {
-    if (!received) {
-      return QString{};
-    }
-    if (!alive) {
-      return QString::fromUtf8(prefix) + QString::fromUtf8(": 切断 (bridge 停止)");
-    }
-    if (ready) {
-      return QString::fromUtf8(prefix) + QString::fromUtf8(": 接続");
-    }
-    if (!reason.empty()) {
-      return QString::fromUtf8(prefix) + QString::fromUtf8(": 未準備 (") +
-             QString::fromStdString(reason) + QString::fromUtf8(")");
-    }
-    return QString::fromUtf8(prefix) + QString::fromUtf8(": 未準備");
-  };
-
-  const QString nav_text = build_badge(
+  // 表示規則は build_backend_badge_text (mapoi_panel_helpers.hpp) に純関数として集約し、
+  // gtest で分岐表 (未受信 / 切断 / 接続 / 未準備±reason、stale reason 抑制) を pin する
+  // (PR #419 review)。ここでは結果を QString へ変換して QLabel に載せるだけ。
+  const QString nav_text = QString::fromStdString(detail::build_backend_badge_text(
     "Nav",
     nav_backend_status_received_, nav_backend_alive_,
-    last_navigation_backend_ready_, last_navigation_reason_);
+    last_navigation_backend_ready_, last_navigation_reason_));
   if (ui_->NavBackendStatusLabel->text() != nav_text) {
     ui_->NavBackendStatusLabel->setText(nav_text);
   }
 
-  const QString loc_text = build_badge(
+  const QString loc_text = QString::fromStdString(detail::build_backend_badge_text(
     "Loc",
     localization_backend_status_received_, localization_backend_alive_,
-    last_localization_backend_ready_, last_localization_reason_);
+    last_localization_backend_ready_, last_localization_reason_));
   if (ui_->LocBackendStatusLabel->text() != loc_text) {
     ui_->LocBackendStatusLabel->setText(loc_text);
   }

--- a/mapoi_rviz_plugins/src/mapoi_panel_backend_status.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_backend_status.cpp
@@ -13,9 +13,14 @@ void MapoiPanel::BackendStatusCallback(
   // RViz panel 側でも backend_ready を見て操作ボタンを gate する (#198, #205 minimal)。
   // backend_status 不在 (旧 mapoi_nav_server build (#208 以前 backend_status contract 未実装、#204 で nav2_bridge へ rename) / panel 単独起動) では callback が呼ばれず、
   // navigation 軸は初期値 (true = enable) を使い続ける。
-  nav_backend_status_received_ = true;
-  last_navigation_backend_ready_ = msg->backend_ready;
-  QMetaObject::invokeMethod(this, [this]() {
+  // #400 スレッド規約: msg の値を値キャプチャしてラムダ内 (UI スレッド) でメンバ更新する。
+  // std::string は bool より競合時のリスクが高いため、メンバへの代入はすべて UI スレッド側で行う。
+  const bool ready = msg->backend_ready;
+  std::string reason = msg->reason;
+  QMetaObject::invokeMethod(this, [this, ready, reason]() {
+    nav_backend_status_received_ = true;
+    last_navigation_backend_ready_ = ready;
+    last_navigation_reason_ = std::move(reason);
     UpdateNavButtonsEnabled();
   }, Qt::QueuedConnection);
 }
@@ -25,9 +30,13 @@ void MapoiPanel::LocalizationBackendStatusCallback(
 {
   // localization bridge の readiness で LocalizationButton を gate する (#209)。
   // 受信前は last_localization_backend_ready_ が初期値 true のままで、互換的に enable のまま。
-  localization_backend_status_received_ = true;
-  last_localization_backend_ready_ = msg->backend_ready;
-  QMetaObject::invokeMethod(this, [this]() {
+  // #400 スレッド規約: msg の値を値キャプチャしてラムダ内 (UI スレッド) でメンバ更新する。
+  const bool ready = msg->backend_ready;
+  std::string reason = msg->reason;
+  QMetaObject::invokeMethod(this, [this, ready, reason]() {
+    localization_backend_status_received_ = true;
+    last_localization_backend_ready_ = ready;
+    last_localization_reason_ = std::move(reason);
     UpdateNavButtonsEnabled();
   }, Qt::QueuedConnection);
 }
@@ -58,6 +67,46 @@ void MapoiPanel::UpdateNavButtonsEnabled()
   ui_->ResumeButton->setEnabled(nav_ready);
   ui_->StopButton->setEnabled(nav_ready);
   ui_->MapComboBox->setEnabled(nav_ready);
+
+  // #400: バックエンド接続状態バッジ更新 (値変化時のみ setText)。
+  // 表示規則 (Nav / Loc 共通):
+  //   *_received_ == false → 空文字 (contract 未実装 publisher / 後方互換状態)
+  //   received && !*_alive_ → "切断 (bridge 停止)" — liveliness lost。stale reason は表示しない
+  //   alive && ready        → "接続"
+  //   alive && !ready       → "未準備 (<reason>)" (reason 空なら括弧ごと省略)
+  auto build_badge = [](const char * prefix, bool received, bool alive, bool ready,
+                        const std::string & reason) -> QString {
+    if (!received) {
+      return QString{};
+    }
+    if (!alive) {
+      return QString::fromUtf8(prefix) + QString::fromUtf8(": 切断 (bridge 停止)");
+    }
+    if (ready) {
+      return QString::fromUtf8(prefix) + QString::fromUtf8(": 接続");
+    }
+    if (!reason.empty()) {
+      return QString::fromUtf8(prefix) + QString::fromUtf8(": 未準備 (") +
+             QString::fromStdString(reason) + QString::fromUtf8(")");
+    }
+    return QString::fromUtf8(prefix) + QString::fromUtf8(": 未準備");
+  };
+
+  const QString nav_text = build_badge(
+    "Nav",
+    nav_backend_status_received_, nav_backend_alive_,
+    last_navigation_backend_ready_, last_navigation_reason_);
+  if (ui_->NavBackendStatusLabel->text() != nav_text) {
+    ui_->NavBackendStatusLabel->setText(nav_text);
+  }
+
+  const QString loc_text = build_badge(
+    "Loc",
+    localization_backend_status_received_, localization_backend_alive_,
+    last_localization_backend_ready_, last_localization_reason_);
+  if (ui_->LocBackendStatusLabel->text() != loc_text) {
+    ui_->LocBackendStatusLabel->setText(loc_text);
+  }
 }
 
 }  // namespace mapoi_rviz_plugins

--- a/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
+++ b/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
@@ -154,6 +154,30 @@
      </property>
     </widget>
    </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_backend_status">
+     <item>
+      <widget class="QLabel" name="NavBackendStatusLabel">
+       <property name="text">
+        <string></string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="LocBackendStatusLabel">
+       <property name="text">
+        <string></string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/mapoi_rviz_plugins/test/test_mapoi_panel_helpers.cpp
+++ b/mapoi_rviz_plugins/test/test_mapoi_panel_helpers.cpp
@@ -1,0 +1,40 @@
+// mapoi_panel_helpers.hpp の build_backend_badge_text (#400) の unit test。
+// バッジ表示規則 (未受信 / 切断 / 接続 / 未準備±reason) と「切断時に stale reason を
+// 表示しない」契約 (issue #400) をテーブル駆動で pin する。header は <string> のみ依存。
+#include <gtest/gtest.h>
+
+#include "mapoi_rviz_plugins/mapoi_panel_helpers.hpp"
+
+using mapoi_rviz_plugins::detail::build_backend_badge_text;
+
+TEST(BuildBackendBadgeText, NotReceivedIsEmpty)
+{
+  // 未受信 (contract 未実装 publisher / 旧構成) は空表示で UI 不変の後方互換。
+  // 他の引数が何であっても received=false が最優先。
+  EXPECT_EQ(build_backend_badge_text("Nav", false, true, true, "reason"), "");
+}
+
+TEST(BuildBackendBadgeText, LivelinessLostHidesStaleReason)
+{
+  // liveliness lost 時は保持中の reason (死亡直前の stale 値) を表示しない (issue #400)。
+  EXPECT_EQ(
+    build_backend_badge_text("Nav", true, false, true, "stale reason"),
+    "Nav: 切断 (bridge 停止)");
+}
+
+TEST(BuildBackendBadgeText, AliveAndReadyIsConnected)
+{
+  EXPECT_EQ(build_backend_badge_text("Loc", true, true, true, ""), "Loc: 接続");
+}
+
+TEST(BuildBackendBadgeText, NotReadyWithReasonShowsReason)
+{
+  EXPECT_EQ(
+    build_backend_badge_text("Nav", true, true, false, "not ready: navigate_to_pose action"),
+    "Nav: 未準備 (not ready: navigate_to_pose action)");
+}
+
+TEST(BuildBackendBadgeText, NotReadyWithoutReasonOmitsParens)
+{
+  EXPECT_EQ(build_backend_badge_text("Loc", true, true, false, ""), "Loc: 未準備");
+}


### PR DESCRIPTION
Closes #400

## 目的

バックエンド不調時、UpdateNavButtonsEnabled は操作ボタンを黙って disable するだけで「なぜ押せないのか」「bridge が落ちたのか起動前なのか」が UI から判別できなかった。msg に既存の `reason` フィールド (RViz 側未使用) を可視化する (WebUI の接続バッジとの非対称解消)。

## 変更

- `mapoi_panel.ui` 最下部に Nav / Loc の小型状態ラベル 2 個 (PlainText 固定) を追加
- 表示規則 (両軸共通): 未受信 → 空 (contract 未実装 publisher / 旧構成では UI 不変の後方互換) / liveliness lost → 「切断 (bridge 停止)」(**stale reason は表示しない** — issue 記載の上書き) / alive+ready → 「接続」 / alive+未 ready → 「未準備 (<reason>)」
- **スレッド規約の統一**: reason (std::string) をスレッド跨ぎで共有しないため、backend callback 2 本と liveliness lambda 2 本を「値キャプチャ → queued lambda 内でメンバ更新」構造へ変更 (PR #412/#414/#416 で確立した UI スレッド所有規約。bool 群も同時に移行し、#417 レビューで指摘された並行読み書きの検討事項も解消)
- バッジは**値変化時のみ setText** (既存 text と比較)。ボタン enable/disable の既存ロジックは不変

## 軽量性

- 新規購読ゼロ・新規 timer ゼロ。既存 1Hz callback ×2 と liveliness event に QLabel 差分更新を相乗りするのみ

## 検証

- humble / jazzy 両 Docker で colcon build 通過、gtest 55 ケース全パス