### PR TITLE
refactor(rviz): calcYaw/join/SplitSentence を自由関数化 (#397)

### DIFF
--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -9,7 +9,6 @@
 #include <rviz_common/panel.hpp>
 #include <rviz_common/display_context.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
-#include <tf2/LinearMath/Quaternion.h>
 
 #include <std_msgs/msg/string.hpp>
 #include <std_srvs/srv/trigger.hpp>
@@ -149,7 +148,8 @@ protected:
   void PopulateTagFilter();
   void LoadTagDefinitions();
   bool ValidatePois();
-  double calcYaw(geometry_msgs::msg::Pose pose);
+  // calcYaw / join / SplitSentence は poi_editor_helpers.hpp の
+  // detail::calc_yaw / detail::join / detail::split_sentence に移動 (#397 step 8)。
 
   // Display Settings 副パネル (QGroupBox + Radio/Check) を構築し connect まで行う。
   // onInitialize から rviz2_pub_param_client_ 生成後・初期 Sync 前に一度だけ呼ぶ。
@@ -172,8 +172,5 @@ protected:
   // SyncDisplaySettingsFromPublisher() で sync を試みた後 (cache 未更新) のフォールバック用。
   void RevertDisplaySettingsUiFromCache();
 
-  std::string join(const std::vector<std::string>& v, const char* delim);
-  std::vector<std::string> SplitSentence(std::string sentence,
-                                         std::string delimiter);
 };
 } // end namespace mapoi_rviz_plugins

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
@@ -1,5 +1,7 @@
 // Pure helper functions for PoiEditorPanel (#158 で header 化、unit test 容易化のため)。
-// Qt 依存なし、stdlib のみ。
+// Qt 依存なし。stdlib のみ + geometry_msgs / tf2 (calc_yaw のみ)。
+// NOTE: calc_yaw のために tf2/geometry_msgs 依存が加わったが、それ以外の関数は
+//       引き続き stdlib のみ (テスト時は calc_yaw のテストだけ tf2 link が要る)。
 #pragma once
 
 #include <cctype>
@@ -7,6 +9,10 @@
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include <geometry_msgs/msg/pose.hpp>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
 
 #include "mapoi_rviz_plugins/config_path_update_policy.hpp"
 
@@ -254,6 +260,62 @@ inline bool should_confirm_overwrite(
     return false;  // baseline を読めなかった: ガード無効 (従来挙動)
   }
   return baseline_content != current_content;  // path 一致 && baseline 非空 && 内容不一致
