### PR TITLE
feat(rviz): PoiEditor に POI 名検索フィルタを追加 (#405)

### DIFF
--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -60,6 +60,7 @@ private Q_SLOTS:
   void SaveButton();
   void TagFilterChanged(int index);
   void TagHelperSelected(int index);
+  void NameFilterChanged(const QString & text);
 
 protected:
   Ui::PoiEditorUi* ui_;
@@ -155,6 +156,11 @@ protected:
   // onInitialize 末尾の初期同期と、SetParameters 失敗時の UI rollback の両方で使う。
   // 成功時は cached_* を更新する。
   void SyncDisplaySettingsFromPublisher();
+
+  // POI 名フィルタ (#405): NameFilterEdit の現在テキストに基づいて全行の表示/非表示を設定する。
+  // setRowHidden (行削除なし) を使うため rowCount() は不変。UpdatePoiTable / TagFilterChanged の
+  // 再構築後に呼び出すことで、再構築後もフィルタ状態を維持する。
+  void ApplyNameFilter();
 
   // service down 等で sync が失敗した場合、cached_* に基づいて UI を revert する。
   // SyncDisplaySettingsFromPublisher() で sync を試みた後 (cache 未更新) のフォールバック用。

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -60,7 +60,6 @@ private Q_SLOTS:
   void SaveButton();
   void TagFilterChanged(int index);
   void TagHelperSelected(int index);
-  void NameFilterChanged(const QString & text);
 
 protected:
   Ui::PoiEditorUi* ui_;
@@ -159,8 +158,11 @@ protected:
 
   // POI 名フィルタ (#405): NameFilterEdit の現在テキストに基づいて全行の表示/非表示を設定する。
   // setRowHidden (行削除なし) を使うため rowCount() は不変。UpdatePoiTable / TagFilterChanged の
-  // 再構築後に呼び出すことで、再構築後もフィルタ状態を維持する。
+  // 再構築後に呼び出すことで、再構築後もフィルタ状態を維持する。textChanged からも直接呼ばれる。
+  // 末尾で UpdatePoiCount を呼び、可視行数と件数表示を同期する (PR #420 review)。
   void ApplyNameFilter();
+  // 単一行だけフィルタを再評価する (#405)。名前セルの編集確定時 (TableChanged) に使用。
+  void ApplyNameFilterToRow(int row);
 
   // service down 等で sync が失敗した場合、cached_* に基づいて UI を revert する。
   // SyncDisplaySettingsFromPublisher() で sync を試みた後 (cache 未更新) のフォールバック用。

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -63,9 +63,10 @@ void PoiEditorPanel::onInitialize()
   connect(ui_->TagFilterComboBox, SIGNAL(activated(int)), this, SLOT(TagFilterChanged(int)));
   connect(ui_->TagHelperComboBox, SIGNAL(activated(int)), this, SLOT(TagHelperSelected(int)));
   // POI 名フィルタ (#405): テキスト変更のたびに setRowHidden で絞り込む。
-  // textChanged は文字入力・clearButton 押下の両方で発火する。
+  // textChanged は文字入力・clearButton 押下の両方で発火する。フィルタ本体は
+  // NameFilterEdit の現在値を直接読むため、シグナル引数は使わず直接 connect する。
   connect(ui_->NameFilterEdit, &QLineEdit::textChanged,
-    this, &PoiEditorPanel::NameFilterChanged);
+    this, &PoiEditorPanel::ApplyNameFilter);
 
   poi_pose_sub_ = node_->create_subscription<geometry_msgs::msg::PoseStamped>(
     "mapoi_rviz_pose", 10, std::bind(&PoiEditorPanel::PoiPoseCallback, this, std::placeholders::_1));
@@ -349,6 +350,11 @@ void PoiEditorPanel::TableChanged(int row, int column)
     // is_table_color_=false で setItem 由来の cellChanged が飛ぶため、既存の green 着色ガードに
     // 相乗りしてユーザー編集だけを拾う (再構築由来の cellChanged では dirty を立てない)。
     table_dirty_ = true;
+    if (column == kColName) {
+      // 名前セルの編集確定時はその行だけ名前フィルタを再評価する (#405、PR #420 review)。
+      // 一致しなくなった行は編集確定と同時に隠れる (絞り込み表示の一貫性を優先)。
+      ApplyNameFilterToRow(row);
+    }
   }
   ui_->SaveButton->setText("save");
   ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
