### PR TITLE
fix(rviz): タグフィルタ変更に未保存編集ガードを追加 (#428)

### DIFF
--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -108,6 +108,13 @@ protected:
   // Tag filter: store all POIs to restore when filter is cleared
   std::vector<mapoi_interfaces::msg::PointOfInterest> all_pois_;
 
+  // 最後にテーブルへ適用したタグフィルタの index (#428)。TagFilterComboBox の activated は
+  // 同じ項目を選び直しても発火するため、これと突き合わせて no-op を弾き、dirty ガードを
+  // かける (判定は detail::decide_tag_filter_change)。0 = "All" (フィルタ無し)。
+  // PopulateTagFilter が combo を "All" (index 0) に再構築するタイミングで 0 にリセットする。
+  // UI (Qt メイン) スレッド上でのみ触るためロック不要。
+  int applied_tag_filter_index_ = 0;
+
   // Tag definitions from server
   std::vector<std::string> known_tag_names_;
   std::vector<bool> known_tag_is_system_;

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
@@ -238,6 +238,41 @@ inline ConfigReloadGuardDecision decide_config_reload_guard(
   return ConfigReloadGuardDecision::kProceed;
 }
 
+// PoiEditorPanel::TagFilterChanged の未保存編集ガード判定 (#428)。
+// タグフィルタ combo の activated(int) は同じ項目を選び直しても発火し、フィルタ適用は
+// 行を setRowCount(0) で丸ごと入れ替えて undo_stack_->clear() するため、未保存編集を
+// 無警告で破棄してしまう (#399 の decide_config_reload_guard は config_path 変更経路のみ
+// カバー)。current index / 適用済み index / dirty から、UI が「何もしない / 確認ダイアログ /
+// そのまま適用」のいずれを取るべきかを判定する純関数。Qt 非依存 (呼び出し側が結果を
+// QMessageBox 表示 + combo revert へ写像する)。
+enum class TagFilterChangeDecision
+{
+  kNoop,      // 適用済みと同じ index の再選択 (フィルタ結果不変なので何もしない)
+  kAskUser,   // 未保存編集ありのため確認ダイアログを出す
+  kProceed,   // そのままフィルタを適用する
+};
+
+// current_index : combo の activated で通知された選択 index
+// applied_index : 最後にテーブルへ適用したフィルタ index (member で追跡)
+// table_dirty   : UI スレッド上のユーザー編集有無 (未保存編集ガードの主軸)
+inline TagFilterChangeDecision decide_tag_filter_change(
+  int current_index,
+  int applied_index,
+  bool table_dirty)
+{
+  // 同一 index の再選択はフィルタ結果が変わらないので何もしない (dirty でも問わない)。
+  // activated は同じ項目を選び直しただけでも発火するため冒頭で弾く。
+  if (current_index == applied_index) {
+    return TagFilterChangeDecision::kNoop;
+  }
+  // 未保存編集がある状態でのフィルタ変更は、破棄可否をユーザーに確認する。
+  if (table_dirty) {
+    return TagFilterChangeDecision::kAskUser;
+  }
+  // dirty でなければそのまま適用する (サーバ状態は変えず表示行を絞るだけ)。
+  return TagFilterChangeDecision::kProceed;
+}
+
 // PoiEditorPanel::SaveButton の外部変更検出判定 (#399)。保存先ファイルが baseline (最後に
 // テーブルへ読み込んだ / 保存した時点の内容) と食い違う場合に上書き確認を出すべきかを返す。
 // WebUI の expected_version 楽観ロック相当のクライアント側実装で、config_version の厳密共有は

--- a/mapoi_rviz_plugins/src/poi_editor_tags.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_tags.cpp
@@ -29,7 +29,37 @@ using detail::kColDescription;
 // Tag Filter
 void PoiEditorPanel::TagFilterChanged(int index)
 {
+  // 未保存編集ガード (#428)。current index / 適用済み index / dirty から純関数で判定する
+  // (#399 の decide_config_reload_guard と同型)。callback はこの判定を no-op / 確認ダイアログ /
+  // フィルタ適用へ写像するだけ。フィルタ適用は setRowCount(0) の行入れ替え + undo_stack_->clear()
+  // で未保存編集を復元不能に破棄するため、config_path 経路と同様にガードが要る。
+  const auto decision = detail::decide_tag_filter_change(
+    index, applied_tag_filter_index_, table_dirty_);
+
+  if (decision == detail::TagFilterChangeDecision::kNoop) {
+    // 適用済みと同じ index の再選択 (activated は選び直しでも発火する) は何もしない。
+    return;
+  }
+  if (decision == detail::TagFilterChangeDecision::kAskUser) {
+    // 未保存編集がある状態でのフィルタ変更。破棄可否をユーザーに確認する。
+    const auto answer = QMessageBox::question(
+      this, tr("Unsaved Edits"),
+      tr("There are unsaved edits. Discard them and change the tag filter?"),
+      QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    if (answer != QMessageBox::Yes) {
+      // 「編集を継続」: combo の選択を適用済み index に戻して何もしない。setCurrentIndex は
+      // activated を発火しないが currentIndexChanged は飛ぶため blockSignals で確実に抑制し、
+      // シグナル再発火 (この slot の再入や将来配線される slot) を防ぐ。
+      const bool blocked = ui_->TagFilterComboBox->blockSignals(true);
+      ui_->TagFilterComboBox->setCurrentIndex(applied_tag_filter_index_);
+      ui_->TagFilterComboBox->blockSignals(blocked);
+      return;
+    }
+    // 「破棄して変更」: 従来通りフィルタ適用へ進む (以降で undo stack を clear する)。
+  }
+
   if (index <= 0) {
+    // "All" 選択: 全再構築 (PopulateTagFilter が applied_tag_filter_index_ を 0 にリセットする)。
     UpdatePoiTable();
     return;
   }
@@ -81,6 +111,9 @@ void PoiEditorPanel::TagFilterChanged(int index)
     undo_stack_->clear();
   }
   RebuildShadowModel();
+
+  // 適用完了。以後この index の再選択は decide_tag_filter_change の kNoop で弾く (#428)。
+  applied_tag_filter_index_ = index;
 }
 
 void PoiEditorPanel::PopulateTagFilter()
@@ -99,6 +132,10 @@ void PoiEditorPanel::PopulateTagFilter()
   for (const auto& tag : unique_tags) {
     ui_->TagFilterComboBox->addItem(QString::fromStdString(tag));
   }
+  // combo を "All" (index 0) に再構築した = フィルタ無し状態に戻ったので追跡を同期する (#428)。
+  // clear()/addItem() は activated を発火しないため TagFilterChanged は呼ばれず、
+  // UpdatePoiTable (全再構築 = 全 POI 表示) と applied index が食い違わないようここで揃える。
+  applied_tag_filter_index_ = 0;
 }
 
 void PoiEditorPanel::LoadTagDefinitions()

