### PR TITLE
feat(rviz): PoiEditor に Undo/Redo を追加 (#407)

### DIFF
--- a/mapoi_rviz_plugins/CMakeLists.txt
+++ b/mapoi_rviz_plugins/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCE_FILES
   src/poi_editor.cpp
   src/poi_editor_display_settings.cpp
   src/poi_editor_save.cpp
+  src/poi_editor_table.cpp
   src/poi_editor_tags.cpp
   src/poi_editor_validation.cpp
   src/mapoi_pose_tool.cpp

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -27,10 +27,16 @@
 #include <QLabel>
 #include <QRadioButton>
 #include <QCheckBox>
+// ApplySetCell / ApplyInsertRow の引数型 (QString / std::vector<QString>) 用 (#407)。
+#include <QString>
 
 namespace Ui {
 class PoiEditorUi;
 }
+
+// Undo/Redo 基盤 (#407)。QUndoStack のポインタメンバだけを持つため前方宣言で足りる
+// (<QUndoStack> の include は poi_editor_table.cpp 側)。
+class QUndoStack;
 
 
 namespace mapoi_rviz_plugins
@@ -46,6 +52,17 @@ public:
   void onInitialize() override;
   void onEnable();
   void onDisable();
+
+  // Undo/Redo 適用ヘルパー (#407)。poi_editor_table.cpp 内 file-local な QUndoCommand
+  // サブクラスの undo()/redo() から呼ばれるため public にする (hpp の公開面を増やさない
+  // 方針だが、file-local コマンドは friend にできないため最小限の public API として露出する)。
+  // いずれも applying_undo_ を立ててシグナル再入 (cellChanged / sectionMoved → 二重
+  // コマンド化・dirty 重複) を抑制し、shadow model を同期する。実装・詳細コメントは
+  // poi_editor_table.cpp。
+  void ApplySetCell(int row, int col, const QString & text);
+  void ApplyInsertRow(int row, const std::vector<QString> & texts);
+  void ApplyRemoveRow(int row);
+  void ApplyMoveSection(int from_visual, int to_visual);
 
 private Q_SLOTS:
   void MapComboBox();
@@ -66,6 +83,27 @@ protected:
   std::string config_path_;
   std::vector<std::string> map_name_list_;
   bool is_table_color_;
+
+  // Undo/Redo 基盤 (#407)。いずれも UI (Qt メイン) スレッド上でのみ触るためロック不要。
+  //
+  // QUndoStack: New/Copy/Delete/セル編集/RowMoved の 5 操作を積む。panel が親 (QObject
+  // 所有権) なので明示 delete 不要。UpdatePoiTable / TagFilterChanged の全再構築時に
+  // clear (行 index 前提が崩れた履歴を残さない)、保存成功時に setClean、cleanChanged で
+  // table_dirty_ と連携する。前方宣言のみ握るためポインタ。
+  QUndoStack * undo_stack_ = nullptr;
+
+  // シグナル再入抑制フラグ (#407 §4)。コマンドの undo()/redo() がテーブルを書き換える際、
+  // cellChanged→TableChanged / sectionMoved→RowMoved の再入で dirty 再 set・二重コマンド化
+  // しないよう、適用ヘルパー (Apply*) がこの間 true にする。TableChanged / RowMoved の冒頭で
+  // これを見て早期 return する。既存の is_table_color_ ガード (再構築中の cellChanged 弾き)
+  // とは目的が異なるため別フラグで共存させる。
+  bool applying_undo_ = false;
+
+  // shadow model (#407 §3)。テーブル内容のミラー (logical row × column の QString)。
+  // QTableWidget の cellChanged は旧値を渡さないため、cellChanged 時に shadow との差分から
+  // old 値を得てセル編集コマンドを生成し、shadow を新値へ更新する。UpdatePoiTable /
+  // TagFilterChanged の全再構築後に RebuildShadowModel で取り直す (行 index 前提を揃える)。
+  std::vector<std::vector<QString>> shadow_;
 
   // Tag filter: store all POIs to restore when filter is cleared
   std::vector<mapoi_interfaces::msg::PointOfInterest> all_pois_;
@@ -144,6 +182,14 @@ protected:
   // Functions
   void InitConfigs(std::string map_name);
   void UpdatePoiTable();
+
+  // Undo/Redo 基盤の初期化と shadow model の (再) 構築 (#407)。定義は poi_editor_table.cpp。
+  // SetupUndoRedo: QUndoStack 生成・ショートカット配線・cleanChanged↔dirty 連携。onInitialize
+  //   から一度だけ呼ぶ (テーブル系 connect 後・初回 UpdatePoiTable 前)。
+  // RebuildShadowModel: shadow_ を現在のテーブル内容で作り直す。全再構築 (UpdatePoiTable /
+  //   TagFilterChanged) の末尾で呼び、cellChanged 差分計算の基準を揃える。
+  void SetupUndoRedo();
+  void RebuildShadowModel();
   void UpdatePoiCount();
   void PopulateTagFilter();
   void LoadTagDefinitions();

--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -6,9 +6,11 @@
 #include <fstream>
 #include <sstream>
 
-#include <QFileDialog>
-#include <QStandardPaths>
+// QFileDialog / QStandardPaths は FileComboBox の移設 (#397 step 9 → poi_editor_table.cpp)
+// に伴い不要化したため削除。
 #include <QTimer>
+// undo_stack_->clear() の呼び出しに完全型が要る (hpp は前方宣言のみ、#407)。
+#include <QUndoStack>
 
 #include "ui_poi_editor.h"
 
@@ -62,6 +64,13 @@ void PoiEditorPanel::onInitialize()
   // NameFilterEdit の現在値を直接読むため、シグナル引数は使わず直接 connect する。
   connect(ui_->NameFilterEdit, &QLineEdit::textChanged,
     this, &PoiEditorPanel::ApplyNameFilter);
+
+  // Undo/Redo 基盤 (#407): QUndoStack 生成・ショートカット (Ctrl+Z / Ctrl+Shift+Z、
+  // WidgetWithChildrenShortcut) 配線・cleanChanged↔dirty 連携をまとめて行う。テーブル系
+  // slot の connect (上の cellChanged / sectionMoved / New/Copy/Delete) より後、初回の
+  // UpdatePoiTable (shadow 初期構築 + stack clear を行う) より前に一度だけ呼ぶ。定義は
+  // poi_editor_table.cpp。
+  SetupUndoRedo();
 
   poi_pose_sub_ = node_->create_subscription<geometry_msgs::msg::PoseStamped>(
     "mapoi_rviz_pose", 10, std::bind(&PoiEditorPanel::PoiPoseCallback, this, std::placeholders::_1));
@@ -142,104 +151,10 @@ void PoiEditorPanel::MapComboBox()
   PoiEditorPanel::UpdatePoiTable();
 }
 