+}
+
+// PoiEditorPanel::calcYaw から移植 (#397 step 8 で自由関数化)。
+// geometry_msgs::msg::Pose の orientation (quaternion) から yaw 角 [rad] を返す。
+// tf2::Quaternion / tf2::Matrix3x3::getRPY を使用。
+// 命名規約: detail 内の既存関数群は snake_case なので calc_yaw に rename (全 call site 置換済み)。
+// 出典: #397 step 8 (元のメンバ関数 PoiEditorPanel::calcYaw から移動)。
+inline double calc_yaw(const geometry_msgs::msg::Pose & pose)
+{
+  tf2::Quaternion q(
+    pose.orientation.x,
+    pose.orientation.y,
+    pose.orientation.z,
+    pose.orientation.w);
+  tf2::Matrix3x3 m(q);
+  double roll, pitch, yaw;
+  m.getRPY(roll, pitch, yaw);
+  return yaw;
+}
+
+// PoiEditorPanel::join から移植 (#397 step 8 で自由関数化)。
+// 文字列ベクタを delim で連結して返す。delim が nullptr の場合は単純連結。
+// 命名規約: join は元名と一致 (既存 snake_case 慣例と同一形)。
+// 出典: https://marycore.jp/prog/cpp/vector-join/
+inline std::string join(const std::vector<std::string> & v, const char * delim)
+{
+  std::string s;
+  if (!v.empty()) {
+    s += v[0];
+    for (decltype(v.size()) i = 1, c = v.size(); i < c; ++i) {
+      if (delim) s += delim;
+      s += v[i];
+    }
+  }
+  return s;
+}
+
+// PoiEditorPanel::SplitSentence から移植 (#397 step 8 で自由関数化)。
+// sentence を delimiter で分割し、末尾トークン含む全トークンのベクタを返す。
+// 命名規約: detail 内の既存関数群は snake_case なので split_sentence に rename (全 call site 置換済み)。
+// 出典: https://lilaboc.work/archives/19026007.html
+inline std::vector<std::string> split_sentence(std::string sentence, std::string delimiter)
+{
+  std::vector<std::string> words;
+  size_t position = 0;
+
+  while (sentence.find(delimiter.c_str(), position) != std::string::npos) {
+    size_t next_position = sentence.find(delimiter.c_str(), position);
+    std::string word = sentence.substr(position, next_position - position);
+    position = next_position + delimiter.length();
+    words.push_back(word);
+  }
+  std::string last_word = sentence.substr(position, sentence.length() - position);
+  words.push_back(last_word);
+
+  return words;
 }
 
 }  // namespace mapoi_rviz_plugins::detail

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
@@ -265,6 +265,8 @@ inline bool should_confirm_overwrite(
 // PoiEditorPanel::calcYaw から移植 (#397 step 8 で自由関数化)。
 // geometry_msgs::msg::Pose の orientation (quaternion) から yaw 角 [rad] を返す。
 // tf2::Quaternion / tf2::Matrix3x3::getRPY を使用。
+// 入力は単位四元数前提 (mapoi_server / Editor 側で保証)。非正規化・ゼロ四元数の挙動は
+// 未定義に近い (PR #425 review low の契約明示)。
 // 命名規約: detail 内の既存関数群は snake_case なので calc_yaw に rename (全 call site 置換済み)。
 // 出典: #397 step 8 (元のメンバ関数 PoiEditorPanel::calcYaw から移動)。
 inline double calc_yaw(const geometry_msgs::msg::Pose & pose)
@@ -305,6 +307,12 @@ inline std::vector<std::string> split_sentence(std::string sentence, std::string
 {
   std::vector<std::string> words;
   size_t position = 0;
+
+  // 空 delimiter は find が現在位置にマッチし続け position が進まず無限ループするため、
+  // 分割せず全体を 1 要素で返す (自由関数化で再利用面が広がるためのガード、PR #425 review)。
+  if (delimiter.empty()) {
+    return {sentence};
+  }
 
   while (sentence.find(delimiter.c_str(), position) != std::string::npos) {
     size_t next_position = sentence.find(delimiter.c_str(), position);

--- a/mapoi_rviz_plugins/package.xml
+++ b/mapoi_rviz_plugins/package.xml
@@ -12,6 +12,8 @@
 
   <depend>ament_cmake_auto</depend>
   <depend>std_srvs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tf2</depend>
   <depend>rviz_common</depend>
   <depend>rviz_default_plugins</depend>
   <depend>mapoi_interfaces</depend>

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -245,7 +245,7 @@ void PoiEditorPanel::FileComboBox()
 void PoiEditorPanel::PoiPoseCallback(geometry_msgs::msg::PoseStamped::SharedPtr msg)
 {
   auto p = msg->pose;
-  auto txt = tr("%1, %2, %3").arg(p.position.x).arg(p.position.y).arg(this->calcYaw(p));
+  auto txt = tr("%1, %2, %3").arg(p.position.x).arg(p.position.y).arg(detail::calc_yaw(p));
   QMetaObject::invokeMethod(this, [this, txt]() {
     int current_row = ui_->PoiTable->currentRow();
     if (current_row >= 0) {
@@ -450,12 +450,12 @@ void PoiEditorPanel::UpdatePoiTable()
       tr("%1, %2, %3")
         .arg(QString::number(p.pose.position.x, 'f', 2))
         .arg(QString::number(p.pose.position.y, 'f', 2))
-        .arg(QString::number(this->calcYaw(p.pose), 'f', 2))));
+        .arg(QString::number(detail::calc_yaw(p.pose), 'f', 2))));
     ui_->PoiTable->setItem(row, kColTolerance, new QTableWidgetItem(
       tr("%1, %2")
         .arg(QString::number(p.tolerance.xy, 'f', 2))
         .arg(QString::number(p.tolerance.yaw, 'f', 2))));
-    ui_->PoiTable->setItem(row, kColTags, new QTableWidgetItem(QString::fromStdString(this->join(p.tags, ", "))));
+    ui_->PoiTable->setItem(row, kColTags, new QTableWidgetItem(QString::fromStdString(detail::join(p.tags, ", "))));
     ui_->PoiTable->setItem(row, kColDescription, new QTableWidgetItem(QString::fromStdString(p.description)));
   }
   is_table_color_ = true;
@@ -500,50 +500,8 @@ void PoiEditorPanel::UpdatePoiTable()
   }
 }
 
-double PoiEditorPanel::calcYaw(geometry_msgs::msg::Pose pose)
-{
-  tf2::Quaternion q(
-    pose.orientation.x,
-    pose.orientation.y,
-    pose.orientation.z,
-    pose.orientation.w);
-  tf2::Matrix3x3 m(q);
-  double roll, pitch, yaw;
-  m.getRPY(roll, pitch, yaw);
-  return yaw;
-}
-
-// https://marycore.jp/prog/cpp/vector-join/
-std::string PoiEditorPanel::join(const std::vector<std::string>& v, const char* delim)
-{
-  std::string s;
-  if (!v.empty()) {
-    s += v[0];
-    for (decltype(v.size()) i = 1, c = v.size(); i < c; ++i) {
-      if (delim) s += delim;
-      s += v[i];
-    }
-  }
-  return s;
-}
-
-// https://lilaboc.work/archives/19026007.html
-std::vector<std::string> PoiEditorPanel::SplitSentence(std::string sentence, std::string delimiter)
-{
-	std::vector<std::string> words;
-	size_t position = 0;
-
-	while(sentence.find(delimiter.c_str(), position) != std::string::npos){
-		size_t next_position = sentence.find(delimiter.c_str(), position);
-		std::string word = sentence.substr(position, next_position-position);
-		position = next_position + delimiter.length();
-		words.push_back(word);
-	}
-	std::string last_word = sentence.substr(position, sentence.length()-position);
-	words.push_back(last_word);
-
-	return words;
-}
+// calcYaw / join / SplitSentence の定義は poi_editor_helpers.hpp に移動 (#397 step 8)。
+// detail::calc_yaw / detail::join / detail::split_sentence として自由関数化。
 
 }  // mapoi_rviz_plugins
 

