### PR TITLE
fix(rviz): is_table_color_ を確定初期化し shadow_ に境界ガード (#432)

### DIFF
--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -82,7 +82,7 @@ protected:
   std::string current_map_;
   std::string config_path_;
   std::vector<std::string> map_name_list_;
-  bool is_table_color_;
+  bool is_table_color_ = false;
 
   // Undo/Redo 基盤 (#407)。いずれも UI (Qt メイン) スレッド上でのみ触るためロック不要。
   //

--- a/mapoi_rviz_plugins/src/poi_editor_table.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_table.cpp
@@ -376,7 +376,11 @@ void PoiEditorPanel::TableChanged(int row, int column)
         column < static_cast<int>(shadow_[row].size())) {
       old_text = shadow_[row][column];
     }
-    if (undo_stack_ && old_text != new_text) {
+    // shadow_ 未構築 (行/列がまだ無い) 状態での書き込みは範囲外アクセスになるため、
+    // ApplySetCell (:258-260) と同型の境界チェックで弾く (#432)。
+    if (undo_stack_ && old_text != new_text &&
+        row < static_cast<int>(shadow_.size()) &&
+        column < static_cast<int>(shadow_[row].size())) {
       // shadow を先に更新してから push する。EditCellCommand の redo() は生成直後に
       // QUndoStack::push が呼ぶが、その redo() は ApplySetCell(new_text) で「既に new_text
       // が入っている」テーブルへ同じ値を上書きするだけ (冪等) なので副作用は無い。


### PR DESCRIPTION
Closes #432

## 目的

`is_table_color_` が未初期化のまま、サービス未接続/timeout で `onInitialize`/`UpdatePoiTable` が early return すると一度も代入されず、セル編集時の挙動が不定値に依存 (UB)。不定値が true と読まれると未構築の `shadow_` への範囲外書き込み → クラッシュ/ヒープ破壊の可能性があった。

## 変更

- `poi_editor.hpp` で `bool is_table_color_ = false;` に確定初期化 (`applying_undo_`/`table_dirty_` と同スタイル)
- `TableChanged` の shadow_ 書き込み + undo コマンド push に `ApplySetCell` と同型の境界チェックを追加 (二重防御)

## 検証

- humble / jazzy 両 Docker で colcon build + colcon test (233 tests) 通過