### PR TITLE
fix(rviz): pose 反映の列 index を kColPose に修正 (#427)

### DIFF
--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -166,7 +166,7 @@ void PoiEditorPanel::PoiPoseCallback(geometry_msgs::msg::PoseStamped::SharedPtr 
   QMetaObject::invokeMethod(this, [this, txt]() {
     int current_row = ui_->PoiTable->currentRow();
     if (current_row >= 0) {
-      ui_->PoiTable->setItem(current_row, 2, new QTableWidgetItem(txt));
+      ui_->PoiTable->setItem(current_row, kColPose, new QTableWidgetItem(txt));
     }
   }, Qt::QueuedConnection);
 }


### PR DESCRIPTION
Closes #427

## 目的

Set Mapoi Pose ツールの pose 反映が PoiEditor の tolerance 列 (index 2) に書き込まれ、pose 列が更新されない上、tolerance セルが 3 要素文字列になって保存時に必ず validation エラーになっていた。

## 変更

- `PoiPoseCallback` の `setItem(current_row, 2, ...)` の列 index literal `2` を `kColPose` に修正 (1 行)。#158 の列再編 (pose 列 2→1) で唯一変換漏れしていた箇所
- ハイライト・dirty・undo 履歴は `cellChanged` 経由の既存機構がそのまま処理するため他の変更なし。repo 全体 grep で列 index literal の残存は本箇所のみであることを確認済み

## 検証

- humble / jazzy 両 Docker で colcon build + colcon test (233 tests) 通過