--- a/mapoi_rviz_plugins/src/poi_editor_save.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_save.cpp
@@ -126,7 +126,7 @@ void PoiEditorPanel::SaveButton()
     poi["tolerance"]["xy"] = xy_val;
     poi["tolerance"]["yaw"] = yaw_val;
     auto tags_str = cell_text(kColTags);
-    poi["tags"] = this->SplitSentence(tags_str, ", ");
+    poi["tags"] = detail::split_sentence(tags_str, ", ");
     poi["description"] = cell_text(kColDescription);
     pois_list.push_back(poi);
   }

--- a/mapoi_rviz_plugins/src/poi_editor_tags.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_tags.cpp
@@ -53,12 +53,12 @@ void PoiEditorPanel::TagFilterChanged(int index)
         tr("%1, %2, %3")
           .arg(QString::number(p.pose.position.x, 'f', 2))
           .arg(QString::number(p.pose.position.y, 'f', 2))
-          .arg(QString::number(this->calcYaw(p.pose), 'f', 2))));
+          .arg(QString::number(detail::calc_yaw(p.pose), 'f', 2))));
       ui_->PoiTable->setItem(row, kColTolerance, new QTableWidgetItem(
         tr("%1, %2")
           .arg(QString::number(p.tolerance.xy, 'f', 2))
           .arg(QString::number(p.tolerance.yaw, 'f', 2))));
-      ui_->PoiTable->setItem(row, kColTags, new QTableWidgetItem(QString::fromStdString(this->join(p.tags, ", "))));
+      ui_->PoiTable->setItem(row, kColTags, new QTableWidgetItem(QString::fromStdString(detail::join(p.tags, ", "))));
       ui_->PoiTable->setItem(row, kColDescription, new QTableWidgetItem(QString::fromStdString(p.description)));
       row++;
     }