-void PoiEditorPanel::ResetButton()
-{
-  PoiEditorPanel::UpdatePoiTable();
-}
-
-void PoiEditorPanel::TableChanged(int row, int column)
-{
-  if(is_table_color_){
-    ui_->PoiTable->item(row, column)->setBackground(Qt::green);
-    // ユーザー編集の dirty マーク (#399)。UpdatePoiTable / TagFilterChanged の再構築中は
-    // is_table_color_=false で setItem 由来の cellChanged が飛ぶため、既存の green 着色ガードに
-    // 相乗りしてユーザー編集だけを拾う (再構築由来の cellChanged では dirty を立てない)。
-    table_dirty_ = true;
-    if (column == kColName) {
-      // 名前セルの編集確定時はその行だけ名前フィルタを再評価する (#405、PR #420 review)。
-      // 一致しなくなった行は編集確定と同時に隠れる (絞り込み表示の一貫性を優先)。
-      ApplyNameFilterToRow(row);
-    }
-  }
-  ui_->SaveButton->setText("save");
-  ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
-  UpdatePoiCount();
-}
-
-void PoiEditorPanel::NewButton()
-{
-  int current_row = ui_->PoiTable->currentRow();
-  int new_row = current_row + 1;
-  ui_->PoiTable->insertRow(new_row);
-  // column 構造 (#158): name / pose / tolerance "xy m, yaw rad" / tags / description
-  ui_->PoiTable->setItem(new_row, kColName, new QTableWidgetItem("new_poi"));
-  ui_->PoiTable->setItem(new_row, kColPose, new QTableWidgetItem("0.0, 0.0, 0.0"));
-  ui_->PoiTable->setItem(new_row, kColTolerance, new QTableWidgetItem("0.5, 0.7854"));  // ≒ π/4 rad
-  ui_->PoiTable->setItem(new_row, kColTags, new QTableWidgetItem(""));
-  ui_->PoiTable->setItem(new_row, kColDescription, new QTableWidgetItem(""));
-  // insertRow / setItem は cellChanged を確実には発火しないため dirty を明示 set (#399)。
-  table_dirty_ = true;
-  UpdatePoiCount();
-}
-
-void PoiEditorPanel::CopyButton()
-{
-  int current_row = ui_->PoiTable->currentRow();
-  if (current_row < 0) return;
-  int new_row = current_row + 1;
-  ui_->PoiTable->insertRow(new_row);
-  for (int col = 0; col < ui_->PoiTable->columnCount(); col++){
-    auto* item = ui_->PoiTable->item(current_row, col);
-    QString txt = item ? item->text() : "";
-    ui_->PoiTable->setItem(new_row, col, new QTableWidgetItem(txt));
-  }
-  // insertRow による行複製は cellChanged を確実には発火しないため dirty を明示 set (#399)。
-  table_dirty_ = true;
-  UpdatePoiCount();
-}
-
-void PoiEditorPanel::DeleteButton()
-{
-  int current_row = ui_->PoiTable->currentRow();
-  ui_->PoiTable->removeRow(current_row);
-  // removeRow は cellChanged を発火しないため dirty を明示 set (#399)。
-  table_dirty_ = true;
-  ui_->SaveButton->setText("save");
-  ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
-  UpdatePoiCount();
-}
-
-void PoiEditorPanel::RowMoved(int logicalIndex, int oldVisualIndex, int newVisualIndex){
-  Q_UNUSED(newVisualIndex);
-  Q_UNUSED(oldVisualIndex);
-  int numCols = ui_->PoiTable->columnCount();
-  for (int col = 0; col < numCols; col++){
-    ui_->PoiTable->item(logicalIndex, col)->setBackground(Qt::green);
-  }
-  // sectionMoved は cellChanged を発火しないため dirty を明示 set (#399)。
-  table_dirty_ = true;
-  ui_->SaveButton->setText("save");
-  ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
-}
-
-void PoiEditorPanel::FileComboBox()
-{
-  int last = ui_->FileComboBox->count() - 1;
-  if(ui_->FileComboBox->currentIndex() == last){
-    QString filename = QFileDialog::getOpenFileName(
-        this, tr("Select a poi_file"), QString::fromStdString(config_path_), tr("YAML files(*.yaml)"));
-    if(filename == ""){
-      ui_->FileComboBox->setItemText(last, "the other");
-      ui_->FileComboBox->setCurrentIndex(0);
-    }else{
-      ui_->FileComboBox->setItemText(last, filename);
-    }
-  } else{
-    int last2 = ui_->FileComboBox->count() - 1;
-    ui_->FileComboBox->setItemText(last2, "the other");
-  }
-  ui_->SaveButton->setText("save");
-}
+// ResetButton / TableChanged / NewButton / CopyButton / DeleteButton / RowMoved /
+// FileComboBox の定義は poi_editor_table.cpp へ切り出した (#397 step 9)。
+// 同 TU には Undo/Redo 基盤 (QUndoStack / QUndoCommand 群 / shadow model / 適用ヘルパー)
+// も実装している (#407。step 9 を先行分割せず Undo/Redo と統合したのは #397 step 9 の記述どおり)。
 
 // SaveButton() の定義は poi_editor_save.cpp へ切り出した (#397 step 6)。
 
@@ -475,7 +390,19 @@ void PoiEditorPanel::UpdatePoiTable()
   // SaveButton の全行ループは非表示行も含めて正しく保存される。
   ApplyNameFilter();
 
+  // Undo/Redo (#407): 全再構築で行 index の前提が総入れ替えになるため、それ以前の
+  // 履歴 (行 index を握るコマンド) を残すと undo で存在しない行を触りかねない。安全側に
+  // 割り切って undo stack を clear し、shadow model を再構築後のテーブルで取り直す。
+  // (名前フィルタ #405 の setRowHidden は行を削除しないため履歴と共存可 = clear 不要。
+  //  タグフィルタ TagFilterChanged 側でも同様に clear + 取り直しを行う。)
+  if (undo_stack_) {
+    undo_stack_->clear();  // ここで clean=true になり cleanChanged→table_dirty_=false も走る
+  }
+  RebuildShadowModel();
+
   // 全再構築 = サーバ状態と一致した時点なので dirty をクリアする (#399)。
+  // stack clear の cleanChanged でも false になるが、undo_stack_ 未生成の初回や
+  // 既に clean だった場合 (cleanChanged 不発) に備えて明示 set は不変のまま残す。
   table_dirty_ = false;
 
   // 外部変更検出 (SaveButton) の baseline スナップショットを取り直す (#399)。

--- a/mapoi_rviz_plugins/src/poi_editor_save.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_save.cpp
@@ -167,13 +167,14 @@ void PoiEditorPanel::SaveButton()
   baseline_path_ = save_path;
   baseline_content_ = out.c_str();
 
