### PR TITLE
fix(rviz): Save 時の YAML::LoadFile に例外ガードを追加 (#429)

### DIFF
--- a/mapoi_rviz_plugins/src/poi_editor_save.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_save.cpp
@@ -79,7 +79,18 @@ void PoiEditorPanel::SaveButton()
 
   int numRows = ui_->PoiTable->rowCount();
 
-  YAML::Node map_info = YAML::LoadFile(ui_->FileComboBox->itemText(0).toStdString());
+  // #429: 保存対象 YAML が読めない (placeholder "file to save" のまま到達 / 外部で削除・破損)
+  // 場合に YAML::BadFile / ParserException が未捕捉のまま漏れると RViz ごと落ちるため、
+  // 他の Save Error 系ダイアログ (open for writing / write failure) と同じパターンで捕捉する。
+  YAML::Node map_info;
+  try {
+    map_info = YAML::LoadFile(ui_->FileComboBox->itemText(0).toStdString());
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(LOGGER, "Failed to load map YAML file: %s", e.what());
+    QMessageBox::critical(this, tr("Save Error"),
+      tr("Failed to load the map YAML file:\n%1").arg(QString::fromStdString(e.what())));
+    return;
+  }
   std::vector<YAML::Node> pois_list;
 
   for (int row = 0; row < numRows; row++) {


### PR DESCRIPTION
Closes #429

## 目的

SaveButton の `YAML::LoadFile` が try/catch 無しで、保存対象が読めない/不正 YAML の場合 (サービス timeout 後の placeholder 項目のまま Save 到達、外部でのファイル削除・破損) に例外が Qt slot から漏れて RViz ごとクラッシュし得た。

## 変更

- `YAML::LoadFile` を try/catch (`std::exception`、yaml-cpp の例外は全て派生) で包み、例外時は既存の Save Error 系パターン (`QMessageBox::critical` + `tr()`) でエラー表示して early return
- 他のファイル I/O (ifstream/ofstream) は既にエラーチェック済みのため変更なし

## 検証

- humble / jazzy 両 Docker で colcon build + colcon test (233 tests) 通過