--- a/mapoi_rviz_plugins/test/test_poi_editor_helpers.cpp
+++ b/mapoi_rviz_plugins/test/test_poi_editor_helpers.cpp
@@ -16,6 +16,9 @@ using mapoi_rviz_plugins::detail::ConfigPathUpdateAction;
 using mapoi_rviz_plugins::detail::ConfigReloadGuardDecision;
 using mapoi_rviz_plugins::detail::decide_config_reload_guard;
 using mapoi_rviz_plugins::detail::should_confirm_overwrite;
+// タグフィルタ変更の未保存編集ガード判定 (#428)
+using mapoi_rviz_plugins::detail::TagFilterChangeDecision;
+using mapoi_rviz_plugins::detail::decide_tag_filter_change;
 
 // 自由関数化した helpers (#397 step 8)
 using mapoi_rviz_plugins::detail::calc_yaw;
@@ -217,6 +220,60 @@ TEST(DecideConfigReloadGuard, NoopTakesPrecedenceOverDialogOpen)
     decide_config_reload_guard(
       ConfigPathUpdateAction::Noop, true, true),
     ConfigReloadGuardDecision::kProceed);
+}
+
+// --- decide_tag_filter_change (#428) ---
+//
+// TagFilterChanged はタグフィルタ combo の activated 時に、この判定を no-op /
+// 確認ダイアログ / フィルタ適用へ写像するだけ。current×applied×dirty の分岐表をここで
+// pin し、未保存編集を黙って捨てる回帰 (no-op 判定の抜け・dirty ガードの反転等) を安く捕える。
+
+TEST(DecideTagFilterChange, SameIndexIsNoop)
+{
+  // 適用済みと同じ index の再選択は何もしない (dirty でなくても)。
+  EXPECT_EQ(
+    decide_tag_filter_change(2, 2, false),
+    TagFilterChangeDecision::kNoop);
+}
+
+TEST(DecideTagFilterChange, SameIndexIsNoopEvenWhenDirty)
+{
+  // 同一 index はフィルタ結果が変わらないので dirty でも問わず no-op (無駄な確認を出さない)。
+  EXPECT_EQ(
+    decide_tag_filter_change(2, 2, true),
+    TagFilterChangeDecision::kNoop);
+}
+
+TEST(DecideTagFilterChange, DifferentIndexNotDirtyProceeds)
+{
+  // 未保存編集なし + index 変化: そのまま適用する。
+  EXPECT_EQ(
+    decide_tag_filter_change(1, 0, false),
+    TagFilterChangeDecision::kProceed);
+}
+
+TEST(DecideTagFilterChange, DifferentIndexDirtyAsksUser)
+{
+  // 未保存編集あり + index 変化: 破棄可否を確認する。
+  EXPECT_EQ(
+    decide_tag_filter_change(1, 0, true),
+    TagFilterChangeDecision::kAskUser);
+}
+
+TEST(DecideTagFilterChange, ChangeToAllNotDirtyProceeds)
+{
+  // フィルタ解除 (index 0 = "All") への変化も dirty でなければそのまま適用。
+  EXPECT_EQ(
+    decide_tag_filter_change(0, 3, false),
+    TagFilterChangeDecision::kProceed);
+}
+
+TEST(DecideTagFilterChange, ChangeToAllDirtyAsksUser)
+{
+  // フィルタ解除も table を丸ごと再構築するため、dirty なら確認する。
+  EXPECT_EQ(
+    decide_tag_filter_change(0, 3, true),
+    TagFilterChangeDecision::kAskUser);
 }
 
 // --- should_confirm_overwrite (#399) ---