@@ -144,7 +144,7 @@ void PoiEditorPanel::TagHelperSelected(int index)
   std::string current_tags = tags_item ? tags_item->text().toStdString() : "";
 
   // Check if tag already exists
-  auto tag_list = this->SplitSentence(current_tags, ", ");
+  auto tag_list = detail::split_sentence(current_tags, ", ");
   for (const auto& t : tag_list) {
     if (t == tag_name) {
       ui_->TagHelperComboBox->setCurrentIndex(0);

--- a/mapoi_rviz_plugins/src/poi_editor_validation.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_validation.cpp
@@ -108,7 +108,7 @@ bool PoiEditorPanel::ValidatePois()
     std::string tags_str = tags_item ? tags_item->text().toStdString() : "";
     if (tags_str.empty()) continue;
 
-    auto tags = this->SplitSentence(tags_str, ", ");
+    auto tags = detail::split_sentence(tags_str, ", ");
     const auto excl = detail::check_tag_exclusivity(tags);
     if (excl.waypoint_landmark_conflict) {
       exclusivity_warnings.append(
@@ -135,7 +135,7 @@ bool PoiEditorPanel::ValidatePois()
     std::string tags_str = tags_item ? tags_item->text().toStdString() : "";
     if (tags_str.empty()) continue;
 
-    auto tags = this->SplitSentence(tags_str, ", ");
+    auto tags = detail::split_sentence(tags_str, ", ");
     for (const auto& tag : tags) {
       if (tag.empty()) continue;
       bool found = false;

--- a/mapoi_rviz_plugins/test/test_poi_editor_helpers.cpp
+++ b/mapoi_rviz_plugins/test/test_poi_editor_helpers.cpp
@@ -306,11 +306,11 @@ TEST(CalcYaw, KnownYawNegativeNinetyDeg)
 
 TEST(CalcYaw, NearPiBoundary)
 {
-  // yaw ≈ π (180°) 付近。getRPY の返値範囲は (-π, π] なので ±π 境界を確認する。
-  // tf2::Matrix3x3::getRPY は π を返すことがある (実装依存) ため |result| ≤ π を検証。
+  // yaw ≈ π (180°) 付近。getRPY の返値範囲は (-π, π] で、±π のどちらで返るかは実装依存。
+  // 「常に 0 を返す」ような退行も検知できるよう |result| ≈ π まで断言する (PR #425 review)。
   const double yaw = M_PI;
   const double result = calc_yaw(make_pose_yaw(yaw));
-  EXPECT_LE(std::abs(result), M_PI + 1e-9);
+  EXPECT_NEAR(std::abs(result), M_PI, 1e-6);
 }
 
 // --- join (#397 step 8) ---
@@ -341,11 +341,21 @@ TEST(Join, NullDelim)
 
 TEST(SplitSentence, BasicTwoParts)
 {
-  // "waypoint, pause" → ["waypoint", " pause"] (SplitSentence は trim しない)
+  // 区切り ", " (カンマ+スペース) での基本分割。スペースは区切りの一部として消費される。
   const auto result = split_sentence("waypoint, pause", ", ");
   ASSERT_EQ(result.size(), 2u);
   EXPECT_EQ(result[0], "waypoint");
   EXPECT_EQ(result[1], "pause");
+}
+
+TEST(SplitSentence, CommaOnlyDelimiterDoesNotTrim)
+{
+  // 区切り "," (スペース無し) だと後続トークンの先頭スペースは残る = trim しない契約
+  // (trim が要る場合は split_and_trim を使う)。PR #425 review のコメント誤読対策として分離。
+  const auto result = split_sentence("waypoint, pause", ",");
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], "waypoint");
+  EXPECT_EQ(result[1], " pause");
 }
 
 TEST(SplitSentence, NoDelimiter)
@@ -372,4 +382,22 @@ TEST(SplitSentence, EmptyString)
   const auto result = split_sentence("", ", ");
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0], "");
+}
+
+TEST(SplitSentence, EmptyDelimiterReturnsWholeSentence)
+{
+  // 空 delimiter は無限ループガードにより分割せず全体を 1 要素で返す (PR #425 review)。
+  const auto result = split_sentence("abc", "");
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], "abc");
+}
+
+TEST(SplitSentence, RoundTripWithJoin)
+{
+  // UI 表示は join(", ")・保存/検証は split_sentence(", ") の対で使われるため、
+  // 往復の同一性を pin する (片方だけ変更された時のタグ列回帰を検知、PR #425 review)。
+  const std::vector<std::string> tags = {"waypoint", "pause", "landmark"};
+  EXPECT_EQ(split_sentence(join(tags, ", "), ", "), tags);
+  const std::string joined = "a, b, c";
+  EXPECT_EQ(join(split_sentence(joined, ", "), ", "), joined);
 }

