### PR TITLE
fix(rviz): 実態のないソートインジケータ表示を削除 (#433)

### DIFF
--- a/mapoi_rviz_plugins/src/poi_editor.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor.cpp
@@ -359,8 +359,7 @@ void PoiEditorPanel::UpdatePoiTable()
                   << tr("tolerance (xy, yaw)") << tr("tags") << tr("description"));
   ui_->PoiTable->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
   ui_->PoiTable->verticalHeader()->setSectionsMovable(true);
-  ui_->PoiTable->horizontalHeader()->setSortIndicatorShown(true);
-  ui_->PoiTable->horizontalHeader()->setSortIndicator(0, Qt::AscendingOrder);
+  // ソートは有効化しない (undo/shadow/save が論理 index 前提) (#433)
 
   is_table_color_ = false;
   for (size_t row = 0; row < numRows; row++){


### PR DESCRIPTION
Closes #433

## 目的

PoiTable のヘッダに常時「name 列 昇順ソート」のインジケータが表示されるが、`setSortingEnabled` は package 内に存在せずソートは一切効いていない。行順は YAML 順 + ドラッグ並べ替えであり、表示が実際の行順序を偽っていた。

## 変更

- `UpdatePoiTable` の `setSortIndicatorShown(true)` / `setSortIndicator(0, Qt::AscendingOrder)` の 2 行を削除し、「ソートは有効化しない (undo/shadow/save が論理 index 前提)」のコメントに置換
- ソートの有効化は不可 (undo/shadow/save 機構が論理 index 前提) のため、インジケータ削除が正しい修正

## 検証

- humble / jazzy 両 Docker で colcon build + colcon test (233 tests) 通過