### PR DESCRIPTION
Closes #428

## 目的

タグフィルタ combo の操作が未保存編集 (セル編集・行追加・行削除) を無警告で破棄し、`undo_stack_->clear()` により Ctrl+Z でも復元不能だった。`activated(int)` 直結のため同じタグを選び直しただけでも発火していた。

## 変更

- 判定を純関数 `detail::decide_tag_filter_change(current_index, applied_index, table_dirty)` → `kNoop / kAskUser / kProceed` に切り出し (#399 の `decide_config_reload_guard` と同型)、`TagFilterChanged` は結果を写像するだけに
- **同一 index 再選択の no-op 化**: 最後に適用したフィルタ index をメンバ `applied_tag_filter_index_` で追跡し、一致なら即 return
- **dirty ガード**: 未保存編集がある状態でのフィルタ変更は確認ダイアログ (Yes/No、default No)。No なら combo を適用済み index に戻して現状維持 (blockSignals で再入防御)
- 追跡 index は フィルタ適用完了時に更新、combo を "All" に再構築する `PopulateTagFilter` で 0 にリセット (combo を変える他経路が無いことは grep で確認)
- `decide_tag_filter_change` の分岐表を pin する gtest 6 ケース追加

## 検証

- humble / jazzy 両 Docker で colcon build + colcon test (239 tests, +6) 通過