-  // Undo/Redo (#407): 保存成功時点を undo stack の clean 基準にする。以降 undo でここへ
-  // 戻れば cleanChanged→table_dirty_=false でガードが再解除される (WebUI の「保存後 undo で
-  // dirty 復活 / さらに undo で保存点へ戻ると clean」と同じ意味論)。stack 自体は clear せず
-  // 保存後も undo で保存前へ戻れる (1.5 秒後の UpdatePoiTable で全再構築 → そこで stack は
-  // clear される。それまでの間の undo/redo は有効)。undo_stack_ 未生成は無いが防御的に check。
+  // Undo/Redo (#407): 保存成功 = 履歴境界として undo stack を clear する (PR #426 review)。
+  // setClean で履歴を残しても、1.5 秒後の UpdatePoiTable 全再構築で stack は消えるため
+  // 「保存直後の 1.5 秒だけ undo でき、直後の再構築で突然保存状態へ戻される」錯乱窓に
+  // しかならない。WebUI (poi-history.js) は保存後も履歴を保つが、RViz 側には保存後の
+  // 自動再構築があるため意図的に分岐する。clear は clean 化を伴い cleanChanged→
+  // table_dirty_=false も走る (上の明示 set と整合)。undo_stack_ 未生成は無いが防御的に check。
   if (undo_stack_) {
-    undo_stack_->setClean();
+    undo_stack_->clear();
   }
 
   // 保存後の reload_map_info 失敗はログだけだと「保存成功と認識したままサーバ側が古い」状態に

--- a/mapoi_rviz_plugins/src/poi_editor_save.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_save.cpp
@@ -8,6 +8,8 @@
 #include <sstream>
 
 #include <QTimer>
+// undo_stack_->setClean() の呼び出しに完全型が要る (hpp は前方宣言のみ、#407)。
+#include <QUndoStack>
 
 // generated UI header: PoiEditorPanel::ui_ (`Ui::PoiEditorUi*`) は poi_editor.hpp では
 // 前方宣言のみなので、`ui_->PoiTable` 等の完全型アクセスにはこの include が要る
@@ -164,6 +166,15 @@ void PoiEditorPanel::SaveButton()
   table_dirty_ = false;
   baseline_path_ = save_path;
   baseline_content_ = out.c_str();
+
+  // Undo/Redo (#407): 保存成功時点を undo stack の clean 基準にする。以降 undo でここへ
+  // 戻れば cleanChanged→table_dirty_=false でガードが再解除される (WebUI の「保存後 undo で
+  // dirty 復活 / さらに undo で保存点へ戻ると clean」と同じ意味論)。stack 自体は clear せず
+  // 保存後も undo で保存前へ戻れる (1.5 秒後の UpdatePoiTable で全再構築 → そこで stack は
+  // clear される。それまでの間の undo/redo は有効)。undo_stack_ 未生成は無いが防御的に check。
+  if (undo_stack_) {
+    undo_stack_->setClean();
+  }
 
   // 保存後の reload_map_info 失敗はログだけだと「保存成功と認識したままサーバ側が古い」状態に
   // 気づけない (PR #424 review medium)。保存自体は完了している旨とあわせて明示する。

--- a/mapoi_rviz_plugins/src/poi_editor_table.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_table.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <QFileDialog>
+#include <QScopedValueRollback>
 #include <QShortcut>
 #include <QUndoCommand>
 #include <QUndoStack>
@@ -104,6 +105,13 @@ private:
 
 // 行削除 (Delete)。redo = row_ を削除、undo = row_ に texts_ を挿入 (削除前の全 cell
 // テキストを保持しておき復元)。生成側で削除前に行テキストをキャプチャする。