@@ -554,8 +560,21 @@ void PoiEditorPanel::ConfigPathCallback(std_msgs::msg::String::SharedPtr msg)
 
 void PoiEditorPanel::UpdatePoiCount()
 {
-  int count = ui_->PoiTable->rowCount();
-  ui_->PoiCountLabel->setText(tr("POIs: %1").arg(count));
+  const int total = ui_->PoiTable->rowCount();
+  int visible = 0;
+  for (int row = 0; row < total; ++row) {
+    if (!ui_->PoiTable->isRowHidden(row)) {
+      ++visible;
+    }
+  }
+  // 名前フィルタ (#405) で非表示行がある間は「可視/全体」を併記し、テーブルの見た目と
+  // 件数表示のズレを避ける (PR #420 review。タグフィルタは行自体を再構築するため
+  // rowCount() に反映済みで、従来表記のまま)。
+  if (visible != total) {
+    ui_->PoiCountLabel->setText(tr("POIs: %1/%2").arg(visible).arg(total));
+  } else {
+    ui_->PoiCountLabel->setText(tr("POIs: %1").arg(total));
+  }
 }
 
 // ValidatePois() の定義は poi_editor_validation.cpp へ切り出した (#346)。

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -62,6 +62,10 @@ void PoiEditorPanel::onInitialize()
   connect(ui_->SaveButton, SIGNAL(clicked()), this, SLOT(SaveButton()));
   connect(ui_->TagFilterComboBox, SIGNAL(activated(int)), this, SLOT(TagFilterChanged(int)));
   connect(ui_->TagHelperComboBox, SIGNAL(activated(int)), this, SLOT(TagHelperSelected(int)));
+  // POI 名フィルタ (#405): テキスト変更のたびに setRowHidden で絞り込む。
+  // textChanged は文字入力・clearButton 押下の両方で発火する。
+  connect(ui_->NameFilterEdit, &QLineEdit::textChanged,
+    this, &PoiEditorPanel::NameFilterChanged);
 
   poi_pose_sub_ = node_->create_subscription<geometry_msgs::msg::PoseStamped>(
     "mapoi_rviz_pose", 10, std::bind(&PoiEditorPanel::PoiPoseCallback, this, std::placeholders::_1));
@@ -638,6 +642,10 @@ void PoiEditorPanel::UpdatePoiTable()
   // green stylesheet が残ったままになる症状 (issue #77 症状 2) を明示リセットで防ぐ。
   ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
   UpdatePoiCount();
+  // 全再構築後、名前フィルタを再適用して絞り込み状態を維持する (#405)。
+  // setRowHidden は行を削除しないため rowCount() = 全 POI 数は変わらず、
+  // SaveButton の全行ループは非表示行も含めて正しく保存される。
+  ApplyNameFilter();
 
   // 全再構築 = サーバ状態と一致した時点なので dirty をクリアする (#399)。
   table_dirty_ = false;

--- a/mapoi_rviz_plugins/src/poi_editor_tags.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_tags.cpp
@@ -1,7 +1,6 @@
 // PoiEditorPanel::TagFilterChanged / PopulateTagFilter / LoadTagDefinitions /
-// TagHelperSelected / NameFilterChanged / ApplyNameFilter の定義。
+// TagHelperSelected / ApplyNameFilter / ApplyNameFilterToRow の定義。
 // (#397 step 7 で poi_editor.cpp から別 TU へ分離、#405 で名前フィルタを追加)
-// クラス構造・宣言 (poi_editor.hpp) は変更なし。
 #include "mapoi_rviz_plugins/poi_editor.hpp"
 #include "mapoi_rviz_plugins/poi_editor_helpers.hpp"
 
@@ -177,38 +176,37 @@ void PoiEditorPanel::TagHelperSelected(int index)
 //   - タグフィルタとの併用: TagFilterChanged → ApplyNameFilter の順に呼ぶことで
 //     「タグ AND 名前」の絞り込みになる。タグフィルタで非一致行は行ごと setRowCount(0) で
 //     排除済みのため、名前フィルタは残行に対して追加絞り込みを行うだけでよい。
-//   - TableChanged (セル編集) での再適用: セル編集は行数を変えないため名前フィルタの
-//     setRowHidden 状態はそのまま有効である。ただし kColName セルを編集した行の
-//     表示状態は次にフィルタテキストが変わるか、UpdatePoiTable / TagFilterChanged が
-//     走るまで変化しない (編集中にリアルタイムで hide/show が切り替わるより安定した挙動)。
+//   - TableChanged (セル編集): セル編集は行数を変えないため setRowHidden 状態は有効なまま。
+//     kColName セルの編集確定時のみ、その行を ApplyNameFilterToRow で再評価する
+//     (PR #420 review。一致しなくなった行は編集確定と同時に隠れる)。
+//   - New/Copy の新規行はフィルタ非一致でもデフォルト可視のまま (作った行が見えないと
+//     編集を継続できないため意図的)。件数表示は UpdatePoiCount の可視/全体 併記で整合する。
 //   - 行ドラッグ (setSectionsMovable): setRowHidden は logical row 基準で visual 並びと
 //     独立。非表示行を跨ぐドラッグは Qt 標準挙動に委ねる。
 // -----------------------------------------------------------------------
 
