### PR TITLE
fix(rviz): service 呼び出しに timeout を付与 (#404)

### DIFF
--- a/mapoi_rviz_plugins/src/mapoi_panel.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel.cpp
@@ -52,7 +52,8 @@ void MapoiPanel::onInitialize()
   }
   auto request = std::make_shared<mapoi_interfaces::srv::GetMapsInfo::Request>();
   auto result = get_maps_info_client_->async_send_request(request);
-  if(rclcpp::spin_until_future_complete(service_node_, result) == rclcpp::FutureReturnCode::SUCCESS)
+  // #404: hang した service で UI スレッドが無期限ブロックしないよう timeout を付ける
+  if(rclcpp::spin_until_future_complete(service_node_, result, 5s) == rclcpp::FutureReturnCode::SUCCESS)
   {
     auto map_info = result.get();
     current_map_ = map_info->map_name;
@@ -62,7 +63,7 @@ void MapoiPanel::onInitialize()
     }
     SetMapComboBox(map_info->map_name);
   }else{
-    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/get_maps_info");
+    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/get_maps_info (timeout or error)");
   }
 
   // Buttons

--- a/mapoi_rviz_plugins/src/mapoi_panel_config.cpp
+++ b/mapoi_rviz_plugins/src/mapoi_panel_config.cpp
@@ -95,7 +95,8 @@ void MapoiPanel::SetNav2GoalComboBox()
   }
 
   auto result_get_pois_info = get_pois_info_client_->async_send_request(request_gtp);