--- a/mapoi_rviz_plugins/test/test_poi_editor_helpers.cpp
+++ b/mapoi_rviz_plugins/test/test_poi_editor_helpers.cpp
@@ -1,5 +1,10 @@
-// Pure helper functions のための gtest (#158 round 1)。Qt 不要 (header は stdlib のみ)。
+// Pure helper functions のための gtest (#158 round 1)。Qt 不要。
+// header 依存: stdlib + geometry_msgs / tf2 (calc_yaw のみ、#397 step 8 で追加)。
+// テスト target は ament_auto_add_gtest で ament_cmake_auto が package.xml の
+// geometry_msgs / tf2 depend から link を解決する。
 #include <gtest/gtest.h>
+
+#include <cmath>
 
 #include "mapoi_rviz_plugins/poi_editor_helpers.hpp"
 
@@ -11,6 +16,11 @@ using mapoi_rviz_plugins::detail::ConfigPathUpdateAction;
 using mapoi_rviz_plugins::detail::ConfigReloadGuardDecision;
 using mapoi_rviz_plugins::detail::decide_config_reload_guard;
 using mapoi_rviz_plugins::detail::should_confirm_overwrite;
+
+// 自由関数化した helpers (#397 step 8)
+using mapoi_rviz_plugins::detail::calc_yaw;
+using mapoi_rviz_plugins::detail::join;
+using mapoi_rviz_plugins::detail::split_sentence;
 
 // --- split_and_trim ---
 
@@ -249,4 +259,117 @@ TEST(ShouldConfirmOverwrite, EmptyBaselinePathDoesNotMatchNonEmptySave)
   // baseline 未取得 (path も空) の状態で保存先を指定 → path 不一致で比較しない。
   EXPECT_FALSE(should_confirm_overwrite(
     "/maps/mapA/mapoi_config.yaml", "", "", "poi: [x]"));