-void PoiEditorPanel::ApplyNameFilter()
+void PoiEditorPanel::ApplyNameFilterToRow(int row)
 {
   const QString filter_text = ui_->NameFilterEdit->text();
-  const int num_rows = ui_->PoiTable->rowCount();
-  for (int row = 0; row < num_rows; ++row) {
-    const auto * name_item = ui_->PoiTable->item(row, kColName);
-    if (filter_text.isEmpty()) {
-      // 空文字 = 全行表示 (フィルタ解除)
-      ui_->PoiTable->setRowHidden(row, false);
-    } else {
-      const QString name_text = name_item ? name_item->text() : QString();
-      // 部分一致・大文字小文字不区別 (WebUI の matchesPoiName と同じ意味論)
-      const bool matches = name_text.contains(filter_text, Qt::CaseInsensitive);
-      ui_->PoiTable->setRowHidden(row, !matches);
-    }
+  if (filter_text.isEmpty()) {
+    // 空文字 = フィルタ解除 (行は常に表示)
+    ui_->PoiTable->setRowHidden(row, false);
+    return;
   }
+  const auto * name_item = ui_->PoiTable->item(row, kColName);
+  const QString name_text = name_item ? name_item->text() : QString();
+  // 部分一致・大文字小文字不区別 (WebUI の matchesPoiName と同じ意味論)
+  ui_->PoiTable->setRowHidden(row, !name_text.contains(filter_text, Qt::CaseInsensitive));
 }
 
-void PoiEditorPanel::NameFilterChanged(const QString & text)
+void PoiEditorPanel::ApplyNameFilter()
 {
-  Q_UNUSED(text);
-  // テキスト変更のたびに setRowHidden を更新する。引数 text は ApplyNameFilter が
-  // ui_->NameFilterEdit->text() から直接読むため ここでは不使用。
-  ApplyNameFilter();
+  const int num_rows = ui_->PoiTable->rowCount();
+  for (int row = 0; row < num_rows; ++row) {
+    ApplyNameFilterToRow(row);
+  }
+  // 可視行数が変わるので件数表示 (可視/全体) を同期する (PR #420 review)。
+  UpdatePoiCount();
 }
 
 }  // namespace mapoi_rviz_plugins

--- a/mapoi_rviz_plugins/src/poi_editor_tags.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_tags.cpp
@@ -1,6 +1,6 @@
 // PoiEditorPanel::TagFilterChanged / PopulateTagFilter / LoadTagDefinitions /
-// TagHelperSelected の定義 (#397 step 7 で poi_editor.cpp から別 TU へ分離)。
-// POI 名検索フィルタ (#405) の追加直前に分割し、タグ操作 UI 系を独立 TU に集約する。
+// TagHelperSelected / NameFilterChanged / ApplyNameFilter の定義。
+// (#397 step 7 で poi_editor.cpp から別 TU へ分離、#405 で名前フィルタを追加)
 // クラス構造・宣言 (poi_editor.hpp) は変更なし。
 #include "mapoi_rviz_plugins/poi_editor.hpp"
 #include "mapoi_rviz_plugins/poi_editor_helpers.hpp"
@@ -66,6 +66,10 @@ void PoiEditorPanel::TagFilterChanged(int index)
   }
   is_table_color_ = true;
   UpdatePoiCount();
+  // タグフィルタで行を再構築した後、名前フィルタを再適用して絞り込み状態を維持する (#405)。
+  // タグフィルタはまずタグ一致行を setRowCount(0) で再構築し、その後 名前フィルタが
+  // setRowHidden で絞り込む。つまり「タグ AND 名前」の併用絞り込みになる。
+  ApplyNameFilter();
 }
 
 void PoiEditorPanel::PopulateTagFilter()
@@ -160,6 +164,51 @@ void PoiEditorPanel::TagHelperSelected(int index)
 
   // Reset combo to placeholder
   ui_->TagHelperComboBox->setCurrentIndex(0);
