### PR TITLE
feat(rviz): 操作失敗と初期位置設定を UI に通知 (#401)

### DIFF
--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/mapoi_panel.hpp
@@ -105,6 +105,12 @@ protected:
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr command_rejected_sub_;
   void CommandRejectedCallback(std_msgs::msg::String::SharedPtr msg);
   QTimer* reject_clear_timer_ {nullptr};
+  // #401: CommandRejectedLabel への一時通知を集約するヘルパー。#398 の CommandRejectedLabel と
+  // reject_clear_timer_ (singleShot 5 秒) を共用し、initial pose 拒否 / route 取得失敗など
+  // ボタン押下起点の操作失敗も同じ揮発表示に載せる (latched な NavStatusLabel は汚さない)。
+  // UI (Qt メイン) スレッドからのみ呼ぶこと (呼び出し元は全て Qt スロット / queued lambda 内)。
+  // is_error=false で情報通知 (緑)。既定はエラー (赤)。
+  void ShowTransientNotice(const QString & text, bool is_error = true);
 
   // #406: mapoi/events 購読。ROUTE 走行中の通過 POI 進捗を RouteProgressLabel に表示する。
   // events は ROUTE 走行時のみ発火 (IDLE/GOAL では無音) なのでアイドル時の負荷はゼロ。

--- a/mapoi_rviz_plugins/src/mapoi_panel_nav_control.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_nav_control.cpp
@@ -62,10 +62,14 @@ void MapoiPanel::MapoiRouteComboBox()
           // (highlighted_route_poi_names_ は上で既に clear 済み)。
           RCLCPP_ERROR(LOGGER, "get_route_pois failed for '%s': %s",
                        route_name_list_[route_index].c_str(), response->error_message.c_str());
+          // #401: route 取得失敗も UI へ。error_message はそのまま PlainText ラベルに載る。
+          ShowTransientNotice(QString::fromStdString("route 取得失敗: " + response->error_message));
         }
       }
     } else {
+      // #401: service 未起動もログのみだと無反応。UI にも一時通知する。
       RCLCPP_ERROR(LOGGER, "mapoi/get_route_pois service not available after 3s timeout.");
+      ShowTransientNotice(QString::fromStdString("route 取得サービス未接続"));
     }
   }
   PublishHighlightPois();
@@ -84,7 +88,9 @@ void MapoiPanel::LocalizationButton()
   // per-writer latched cache が単一化され stale POI を構造的に排除する。bridge が POI resolve /
   // landmark 排他 / `/initialpose` 配信 / retry を一元処理する点は不変 (#209)。
   if (!request_initial_pose_client_->wait_for_service(3s)) {
+    // #401: service 未起動もログのみだと無反応で操作失敗に気づけない。UI にも一時通知する。
     RCLCPP_ERROR(LOGGER, "mapoi/request_initial_pose service not available after 3s timeout.");
+    ShowTransientNotice(QString::fromStdString("初期位置設定サービス未接続"));
     return;
   }
   auto request = std::make_shared<mapoi_interfaces::srv::RequestInitialPose::Request>();
@@ -95,16 +101,29 @@ void MapoiPanel::LocalizationButton()
     // #299: server は非空 map_name が現在 map と不一致な要求を publish せず success=false で
     // 返すようになった (panel の current_map_ が stale な窓など)。future 完了 = 成功ではない
     // ので response を確認し、reject を operator に成功と誤認させない。
+    // #421 review: null チェックは MapoiRouteComboBox と同じく `response && response->success` に統一。
     const auto response = result.get();
-    if (response->success) {
+    if (response && response->success) {
       RCLCPP_INFO(LOGGER, "Requested initial pose: %s (map: %s).",
                   request->poi_name.c_str(), current_map_.c_str());
-    } else {
+      // #401: 成功フィードバック。オペレータが初期位置設定の受理を確認できるようにする。
+      // 成功は情報通知 (緑)。エラーの赤と区別して誤警戒を避ける。
+      ShowTransientNotice(QString::fromStdString("初期位置設定: " + request->poi_name),
+                          /*is_error=*/false);
+    } else if (response) {
       RCLCPP_ERROR(LOGGER, "request_initial_pose rejected: %s",
                    response->error_message.c_str());
+      // #401: 拒否も UI へ。error_message はそのまま PlainText ラベルに載る (#398 で rich text 無効化済み)。
+      ShowTransientNotice(QString::fromStdString("初期位置設定 拒否: " + response->error_message));
+    } else {
+      // response が null (future 完了だが応答本体なし)。timeout/failed と同じ扱い。
+      RCLCPP_ERROR(LOGGER, "request_initial_pose call failed or timed out.");
+      ShowTransientNotice(QString::fromStdString("初期位置設定 失敗 (応答なし)"));
     }
   } else {
+    // #401: 応答なし (timeout/失敗) もログのみだと無反応。UI にも通知する。
     RCLCPP_ERROR(LOGGER, "request_initial_pose call failed or timed out.");
+    ShowTransientNotice(QString::fromStdString("初期位置設定 失敗 (応答なし)"));
   }
 }
 

--- a/mapoi_rviz_plugins/src/mapoi_panel_nav_control.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_nav_control.cpp
@@ -62,8 +62,17 @@ void MapoiPanel::MapoiRouteComboBox()
           // (highlighted_route_poi_names_ は上で既に clear 済み)。
           RCLCPP_ERROR(LOGGER, "get_route_pois failed for '%s': %s",
                        route_name_list_[route_index].c_str(), response->error_message.c_str());