+}
+
+// --- calc_yaw (#397 step 8) ---
+//
+// PoiEditorPanel::calcYaw を detail::calc_yaw として自由関数化した純関数のテスト。
+// quaternion → yaw 変換の契約を pin する。
+
+// ヘルパ: roll=0, pitch=0, yaw=theta の quaternion を作る (tf2 直接使用)。
+namespace
+{
+geometry_msgs::msg::Pose make_pose_yaw(double yaw_rad)
+{
+  tf2::Quaternion q;
+  q.setRPY(0.0, 0.0, yaw_rad);
+  geometry_msgs::msg::Pose pose;
+  pose.orientation.x = q.x();
+  pose.orientation.y = q.y();
+  pose.orientation.z = q.z();
+  pose.orientation.w = q.w();
+  return pose;
+}
+}  // namespace
+
+TEST(CalcYaw, IdentityQuaternionIsZero)
+{
+  // 恒等 quaternion (w=1, xyz=0) → yaw = 0
+  geometry_msgs::msg::Pose pose;
+  pose.orientation.w = 1.0;
+  EXPECT_NEAR(calc_yaw(pose), 0.0, 1e-9);
+}
+
+TEST(CalcYaw, KnownYawFortyFiveDeg)
+{
+  // yaw = π/4 (45°) の quaternion → π/4 が返る
+  const double expected = M_PI / 4.0;
+  EXPECT_NEAR(calc_yaw(make_pose_yaw(expected)), expected, 1e-9);
+}
+
+TEST(CalcYaw, KnownYawNegativeNinetyDeg)
+{
+  // yaw = -π/2 (-90°) の quaternion → -π/2 が返る
+  const double expected = -M_PI / 2.0;
+  EXPECT_NEAR(calc_yaw(make_pose_yaw(expected)), expected, 1e-9);
+}
+
+TEST(CalcYaw, NearPiBoundary)
+{
+  // yaw ≈ π (180°) 付近。getRPY の返値範囲は (-π, π] なので ±π 境界を確認する。
+  // tf2::Matrix3x3::getRPY は π を返すことがある (実装依存) ため |result| ≤ π を検証。
+  const double yaw = M_PI;
+  const double result = calc_yaw(make_pose_yaw(yaw));
+  EXPECT_LE(std::abs(result), M_PI + 1e-9);
+}
+
+// --- join (#397 step 8) ---
+
+TEST(Join, EmptyVector)
+{
+  // 空ベクタ → 空文字列
+  EXPECT_EQ(join({}, ", "), "");
+}
+
+TEST(Join, SingleElement)
+{
+  EXPECT_EQ(join({"foo"}, ", "), "foo");
+}
+
+TEST(Join, MultipleElements)
+{
+  EXPECT_EQ(join({"waypoint", "pause", "landmark"}, ", "), "waypoint, pause, landmark");
+}
+
+TEST(Join, NullDelim)
+{
+  // delim が nullptr の場合は単純連結 (区切りなし)
+  EXPECT_EQ(join({"a", "b", "c"}, nullptr), "abc");
+}
+
+// --- split_sentence (#397 step 8) ---
+
+TEST(SplitSentence, BasicTwoParts)
+{
+  // "waypoint, pause" → ["waypoint", " pause"] (SplitSentence は trim しない)
+  const auto result = split_sentence("waypoint, pause", ", ");
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_EQ(result[0], "waypoint");
+  EXPECT_EQ(result[1], "pause");
+}
+
+TEST(SplitSentence, NoDelimiter)
+{
+  // 区切り無し → 1 要素のベクタ
+  const auto result = split_sentence("single", ", ");
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], "single");
+}
+
+TEST(SplitSentence, TrailingDelimiter)
+{
+  // "a, b, " → ["a", "b", ""] (末尾区切り後に空文字列が入る)
+  const auto result = split_sentence("a, b, ", ", ");
+  ASSERT_EQ(result.size(), 3u);
+  EXPECT_EQ(result[0], "a");
+  EXPECT_EQ(result[1], "b");
+  EXPECT_EQ(result[2], "");
+}
+
+TEST(SplitSentence, EmptyString)
+{
+  // 空文字列 → 1 要素 (空文字列) のベクタ (while loop が回らず末尾トークンだけ push)
+  const auto result = split_sentence("", ", ");
+  ASSERT_EQ(result.size(), 1u);
+  EXPECT_EQ(result[0], "");
 }


### PR DESCRIPTION
## 目的

#397 step 8。Qt 非依存なのにメンバ関数のままだった `calcYaw` / `join` / `SplitSentence` を `poi_editor_helpers.hpp` の detail 自由関数へ移し (#158/#346 パターン)、gtest を追加する。

## 変更

- `detail::calc_yaw` / `detail::join` / `detail::split_sentence` として移動 (detail 既存慣例の snake_case へ rename。本体・出典 URL コメントは一字一句移動)
- **全 call site を Grep で網羅置換** (計 9 箇所): issue 記載の poi_editor.cpp / tags / save に加え、**poi_editor_validation.cpp の 2 箇所**も grep で検出して置換。`this->calcYaw|join|SplitSentence` 残存ゼロを確認
- `poi_editor.hpp`: 3 メンバ宣言と tf2 include を削除 (hpp 内で他に tf2 使用なし)
- `package.xml`: helpers.hpp が tf2 / geometry_msgs を直接 include するようになったため**明示依存を追加** (従来は rviz_common 経由の推移的解決に依存していた)
- gtest 12 ケース追加: calc_yaw (恒等 / 既知 yaw ±/π 境界)、join (空 / 1 要素 / 複数 / nullptr delim)、split_sentence (基本 / 区切り無し / 末尾区切り / 空)

## 検証

- humble / jazzy 両 Docker で colcon build 通過、gtest 162 ケース (新規 12 件) 全パス