+//
+// 既知制限 (PR #426 review): 行ドラッグ (visual 並び替え) 済みのテーブルで削除→undo すると、
+// 内容は logical index に正しく復元されるが、visual 位置は既定 (logical と同じ) に戻る
+// (QHeaderView は削除された section の visual 位置を記憶しない)。visual 位置まで復元するには
+// visualIndex のキャプチャ + moveSection 逆適用が要るが、複合エッジ (並び替え+削除+undo) の
+// 頻度に対して複雑化が見合わないため割り切る。保存後の UpdatePoiTable 再構築で visual =
+// logical に正規化される点は従来通り。
 class RemoveRowCommand : public QUndoCommand
 {
 public:
@@ -228,28 +236,31 @@ void PoiEditorPanel::ApplySetCell(int row, int col, const QString & text)
   // 既存の is_table_color_ ガード (再構築中の cellChanged を弾く) とは目的が異なるので
   // 別フラグで共存させる (is_table_color_ は着色/dirty の可否、applying_undo_ は
   // コマンド適用中の TableChanged 全処理スキップ)。
-  applying_undo_ = true;
-  if (row >= 0 && row < ui_->PoiTable->rowCount()) {
-    // 既存 item があれば setText で更新する (setItem による delete/再生成を避ける)。
-    // push 時の初回 redo() は cellChanged ハンドラ (TableChanged) の呼び出し中に走るため、
-    // シグナルを発火させた item 自体を破棄すると再入安全性が脆くなる。setText なら
-    // item 実体を保ったまま値だけ更新でき、同値上書き (冪等 redo) も無害。
-    if (auto * existing = ui_->PoiTable->item(row, col)) {
-      existing->setText(text);
-    } else {
-      ui_->PoiTable->setItem(row, col, new QTableWidgetItem(text));
-    }
-    // 編集済みの視覚マーク (通常編集の green 着色に合わせる)。
-    if (auto * item = ui_->PoiTable->item(row, col)) {
-      item->setBackground(Qt::green);
-    }
-    // shadow を書き換え後の値に同期する (次の cellChanged 差分計算の基準を更新)。
-    if (row < static_cast<int>(shadow_.size()) &&
-        col < static_cast<int>(shadow_[row].size())) {
-      shadow_[row][col] = text;
+  {
+    // QScopedValueRollback で例外・早期 return でもフラグが必ず復元されるようにする
+    // (true のまま残ると以降の編集が全て握りつぶされるため、PR #426 review)。
+    const QScopedValueRollback<bool> guard(applying_undo_, true);
+    if (row >= 0 && row < ui_->PoiTable->rowCount()) {
+      // 既存 item があれば setText で更新する (setItem による delete/再生成を避ける)。
+      // push 時の初回 redo() は cellChanged ハンドラ (TableChanged) の呼び出し中に走るため、
+      // シグナルを発火させた item 自体を破棄すると再入安全性が脆くなる。setText なら
+      // item 実体を保ったまま値だけ更新でき、同値上書き (冪等 redo) も無害。
+      if (auto * existing = ui_->PoiTable->item(row, col)) {
+        existing->setText(text);
+      } else {
+        ui_->PoiTable->setItem(row, col, new QTableWidgetItem(text));
+      }
+      // 編集済みの視覚マーク (通常編集の green 着色に合わせる)。
+      if (auto * item = ui_->PoiTable->item(row, col)) {
+        item->setBackground(Qt::green);
+      }
+      // shadow を書き換え後の値に同期する (次の cellChanged 差分計算の基準を更新)。
+      if (row < static_cast<int>(shadow_.size()) &&
+          col < static_cast<int>(shadow_[row].size())) {
+        shadow_[row][col] = text;
+      }
     }
   }
-  applying_undo_ = false;
   // 名前セルの undo/redo は TableChanged と同じくその行のフィルタを再評価する (#405 整合)。
   // undo で名前を戻したら隠れていた行が再表示される / redo で非一致になれば隠れる、を
   // 通常編集と揃える。applying_undo_ を戻した後に呼ぶ (setRowHidden は cellChanged 非発火)。
@@ -273,19 +284,20 @@ void PoiEditorPanel::ApplyInsertRow(int row, const std::vector<QString> & texts)
   // 行挿入 (New/Copy の redo、Delete の undo)。insertRow は cellChanged を確実には
   // 発火しないが、setItem 経由の cellChanged が飛ぶ可能性があるため applying_undo_ で
   // 抑制する (二重コマンド化・dirty の重複計上を防ぐ)。
-  applying_undo_ = true;
-  ui_->PoiTable->insertRow(row);
-  for (int col = 0; col < kColCount && col < static_cast<int>(texts.size()); ++col) {
-    ui_->PoiTable->setItem(row, col, new QTableWidgetItem(texts[col]));
+  {
+    const QScopedValueRollback<bool> guard(applying_undo_, true);  // 例外安全 (PR #426 review)
+    ui_->PoiTable->insertRow(row);
+    for (int col = 0; col < kColCount && col < static_cast<int>(texts.size()); ++col) {
+      ui_->PoiTable->setItem(row, col, new QTableWidgetItem(texts[col]));
+    }
+    // shadow に行を挿入して以降の差分計算の基準を保つ。
+    if (row >= 0 && row <= static_cast<int>(shadow_.size())) {
+      std::vector<QString> shadow_row(texts.begin(),
+        texts.begin() + std::min(texts.size(), static_cast<size_t>(kColCount)));
+      shadow_row.resize(kColCount);
+      shadow_.insert(shadow_.begin() + row, std::move(shadow_row));
+    }
   }
-  // shadow に行を挿入して以降の差分計算の基準を保つ。
-  if (row >= 0 && row <= static_cast<int>(shadow_.size())) {
-    std::vector<QString> shadow_row(texts.begin(),
-      texts.begin() + std::min(texts.size(), static_cast<size_t>(kColCount)));
-    shadow_row.resize(kColCount);
-    shadow_.insert(shadow_.begin() + row, std::move(shadow_row));
-  }
-  applying_undo_ = false;
   table_dirty_ = true;
   // 挿入行は名前フィルタで再評価しない (#405 の「New/Copy の新規行はフィルタ非一致でも
   // デフォルト可視」意図を維持)。Delete の undo による行復元でも復元行を可視で戻すことで
@@ -298,14 +310,15 @@ void PoiEditorPanel::ApplyRemoveRow(int row)
 {
   // 行削除 (Delete の redo、New/Copy の undo)。removeRow は cellChanged を発火しないが、
   // 対称性のため applying_undo_ で括る。shadow からも同じ行を落とす。
-  applying_undo_ = true;
-  if (row >= 0 && row < ui_->PoiTable->rowCount()) {
-    ui_->PoiTable->removeRow(row);
+  {
+    const QScopedValueRollback<bool> guard(applying_undo_, true);  // 例外安全 (PR #426 review)
+    if (row >= 0 && row < ui_->PoiTable->rowCount()) {
+      ui_->PoiTable->removeRow(row);
+    }
+    if (row >= 0 && row < static_cast<int>(shadow_.size())) {
+      shadow_.erase(shadow_.begin() + row);
+    }
   }
-  if (row >= 0 && row < static_cast<int>(shadow_.size())) {
-    shadow_.erase(shadow_.begin() + row);
-  }
-  applying_undo_ = false;
   table_dirty_ = true;
   ui_->SaveButton->setText("save");
   ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
@@ -319,9 +332,10 @@ void PoiEditorPanel::ApplyMoveSection(int from_visual, int to_visual)
   // を抑制する。moveSection は visual index 基準 (logical は不変) なので shadow は
   // 触らない (shadow は logical row の内容ミラーであり visual 並びに依存しない — #405 の
   // 名前フィルタが logical 基準なのと同じ扱い)。
-  applying_undo_ = true;
-  ui_->PoiTable->verticalHeader()->moveSection(from_visual, to_visual);
-  applying_undo_ = false;
+  {
+    const QScopedValueRollback<bool> guard(applying_undo_, true);  // 例外安全 (PR #426 review)
+    ui_->PoiTable->verticalHeader()->moveSection(from_visual, to_visual);
+  }
   table_dirty_ = true;
   ui_->SaveButton->setText("save");
   ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");

--- a/mapoi_rviz_plugins/src/poi_editor_table.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_table.cpp
@@ -1,0 +1,478 @@
+// PoiEditorPanel のテーブル編集系ハンドラと Undo/Redo 基盤 (#407)。
+//
+// このファイルは 2 つの責務を 1 TU にまとめる:
+//   (A) #397 step 9: ResetButton / TableChanged / NewButton / CopyButton /
+//       DeleteButton / RowMoved / FileComboBox を poi_editor.cpp から機械的に移設。
+//   (B) #407: QUndoStack ベースの Undo/Redo (行追加 New / 複製 Copy / 削除 Delete /
+//       セル編集 / 行並べ替え RowMoved の 5 操作をコマンド化)。
+//
+// step 9 を先行分割せず本 issue と統合したのは、Undo/Redo がこの 7 slot のブロックを
+// 丸ごと QUndoCommand 化で書き換えるため、分割 → 即作り直しの二度手間を避ける狙い
+// (#397 step 9 の記述・#407 提案どおり)。
+//
+// QUndoCommand サブクラス群は TU 内 file-local (無名 namespace) とし、hpp の公開面を
+// 増やさない (#407 設計)。コマンドは panel の protected メンバへ直接触らず、hpp に最小限
+// 追加した「適用ヘルパー member 関数」(Apply*) 経由でテーブルを書き換える。
+#include "mapoi_rviz_plugins/poi_editor.hpp"
+#include "mapoi_rviz_plugins/poi_editor_helpers.hpp"
+
+#include <algorithm>  // std::min (ApplyInsertRow の shadow_row clamp)
+#include <utility>    // std::move (コマンドへのテキスト move)
+#include <vector>
+
+#include <QFileDialog>
+#include <QShortcut>
+#include <QUndoCommand>
+#include <QUndoStack>
+
+// generated UI header: PoiEditorPanel::ui_ (`Ui::PoiEditorUi*`) は poi_editor.hpp では
+// 前方宣言のみなので、`ui_->PoiTable` 等の完全型アクセスにはこの include が要る
+// (poi_editor_save.cpp / poi_editor_validation.cpp と同じ)。
+#include "ui_poi_editor.h"
+
+namespace mapoi_rviz_plugins
+{
+
+// PoiTable column index 定数は poi_editor_helpers.hpp に集約 (#158 で導入)。
+using detail::kColName;
+using detail::kColPose;
+using detail::kColTolerance;
+using detail::kColTags;
+using detail::kColDescription;
+using detail::kColCount;
+
+// ---------------------------------------------------------------------------
+// QUndoCommand サブクラス群 (#407)
+// ---------------------------------------------------------------------------
+// いずれも TU 内 file-local (無名 namespace)。panel の protected メンバへは触らず、
+// hpp に追加した適用ヘルパー (ApplyInsertRow / ApplyRemoveRow / ApplySetCell /
+// ApplyMoveSection) 経由でテーブルを書き換える。ヘルパー側で applying_undo_ を立てて
+// cellChanged / sectionMoved の再入を抑制し、shadow model も同期する (下記参照)。
+//
+// 各コマンドは undo/redo に必要な最小の値 (行 index・列・old/new テキスト・行の全 cell
+// テキスト) を自前で保持する。QTableWidgetItem のポインタは Qt がテーブル操作時に破棄・
+// 再生成するため保持せず、常に「行 index + テキスト」で持つ。
+namespace
+{
+
+// 行全体 (kColCount 列) のテキストを保持する軽量な行スナップショット。
+using RowTexts = std::vector<QString>;
+
+// セル 1 個の編集 (#407)。TableChanged が shadow との差分から old/new を得て生成する。
+// redo = new を書き込む、undo = old を書き戻す。行構造は変えないため index は不変。
+class EditCellCommand : public QUndoCommand
+{
+public:
+  EditCellCommand(PoiEditorPanel * panel, int row, int col,
+                  QString old_text, QString new_text)
+  : panel_(panel), row_(row), col_(col),
+    old_text_(std::move(old_text)), new_text_(std::move(new_text))
+  {
+    setText(QObject::tr("edit cell"));
+  }
+
+  void undo() override { panel_->ApplySetCell(row_, col_, old_text_); }
+  void redo() override { panel_->ApplySetCell(row_, col_, new_text_); }
+
+private:
+  PoiEditorPanel * panel_;
+  int row_;
+  int col_;
+  QString old_text_;
+  QString new_text_;
+};
+
+// 行追加 (New) / 複製 (Copy) 共通。redo = row_ に texts_ の行を挿入、undo = row_ を削除。
+// New は "new_poi" 既定行、Copy は複製元行のテキストを texts_ に持つ (生成側で構築)。
+class InsertRowCommand : public QUndoCommand
+{
+public:
+  InsertRowCommand(PoiEditorPanel * panel, int row, RowTexts texts, const QString & label)
+  : panel_(panel), row_(row), texts_(std::move(texts))
+  {
+    setText(label);
+  }
+
+  void undo() override { panel_->ApplyRemoveRow(row_); }
+  void redo() override { panel_->ApplyInsertRow(row_, texts_); }
+
+private:
+  PoiEditorPanel * panel_;
+  int row_;
+  RowTexts texts_;
+};
+
+// 行削除 (Delete)。redo = row_ を削除、undo = row_ に texts_ を挿入 (削除前の全 cell
+// テキストを保持しておき復元)。生成側で削除前に行テキストをキャプチャする。
+class RemoveRowCommand : public QUndoCommand
+{
+public:
+  RemoveRowCommand(PoiEditorPanel * panel, int row, RowTexts texts)
+  : panel_(panel), row_(row), texts_(std::move(texts))
+  {
+    setText(QObject::tr("delete row"));
+  }
+
+  void undo() override { panel_->ApplyInsertRow(row_, texts_); }
+  void redo() override { panel_->ApplyRemoveRow(row_); }
+
+private:
+  PoiEditorPanel * panel_;
+  int row_;
+  RowTexts texts_;
+};
+
+// 行並べ替え (RowMoved)。verticalHeader()->moveSection の逆適用で undo する (#407 §8)。
+// sectionMoved は (logicalIndex, oldVisual, newVisual) を渡すので、redo = old→new、
+// undo = new→old へ moveSection する。moveSection の再入抑制も適用ヘルパー側で行う。
+//
+// 他コマンド (Insert/Remove) と非対称な点: New/Copy/Delete slot は「push するだけ・実操作は
+// redo」設計なので QUndoStack::push が呼ぶ初回 redo() が実操作を担う。一方 RowMoved は
+// sectionMoved シグナル由来 = ユーザーが既にドラッグで移動を完了した後に発火するため、
+// push 時の初回 redo() で再度 moveSection(old→new) すると二重移動になる。first_redo_ で
+// 初回 redo() のみ実 moveSection をスキップする (以降の redo = やり直しでは実行する)。
+class MoveRowCommand : public QUndoCommand
+{
+public:
+  MoveRowCommand(PoiEditorPanel * panel, int old_visual, int new_visual)
+  : panel_(panel), old_visual_(old_visual), new_visual_(new_visual)
+  {
+    setText(QObject::tr("move row"));
+  }
+
+  void undo() override { panel_->ApplyMoveSection(new_visual_, old_visual_); }
+  void redo() override
+  {
+    // 初回 redo (= push 時) は既にユーザー操作で移動済みなので実行しない (二重移動防止)。
+    // dirty / 着色 / SaveButton 文言は RowMoved slot 側で付与済み。
+    if (first_redo_) {
+      first_redo_ = false;
+      return;
+    }
+    panel_->ApplyMoveSection(old_visual_, new_visual_);
+  }
+
+private:
+  PoiEditorPanel * panel_;
+  int old_visual_;
+  int new_visual_;
+  bool first_redo_ = true;
+};
+
+// 指定行の全 cell テキストを取り出す (Copy の複製元・Delete の復元用スナップショット)。
+RowTexts CaptureRowTexts(QTableWidget * table, int row)
+{
+  RowTexts texts;
+  texts.reserve(kColCount);
+  for (int col = 0; col < kColCount; ++col) {
+    auto * item = table->item(row, col);
+    texts.push_back(item ? item->text() : QString());
+  }
+  return texts;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Undo/Redo 基盤の初期化・適用ヘルパー (#407)
+// ---------------------------------------------------------------------------
+
+void PoiEditorPanel::SetupUndoRedo()
+{
+  // QUndoStack は panel が親 (QObject 所有権) なので明示 delete 不要。
+  undo_stack_ = new QUndoStack(this);
+
+  // ショートカット (#407 §7)。context は WidgetWithChildrenShortcut にして、パネル
+  // (と子ウィジェット) に focus がある時だけ有効化する。RViz 全体のキーマップと衝突させない
+  // (issue 要件)。QKeySequence::Undo = Ctrl+Z、Redo = Ctrl+Shift+Z (プラットフォーム標準)。
+  auto * undo_shortcut = new QShortcut(QKeySequence::Undo, this);
+  undo_shortcut->setContext(Qt::WidgetWithChildrenShortcut);
+  connect(undo_shortcut, &QShortcut::activated, undo_stack_, &QUndoStack::undo);
+
+  auto * redo_shortcut = new QShortcut(QKeySequence::Redo, this);
+  redo_shortcut->setContext(Qt::WidgetWithChildrenShortcut);
+  connect(redo_shortcut, &QShortcut::activated, undo_stack_, &QUndoStack::redo);
+
+  // dirty 連携 (#407 §6, #399)。undo で編集前 (clean) に戻ったら未保存ガードを解除する。
+  // WebUI の「undo で clean に戻るとガード解除」(beforeunload.e2e.js の
+  // "undo back to clean removes the guard again") と同じ意味論。clean=false へ移る
+  // (= 編集が入る) 側は既存の table_dirty_ 手動 set が担うため、ここでは clean へ戻った
+  // 時だけ dirty=false にする (既存 dirty set は不変のまま連携させる)。
+  connect(undo_stack_, &QUndoStack::cleanChanged, this, [this](bool clean) {
+    if (clean) {
+      table_dirty_ = false;
+    }
+  });
+}
+
+void PoiEditorPanel::RebuildShadowModel()
+{
+  // shadow model の (再) 構築 (#407 §3)。テーブル内容のミラーを持ち、cellChanged 時に
+  // shadow との差分から old 値を得る (QTableWidget の cellChanged は旧値を渡さないため)。
+  // UpdatePoiTable / TagFilterChanged の全再構築時に取り直す (呼び出しは各所から)。
+  const int rows = ui_->PoiTable->rowCount();
+  const int cols = ui_->PoiTable->columnCount();
+  shadow_.assign(rows, std::vector<QString>(cols));
+  for (int r = 0; r < rows; ++r) {
+    for (int c = 0; c < cols; ++c) {
+      auto * item = ui_->PoiTable->item(r, c);
+      shadow_[r][c] = item ? item->text() : QString();
+    }
+  }
+}
+
+void PoiEditorPanel::ApplySetCell(int row, int col, const QString & text)
+{
+  // コマンドの undo()/redo() からのセル書き換え。applying_undo_ を立てて cellChanged→
+  // TableChanged の再入 (dirty 再 set・二重コマンド化) を抑制する (#407 §4)。
+  // 既存の is_table_color_ ガード (再構築中の cellChanged を弾く) とは目的が異なるので
+  // 別フラグで共存させる (is_table_color_ は着色/dirty の可否、applying_undo_ は
+  // コマンド適用中の TableChanged 全処理スキップ)。
+  applying_undo_ = true;
+  if (row >= 0 && row < ui_->PoiTable->rowCount()) {
+    // 既存 item があれば setText で更新する (setItem による delete/再生成を避ける)。
+    // push 時の初回 redo() は cellChanged ハンドラ (TableChanged) の呼び出し中に走るため、
+    // シグナルを発火させた item 自体を破棄すると再入安全性が脆くなる。setText なら
+    // item 実体を保ったまま値だけ更新でき、同値上書き (冪等 redo) も無害。
+    if (auto * existing = ui_->PoiTable->item(row, col)) {
+      existing->setText(text);
+    } else {
+      ui_->PoiTable->setItem(row, col, new QTableWidgetItem(text));
+    }
+    // 編集済みの視覚マーク (通常編集の green 着色に合わせる)。
+    if (auto * item = ui_->PoiTable->item(row, col)) {
+      item->setBackground(Qt::green);
+    }
+    // shadow を書き換え後の値に同期する (次の cellChanged 差分計算の基準を更新)。
+    if (row < static_cast<int>(shadow_.size()) &&
+        col < static_cast<int>(shadow_[row].size())) {
+      shadow_[row][col] = text;
+    }
+  }
+  applying_undo_ = false;
+  // 名前セルの undo/redo は TableChanged と同じくその行のフィルタを再評価する (#405 整合)。
+  // undo で名前を戻したら隠れていた行が再表示される / redo で非一致になれば隠れる、を
+  // 通常編集と揃える。applying_undo_ を戻した後に呼ぶ (setRowHidden は cellChanged 非発火)。
+  if (col == kColName) {
+    ApplyNameFilterToRow(row);
+  }
+  // dirty / SaveButton 表示はコマンド適用でも通常編集と同じく更新する。
+  // 順序保証 (#407 §6): QUndoStack::undo() は「command->undo() 実行 → index 更新 →
+  // cleanChanged emit」の順で走る。ここ (command->undo() 内) で table_dirty_=true にしても、
+  // その直後の cleanChanged(true) が table_dirty_=false へ上書きするため、最後の 1 手を
+  // undo して clean に戻った時は最終的に dirty=false になる (WebUI の「undo で clean に
+  // 戻るとガード解除」と一致)。まだ手が残る undo なら clean にならず dirty=true が残る。
+  table_dirty_ = true;
+  ui_->SaveButton->setText("save");
+  ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
+  UpdatePoiCount();
+}
+
+void PoiEditorPanel::ApplyInsertRow(int row, const std::vector<QString> & texts)
+{
+  // 行挿入 (New/Copy の redo、Delete の undo)。insertRow は cellChanged を確実には
+  // 発火しないが、setItem 経由の cellChanged が飛ぶ可能性があるため applying_undo_ で
+  // 抑制する (二重コマンド化・dirty の重複計上を防ぐ)。
+  applying_undo_ = true;
+  ui_->PoiTable->insertRow(row);
+  for (int col = 0; col < kColCount && col < static_cast<int>(texts.size()); ++col) {
+    ui_->PoiTable->setItem(row, col, new QTableWidgetItem(texts[col]));
+  }
+  // shadow に行を挿入して以降の差分計算の基準を保つ。
+  if (row >= 0 && row <= static_cast<int>(shadow_.size())) {
+    std::vector<QString> shadow_row(texts.begin(),
+      texts.begin() + std::min(texts.size(), static_cast<size_t>(kColCount)));
+    shadow_row.resize(kColCount);
+    shadow_.insert(shadow_.begin() + row, std::move(shadow_row));
+  }
+  applying_undo_ = false;
+  table_dirty_ = true;
+  // 挿入行は名前フィルタで再評価しない (#405 の「New/Copy の新規行はフィルタ非一致でも
+  // デフォルト可視」意図を維持)。Delete の undo による行復元でも復元行を可視で戻すことで
+  // ユーザーが編集を継続できる (元の New/Copy がフィルタ処理を持たなかったのと同じ挙動)。
+  // insertRow は非表示状態を継承しないため既定で可視になる。
+  UpdatePoiCount();
+}
+
+void PoiEditorPanel::ApplyRemoveRow(int row)
+{
+  // 行削除 (Delete の redo、New/Copy の undo)。removeRow は cellChanged を発火しないが、
+  // 対称性のため applying_undo_ で括る。shadow からも同じ行を落とす。
+  applying_undo_ = true;
+  if (row >= 0 && row < ui_->PoiTable->rowCount()) {
+    ui_->PoiTable->removeRow(row);
+  }
+  if (row >= 0 && row < static_cast<int>(shadow_.size())) {
+    shadow_.erase(shadow_.begin() + row);
+  }
+  applying_undo_ = false;
+  table_dirty_ = true;
+  ui_->SaveButton->setText("save");
+  ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
+  UpdatePoiCount();
+}
+
+void PoiEditorPanel::ApplyMoveSection(int from_visual, int to_visual)
+{
+  // 行並べ替えの適用 (RowMoved のコマンド化、#407 §8)。verticalHeader()->moveSection は
+  // sectionMoved を発火するため、applying_undo_ で RowMoved slot の再入 (二重コマンド化)
+  // を抑制する。moveSection は visual index 基準 (logical は不変) なので shadow は
+  // 触らない (shadow は logical row の内容ミラーであり visual 並びに依存しない — #405 の
+  // 名前フィルタが logical 基準なのと同じ扱い)。
+  applying_undo_ = true;
+  ui_->PoiTable->verticalHeader()->moveSection(from_visual, to_visual);
+  applying_undo_ = false;
+  table_dirty_ = true;
+  ui_->SaveButton->setText("save");
+  ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
+}
+
+// ---------------------------------------------------------------------------
+// テーブル編集系 slot (#397 step 9 で poi_editor.cpp から移設 + #407 でコマンド化)
+// ---------------------------------------------------------------------------
+
+void PoiEditorPanel::ResetButton()
+{
+  PoiEditorPanel::UpdatePoiTable();
+}
+
+void PoiEditorPanel::TableChanged(int row, int column)
+{
+  // コマンドの undo()/redo() 由来の setItem では applying_undo_ が立っている。この時は
+  // dirty 再 set・二重コマンド化・着色を全てスキップする (適用ヘルパー側が dirty/着色/
+  // SaveButton を一括更新するため、ここで重ねない — #407 §4)。
+  if (applying_undo_) {
+    return;
+  }
+
+  if(is_table_color_){
+    ui_->PoiTable->item(row, column)->setBackground(Qt::green);
+    // ユーザー編集の dirty マーク (#399)。UpdatePoiTable / TagFilterChanged の再構築中は
+    // is_table_color_=false で setItem 由来の cellChanged が飛ぶため、既存の green 着色ガードに
+    // 相乗りしてユーザー編集だけを拾う (再構築由来の cellChanged では dirty を立てない)。
+    table_dirty_ = true;
+
+    // セル編集のコマンド化 (#407 §3)。cellChanged は旧値を渡さないため shadow model との
+    // 差分から old 値を得てコマンドを push し、shadow を新値へ更新する。値が変わっていない
+    // (old == new) 場合はコマンドを積まない (フィルタ再評価等で発火する空 cellChanged を弾く)。
+    auto * item = ui_->PoiTable->item(row, column);
+    const QString new_text = item ? item->text() : QString();
+    QString old_text;
+    if (row < static_cast<int>(shadow_.size()) &&
+        column < static_cast<int>(shadow_[row].size())) {
+      old_text = shadow_[row][column];
+    }
+    if (undo_stack_ && old_text != new_text) {
+      // shadow を先に更新してから push する。EditCellCommand の redo() は生成直後に
+      // QUndoStack::push が呼ぶが、その redo() は ApplySetCell(new_text) で「既に new_text
+      // が入っている」テーブルへ同じ値を上書きするだけ (冪等) なので副作用は無い。
+      shadow_[row][column] = new_text;
+      undo_stack_->push(new EditCellCommand(this, row, column, old_text, new_text));
+    }
+
+    if (column == kColName) {
+      // 名前セルの編集確定時はその行だけ名前フィルタを再評価する (#405、PR #420 review)。
+      // 一致しなくなった行は編集確定と同時に隠れる (絞り込み表示の一貫性を優先)。
+      ApplyNameFilterToRow(row);
+    }
+  }
+  ui_->SaveButton->setText("save");
+  ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
+  UpdatePoiCount();
+}
+
+void PoiEditorPanel::NewButton()
+{
+  int current_row = ui_->PoiTable->currentRow();
+  int new_row = current_row + 1;
+  // column 構造 (#158): name / pose / tolerance "xy m, yaw rad" / tags / description
+  RowTexts texts = {
+    QStringLiteral("new_poi"),
+    QStringLiteral("0.0, 0.0, 0.0"),
+    QStringLiteral("0.5, 0.7854"),  // ≒ π/4 rad
+    QString(),
+    QString(),
+  };
+  // コマンド化 (#407)。redo() = ApplyInsertRow が実際の挿入・dirty set・shadow 更新を行う。
+  // insertRow / setItem は cellChanged を確実には発火しないため dirty はヘルパー側で明示 set (#399)。
+  if (undo_stack_) {
+    undo_stack_->push(new InsertRowCommand(this, new_row, std::move(texts),
+      QObject::tr("add row")));
+  }
+}
+
+void PoiEditorPanel::CopyButton()
+{
+  int current_row = ui_->PoiTable->currentRow();
+  if (current_row < 0) return;
+  int new_row = current_row + 1;
+  // 複製元行の全 cell テキストを持ってコマンド化 (#407)。redo() = ApplyInsertRow。
+  RowTexts texts = CaptureRowTexts(ui_->PoiTable, current_row);
+  if (undo_stack_) {
+    undo_stack_->push(new InsertRowCommand(this, new_row, std::move(texts),
+      QObject::tr("copy row")));
+  }
+}
+
+void PoiEditorPanel::DeleteButton()
+{
+  int current_row = ui_->PoiTable->currentRow();
+  // 選択行なし (-1) の早期 return を追加 (#407)。元は removeRow(-1) が Qt 側で no-op に
+  // なるだけだったが、コマンド化すると空の RemoveRowCommand が積まれて dirty が立つため
+  // 明示的に弾く (元挙動「選択なしなら何も起きない」を維持。CopyButton と同じガード)。
+  if (current_row < 0) return;
+  // 削除前に行の全 cell テキストをキャプチャしてコマンド化 (#407)。undo() でこのテキストを
+  // 同 index へ復元する。removeRow は cellChanged を発火しないため dirty はヘルパー側で明示 set (#399)。
+  RowTexts texts = CaptureRowTexts(ui_->PoiTable, current_row);
+  if (undo_stack_) {
+    undo_stack_->push(new RemoveRowCommand(this, current_row, std::move(texts)));
+  }
+}
+
+void PoiEditorPanel::RowMoved(int logicalIndex, int oldVisualIndex, int newVisualIndex){
+  // コマンドの undo()/redo() 由来の moveSection では applying_undo_ が立っているため
+  // 二重コマンド化を抑制する (#407 §4/§8)。
+  if (applying_undo_) {
+    return;
+  }
+  // ユーザー操作由来の並べ替え。逆適用できるよう old/new visual index でコマンド化する。
+  // undo() = new→old、redo() (やり直し) = old→new へ moveSection。push 時の初回 redo() は
+  // MoveRowCommand::first_redo_ で実 moveSection をスキップする (既にドラッグで移動済み)。
+  if (undo_stack_) {
+    undo_stack_->push(new MoveRowCommand(this, oldVisualIndex, newVisualIndex));
+  }
+  // 着色・dirty・SaveButton 文言はこの slot で付与する (初回 redo が実操作を伴わないため
+  // ApplyMoveSection には委ねない)。着色は従来通り logicalIndex 基準 — item() は logical
+  // 行アクセスなので、visual index を渡すと並び替え後は別の行を着色してしまう。
+  int numCols = ui_->PoiTable->columnCount();
+  for (int col = 0; col < numCols; col++){
+    if (auto * item = ui_->PoiTable->item(logicalIndex, col)) {
+      item->setBackground(Qt::green);
+    }
+  }
+  // sectionMoved は cellChanged を発火しないため dirty を明示 set (#399)。
+  table_dirty_ = true;
+  ui_->SaveButton->setText("save");
+  ui_->SaveButton->setStyleSheet("QPushButton {background-color: white; color: black;}");
+}
+
+void PoiEditorPanel::FileComboBox()
+{
+  int last = ui_->FileComboBox->count() - 1;
+  if(ui_->FileComboBox->currentIndex() == last){
+    QString filename = QFileDialog::getOpenFileName(
+        this, tr("Select a poi_file"), QString::fromStdString(config_path_), tr("YAML files(*.yaml)"));
+    if(filename == ""){
+      ui_->FileComboBox->setItemText(last, "the other");
+      ui_->FileComboBox->setCurrentIndex(0);
+    }else{
+      ui_->FileComboBox->setItemText(last, filename);
+    }
+  } else{
+    int last2 = ui_->FileComboBox->count() - 1;
+    ui_->FileComboBox->setItemText(last2, "the other");
+  }
+  ui_->SaveButton->setText("save");
+}
+
+}  // namespace mapoi_rviz_plugins

--- a/mapoi_rviz_plugins/src/poi_editor_tags.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_tags.cpp
@@ -4,6 +4,9 @@
 #include "mapoi_rviz_plugins/poi_editor.hpp"
 #include "mapoi_rviz_plugins/poi_editor_helpers.hpp"
 
+// undo_stack_->clear() の呼び出しに完全型が要る (hpp は前方宣言のみ、#407)。
+#include <QUndoStack>
+
 // generated UI header: PoiEditorPanel::ui_ (`Ui::PoiEditorUi*`) は poi_editor.hpp では
 // 前方宣言のみなので、`ui_->TagFilterComboBox` 等の完全型アクセスにはこの include が要る
 // (poi_editor_save.cpp / poi_editor_validation.cpp と同じ)。
@@ -69,6 +72,15 @@ void PoiEditorPanel::TagFilterChanged(int index)
   // タグフィルタはまずタグ一致行を setRowCount(0) で再構築し、その後 名前フィルタが
   // setRowHidden で絞り込む。つまり「タグ AND 名前」の併用絞り込みになる。
   ApplyNameFilter();
+
+  // Undo/Redo (#407): タグフィルタの適用は setRowCount(0) で行を丸ごと入れ替えるため、
+  // 行 index を握る既存履歴が崩れる。UpdatePoiTable の全再構築と同じ理由で undo stack を
+  // clear し、shadow model をフィルタ後のテーブルで取り直す (index <= 0 の解除パスは
+  // UpdatePoiTable を呼ぶのでそちらで clear + 取り直し済み)。
+  if (undo_stack_) {
+    undo_stack_->clear();
+  }
+  RebuildShadowModel();
 }
 
 void PoiEditorPanel::PopulateTagFilter()


### PR DESCRIPTION
Closes #407

## 目的

編集の取り消し手段が ResetButton による全破棄のみで、誤削除 1 回のために全編集を捨てるしかなかった (WebUI は capture-before-mutate 方式実装済みの非対称)。あわせて #397 step 9 (poi_editor_table.cpp 分割) を統合実施し、**#397 の全 9 step が完了**。

## 変更

- **QUndoStack ベースで 5 操作をコマンド化** (New / Copy / Delete / セル編集 / 行並べ替え)。コマンドは新 TU `poi_editor_table.cpp` 内 file-local とし、hpp には最小限の適用ヘルパー (Apply* 4 種) のみ公開
- **セル編集の旧値キャプチャ**: cellChanged は旧値を渡さないため shadow model (テーブル内容ミラー) との差分でコマンド化。同値変更はコマンド化しない
- **シグナル再入抑制**: `applying_undo_` フラグで undo/redo 適用中の cellChanged/sectionMoved 由来の二重コマンド化・dirty 重複を抑制 (既存 is_table_color_ ガードと目的別に共存)
- **履歴の生存範囲 (安全側)**: UpdatePoiTable / TagFilterChanged の全再構築で stack clear (行 index 前提が崩れた履歴を残さない)。名前フィルタ (#405、setRowHidden) は行を消さないため履歴と共存
- **dirty (#399) 連携**: `cleanChanged` で clean 復帰時に table_dirty_=false (WebUI の「undo で clean に戻るとガード解除」と同じ意味論)。**保存成功時は stack を clear** (保存 = 履歴境界。1.5 秒後の再構築で履歴が消える以上、保存後 undo は錯乱窓にしかならないため — レビュー対応で setClean から変更)。副次: タグフィルタ適用時の stack clear で dirty=false になるが、その時点で編集は既に再構築で破棄済みのため、従来「消えた編集に対して確認ダイアログが出る」誤検出がむしろ解消される
- **ショートカット**: Ctrl+Z / Ctrl+Shift+Z (QKeySequence 標準)。`Qt::WidgetWithChildrenShortcut` でパネル focus 時のみ有効 (RViz キーマップと非衝突、issue 要件)
- **#397 step 9**: ResetButton / TableChanged / New / Copy / Delete / RowMoved / FileComboBox を新 TU へ移設 (既存処理 — green 着色・dirty set・kColName 行再評価・SaveButton 文言リセット — は維持)
- MoveRowCommand は「push 時の初回 redo をスキップ」する非対称設計 (sectionMoved はドラッグ完了後に発火するため二重移動を防ぐ)。RowMoved の着色は従来通り logicalIndex 基準
- DeleteButton に選択なし (-1) の早期 return を追加 (空コマンド積み防止、元の no-op 挙動は不変)
- server 改修なし・新規購読/timer なし・in-memory 編集のみ

## 検証

- humble / jazzy 両 Docker で colcon build 通過、gtest 165 ケース全パス