-          // #401: route 取得失敗も UI へ。error_message はそのまま PlainText ラベルに載る。
-          ShowTransientNotice(QString::fromStdString("route 取得失敗: " + response->error_message));
+          // #401: route 取得失敗も UI へ。error_message はそのまま PlainText ラベルに載る
+          // (空なら文言が宙に浮くためフォールバック、PR #423 review low)。
+          const std::string err =
+            response->error_message.empty() ? "(詳細なし)" : response->error_message;
+          ShowTransientNotice(QString::fromStdString("route 取得失敗: " + err));
+        } else {
+          // response が null (future 完了だが応答本体なし)。LocalizationButton と同じ 3 分岐に
+          // 揃え、無表示のまま取りこぼさない (PR #423 review)。
+          RCLCPP_ERROR(LOGGER, "get_route_pois call failed for '%s' (null response).",
+                       route_name_list_[route_index].c_str());
+          ShowTransientNotice(QString::fromStdString("route 取得 失敗 (応答なし)"));
         }
       }
     } else {
@@ -114,7 +123,10 @@ void MapoiPanel::LocalizationButton()
       RCLCPP_ERROR(LOGGER, "request_initial_pose rejected: %s",
                    response->error_message.c_str());
       // #401: 拒否も UI へ。error_message はそのまま PlainText ラベルに載る (#398 で rich text 無効化済み)。
-      ShowTransientNotice(QString::fromStdString("初期位置設定 拒否: " + response->error_message));
+      // 空 message は文言が宙に浮くためフォールバック (PR #423 review low)。
+      const std::string err =
+        response->error_message.empty() ? "(詳細なし)" : response->error_message;
+      ShowTransientNotice(QString::fromStdString("初期位置設定 拒否: " + err));
     } else {
       // response が null (future 完了だが応答本体なし)。timeout/failed と同じ扱い。
       RCLCPP_ERROR(LOGGER, "request_initial_pose call failed or timed out.");

--- a/mapoi_rviz_plugins/src/mapoi_panel_nav_status.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_nav_status.cpp
@@ -147,6 +147,19 @@ void MapoiPanel::PoiEventCallback(mapoi_interfaces::msg::PoiEvent::SharedPtr msg
   }, Qt::QueuedConnection);
 }
 
+// #401: CommandRejectedLabel への一時通知の共用ヘルパー。#398 の CommandRejectedLabel と
+// reject_clear_timer_ (singleShot 5 秒) をここ (両者の責務がある TU) で集約する。
+// UI (Qt メイン) スレッドからのみ呼ぶ前提: CommandRejectedCallback は queued lambda 内、
+// LocalizationButton / MapoiRouteComboBox は Qt スロット内 = いずれも UI スレッド。
+// is_error で文字色を切り替える (エラー=赤 / 情報=緑)。成功通知まで赤にすると
+// オペレータに誤警戒を与えるため、.ui の初期値に頼らず呼び出しごとに設定する。
+void MapoiPanel::ShowTransientNotice(const QString & text, bool is_error)
+{
+  ui_->CommandRejectedLabel->setStyleSheet(is_error ? "color: red;" : "color: green;");
+  ui_->CommandRejectedLabel->setText(text);
+  reject_clear_timer_->start();  // 連続通知時は自動リスタートで 5 秒延長
+}
+
 // #398: mapoi/nav/command_rejected コールバック。payload は target 名のみの文字列
 // (README §Publishers command_rejected 節参照)。NavStatusLabel (latched 状態スナップショット) には
 // 一切触れず、CommandRejectedLabel に一時表示して 5 秒後にクリアする。
@@ -157,8 +170,7 @@ void MapoiPanel::CommandRejectedCallback(std_msgs::msg::String::SharedPtr msg)
     const QString text = target.empty()
       ? QString::fromStdString("コマンド拒否")
       : QString::fromStdString("コマンド拒否: " + target);
-    ui_->CommandRejectedLabel->setText(text);
-    reject_clear_timer_->start();  // 連続 reject 時は自動リスタートで 5 秒延長
+    ShowTransientNotice(text);  // #401: 一時通知機構を共用 (挙動不変)
   }, Qt::QueuedConnection);
 }
 


### PR DESCRIPTION
Closes #401

## 目的

request_initial_pose の拒否/timeout、service 未起動、get_route_pois の失敗が RCLCPP ログにしか出ず、コンソールを見ていないオペレータが「初期位置を設定したつもりで走行開始」する誤認リスクがあった (安全性直結の操作フィードバック欠落)。

## 変更

- **表示先の設計確定** (issue の選択肢 (a)/(b)): #398 の `CommandRejectedLabel` + `reject_clear_timer_` (singleShot 5 秒) を**共用** — latched な NavStatusLabel を汚さない方針に合致し、issue 記載の「タイマー/表示機構を共用可能」を採用。モーダルは操作の流れを止めるため不採用
- 共用ヘルパー `ShowTransientNotice(text, is_error=true)` を新設 (定義は CommandRejectedLabel の責務がある nav_status TU)。**エラー=赤 / 情報=緑** で文字色を切替え、成功通知の誤警戒を回避。UI スレッド専用の前提を宣言・定義双方にコメント明記
- 通知分岐: 初期位置設定の 成功 (緑)/拒否 (error_message 付き)/応答なし/service 未接続、route 取得の 失敗 (error_message 付き)/service 未接続 の計 6 分岐 + #398 の reject 表示を同ヘルパーに整理 (挙動不変)。既存 RCLCPP ログは全残置 (ログ + UI の二重通知)
- **応答チェック統一** (PR #421 review low の回収): LocalizationButton の response 判定を `response && response->success` の null 安全な 3 分岐に統一
- server 改修なし・新規購読/タイマーなし (イベント時の同期 UI 更新のみ)

## 検証

- humble / jazzy 両 Docker で colcon build 通過、gtest 150 ケース全パス