+}
+
+// POI 名フィルタ (#405)
+// -----------------------------------------------------------------------
+// 設計判断:
+//   - setRowHidden を使うため行は削除せず rowCount() は不変。
+//     SaveButton の全行ループは非表示行も含めて正しく保存される
+//     (タグフィルタの setRowCount(0) 再構築とは異なり、保存ブロック不要)。
+//   - 判定は logical row の item text に対して行う (verticalHeader の
+//     visual 並び替えには依存しない)。
+//   - タグフィルタとの併用: TagFilterChanged → ApplyNameFilter の順に呼ぶことで
+//     「タグ AND 名前」の絞り込みになる。タグフィルタで非一致行は行ごと setRowCount(0) で
+//     排除済みのため、名前フィルタは残行に対して追加絞り込みを行うだけでよい。
+//   - TableChanged (セル編集) での再適用: セル編集は行数を変えないため名前フィルタの
+//     setRowHidden 状態はそのまま有効である。ただし kColName セルを編集した行の
+//     表示状態は次にフィルタテキストが変わるか、UpdatePoiTable / TagFilterChanged が
+//     走るまで変化しない (編集中にリアルタイムで hide/show が切り替わるより安定した挙動)。
+//   - 行ドラッグ (setSectionsMovable): setRowHidden は logical row 基準で visual 並びと
+//     独立。非表示行を跨ぐドラッグは Qt 標準挙動に委ねる。
+// -----------------------------------------------------------------------
+
+void PoiEditorPanel::ApplyNameFilter()
+{
+  const QString filter_text = ui_->NameFilterEdit->text();
+  const int num_rows = ui_->PoiTable->rowCount();
+  for (int row = 0; row < num_rows; ++row) {
+    const auto * name_item = ui_->PoiTable->item(row, kColName);
+    if (filter_text.isEmpty()) {
+      // 空文字 = 全行表示 (フィルタ解除)
+      ui_->PoiTable->setRowHidden(row, false);
+    } else {
+      const QString name_text = name_item ? name_item->text() : QString();
+      // 部分一致・大文字小文字不区別 (WebUI の matchesPoiName と同じ意味論)
+      const bool matches = name_text.contains(filter_text, Qt::CaseInsensitive);
+      ui_->PoiTable->setRowHidden(row, !matches);
+    }
+  }
+}
+
+void PoiEditorPanel::NameFilterChanged(const QString & text)
+{
+  Q_UNUSED(text);
+  // テキスト変更のたびに setRowHidden を更新する。引数 text は ApplyNameFilter が
+  // ui_->NameFilterEdit->text() から直接読むため ここでは不使用。
+  ApplyNameFilter();
 }
 
 }  // namespace mapoi_rviz_plugins

--- a/mapoi_rviz_plugins/src/ui/poi_editor.ui
+++ b/mapoi_rviz_plugins/src/ui/poi_editor.ui
@@ -48,6 +48,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QLineEdit" name="NameFilterEdit">
+       <property name="placeholderText">
+        <string>POI 名で絞り込み</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="ResetButton">
        <property name="text">
         <string>reset POIs</string>


### PR DESCRIPTION
Closes #405

## 目的

PoiTable で目的行を探す手段はタグフィルタのみで、POI が数十件を超える現場で名前から素早く行へ到達できなかった (WebUI には実装済みで非対称)。

## 変更

- `poi_editor.ui` に QLineEdit (`NameFilterEdit`、clearButton 付き) を追加し、textChanged で部分一致・大文字小文字不区別の絞り込み (WebUI の matchesPoiName と同じ意味論)
- **`setRowHidden` 方式 (行削除なし)**: rowCount() 不変のため SaveButton の全行ループは非表示行も含め正しく保存される → タグフィルタのような保存ブロック不要 (issue 記載の核心)。判定は logical row 基準で行ドラッグの visual 並びと独立
- 再適用: `UpdatePoiTable` / `TagFilterChanged` の再構築後に `ApplyNameFilter()` を呼び、絞り込み状態を維持。タグフィルタとは「タグ AND 名前」の併用絞り込み
- セル編集 (TableChanged) では再適用しない: 行数不変で hide 状態は有効なまま。名前セル編集行の表示状態は次の再構築/フィルタ変更まで維持 (編集中のリアルタイム hide より安定、設計判断はコメントに明記)
- 実装は表示絞り込み機構の同居先 `poi_editor_tags.cpp` (#397 step 7 の分割を回収)。server 改修なし・完全クライアント内

## 軽量性

- 購読ゼロ・周期処理ゼロ。入力イベント時のみ O(行数) の setRowHidden。タグフィルタのような全 clear→re-new は増やさない

## 検証

- humble / jazzy 両 Docker で colcon build 通過、gtest 全パス