-  if(rclcpp::spin_until_future_complete(service_node_, result_get_pois_info) == rclcpp::FutureReturnCode::SUCCESS)
+  // #404: timeout (説明は mapoi_panel.cpp)
+  if(rclcpp::spin_until_future_complete(service_node_, result_get_pois_info, 5s) == rclcpp::FutureReturnCode::SUCCESS)
   {
 
     auto pois_all = result_get_pois_info.get()->pois_list;
@@ -138,7 +139,8 @@ void MapoiPanel::SetMapoiRouteComboBox()
 
   auto request = std::make_shared<mapoi_interfaces::srv::GetRoutesInfo::Request>();
   auto result = get_routes_info_client_->async_send_request(request);
-  if(rclcpp::spin_until_future_complete(service_node_, result) == rclcpp::FutureReturnCode::SUCCESS)
+  // #404: timeout (説明は mapoi_panel.cpp)
+  if(rclcpp::spin_until_future_complete(service_node_, result, 5s) == rclcpp::FutureReturnCode::SUCCESS)
   {
     ui_->MapoiRouteComboBox->clear();
     ui_->MapoiRouteComboBox->addItem(QString::fromStdString("(なし)"));

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -136,7 +136,7 @@ void PoiEditorPanel::MapComboBox()
   // #404: timeout (説明は poi_editor.cpp onInitialize)
   if (rclcpp::spin_until_future_complete(service_node_, result_sm, 5s) != rclcpp::FutureReturnCode::SUCCESS ||
       !result_sm.get()->success) {
-    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/select_map");
+    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/select_map (timeout or error)");
     return;
   }
   PoiEditorPanel::UpdatePoiTable();

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -75,8 +75,9 @@ void PoiEditorPanel::onInitialize()
   }
   auto request = std::make_shared<mapoi_interfaces::srv::GetMapsInfo::Request>();
   auto result = get_maps_info_client_->async_send_request(request);
-  if (rclcpp::spin_until_future_complete(service_node_, result) != rclcpp::FutureReturnCode::SUCCESS) {
-    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/get_maps_info");
+  // #404: hang した service で UI スレッドが無期限ブロックしないよう timeout を付ける
+  if (rclcpp::spin_until_future_complete(service_node_, result, 5s) != rclcpp::FutureReturnCode::SUCCESS) {
+    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/get_maps_info (timeout or error)");
     return;
   }
   auto map_info = result.get();
@@ -132,7 +133,8 @@ void PoiEditorPanel::MapComboBox()
   }
 
   auto result_sm = select_map_client_->async_send_request(request_sm);
-  if (rclcpp::spin_until_future_complete(service_node_, result_sm) != rclcpp::FutureReturnCode::SUCCESS ||
+  // #404: timeout (説明は poi_editor.cpp onInitialize)
+  if (rclcpp::spin_until_future_complete(service_node_, result_sm, 5s) != rclcpp::FutureReturnCode::SUCCESS ||
       !result_sm.get()->success) {
     RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/select_map");
     return;
@@ -416,7 +418,11 @@ void PoiEditorPanel::UpdatePoiTable()
   }
 
   auto result_gtp = get_pois_info_client_->async_send_request(request_gtp);
-  rclcpp::spin_until_future_complete(service_node_, result_gtp);
+  // #404: timeout (説明は poi_editor.cpp onInitialize)
+  if (rclcpp::spin_until_future_complete(service_node_, result_gtp, 5s) != rclcpp::FutureReturnCode::SUCCESS) {
+    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/get_pois_info (timeout or error)");
+    return;
+  }
   auto poi_info = result_gtp.get();
   auto pois = poi_info->pois_list;
   auto numRows = pois.size();

--- a/mapoi_rviz_plugins/src/poi_editor_save.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_save.cpp
@@ -171,7 +171,13 @@ void PoiEditorPanel::SaveButton()
   }
   auto request_reload_map_info = std::make_shared<std_srvs::srv::Trigger::Request>();
   auto result_reload_map_info = reload_map_info_client_->async_send_request(request_reload_map_info);
-  rclcpp::spin_until_future_complete(service_node_, result_reload_map_info);
+  // #404: timeout (説明は poi_editor.cpp)。保存自体は完了済み。timeout / 非 SUCCESS 時は
+  // suppression・QTimer (UpdatePoiTable 遅延再構築) フローに進まず return する。
+  // SAVED! 表示は既に完了しているが、それは既存の wait_for_service 失敗 return と同じ位置づけ。
+  if (rclcpp::spin_until_future_complete(service_node_, result_reload_map_info, 5s) != rclcpp::FutureReturnCode::SUCCESS) {
+    RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/reload_map_info (timeout or error)");
+    return;
+  }
 
   // Drag による reorder は Qt の visual order だけ変えるため、Save 後も verticalHeader の
   // 番号は元の logical order のまま (例: [3, 1, 2] のように見える)。

--- a/mapoi_rviz_plugins/src/poi_editor_save.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_save.cpp
@@ -165,8 +165,16 @@ void PoiEditorPanel::SaveButton()
   baseline_path_ = save_path;
   baseline_content_ = out.c_str();
 
+  // 保存後の reload_map_info 失敗はログだけだと「保存成功と認識したままサーバ側が古い」状態に
+  // 気づけない (PR #424 review medium)。保存自体は完了している旨とあわせて明示する。
+  auto warn_reload_failed = [this]() {
+    QMessageBox::warning(this, tr("Reload Failed"),
+      tr("The configuration was saved, but the server failed to reload it.\n"
+         "Other clients may not see the change until the server reloads."));
+  };
   if (!reload_map_info_client_->wait_for_service(3s)) {
     RCLCPP_ERROR(LOGGER, "mapoi/reload_map_info service not available after 3s timeout.");
+    warn_reload_failed();
     return;
   }
   auto request_reload_map_info = std::make_shared<std_srvs::srv::Trigger::Request>();
@@ -176,6 +184,7 @@ void PoiEditorPanel::SaveButton()
   // SAVED! 表示は既に完了しているが、それは既存の wait_for_service 失敗 return と同じ位置づけ。
   if (rclcpp::spin_until_future_complete(service_node_, result_reload_map_info, 5s) != rclcpp::FutureReturnCode::SUCCESS) {
     RCLCPP_ERROR(LOGGER, "Failed to call service mapoi/reload_map_info (timeout or error)");
+    warn_reload_failed();
     return;
   }
 

--- a/mapoi_rviz_plugins/src/poi_editor_tags.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_tags.cpp
@@ -98,7 +98,11 @@ void PoiEditorPanel::LoadTagDefinitions()
 
   auto request = std::make_shared<mapoi_interfaces::srv::GetTagDefinitions::Request>();
   auto result = get_tag_defs_client_->async_send_request(request);
-  rclcpp::spin_until_future_complete(service_node_, result);
+  // #404: timeout (説明は poi_editor.cpp)。非 SUCCESS 時は result.get() せず return。
+  if (rclcpp::spin_until_future_complete(service_node_, result, 5s) != rclcpp::FutureReturnCode::SUCCESS) {
+    RCLCPP_WARN(LOGGER, "Failed to call service mapoi/get_tag_definitions (timeout or error), TagHelper will be empty.");
+    return;
+  }
   auto response = result.get();
 
   known_tag_names_.clear();


### PR DESCRIPTION
Closes #404

## 目的

`wait_for_service(3s)` はあるが `spin_until_future_complete` に timeout 引数が無い呼び出しが残っており、service が request 受理後に hang すると UI スレッドが無期限ブロックし panel 全体がフリーズし得た (可用性の欠陥)。また既存コードの模倣でこのパターンが新規実装へ複製されるリスクがあった。

## 変更

- Grep で全 call site を列挙し、timeout 無しの **8 箇所** (issue 記載の 7 箇所 + poi_editor.cpp onInitialize の get_maps_info) を 3 引数版 `spin_until_future_complete(..., 5s)` へ置換 (5s は mapoi_panel_nav_control.cpp の既存先行例に統一)
- timeout / 非 SUCCESS 時は既存の wait_for_service 失敗分岐と同じ安全側 (RCLCPP_ERROR/WARN + return、UI は現状維持)
- `LoadTagDefinitions` は SUCCESS 判定なしで `result.get()` していた問題も修正 (非 SUCCESS 時は WARN + return、TagHelper 空 = service 不在時と同じ扱い)
- SaveButton の reload_map_info: 失敗時は suppression / 遅延再構築フローに進まず return (既存の wait_for_service 失敗 return と同じ位置づけ)。保存自体は完了済み
- 正常系の挙動は不変。timeout 済みの既存箇所 (nav_control 5s / display_settings 200・500ms) には触れていない

## 検証

- humble / jazzy 両 Docker で colcon build 通過、gtest 150 ケース全パス
- 以後の新規 service 連携は timeout 付き呼び出しを標準とする (issue 記載のレビュー観点)