### PR TITLE
fix(rviz): New/Copy の挿入位置を視覚順基準に修正 (#434)

### DIFF
--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -60,7 +60,12 @@ public:
   // コマンド化・dirty 重複) を抑制し、shadow model を同期する。実装・詳細コメントは
   // poi_editor_table.cpp。
   void ApplySetCell(int row, int col, const QString & text);
-  void ApplyInsertRow(int row, const std::vector<QString> & texts);
+  // visual_ref_row (#434): >= 0 の時、挿入後に新規行を logical `visual_ref_row` 行の視覚直下へ
+  // moveSection する (New/Copy 経路が選択行の logical index を渡す)。-1 (既定) なら視覚移動しない
+  // = 行削除 undo の再挿入はこちらで、visual 位置を既定に戻す #426 の既知制限を維持する。
+  // visual_ref_row は挿入 (row 位置) で index がずれない行 (< row) であること。New/Copy は
+  // row = current_row + 1 なので visual_ref_row = current_row < row を満たす。
+  void ApplyInsertRow(int row, const std::vector<QString> & texts, int visual_ref_row = -1);
   void ApplyRemoveRow(int row);
   void ApplyMoveSection(int from_visual, int to_visual);
 

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
@@ -34,25 +34,6 @@ constexpr int kColTags = 3;
 constexpr int kColDescription = 4;
 constexpr int kColCount = 5;
 
-// PoiEditorPanel の New/Copy 行挿入 (#434) の視覚移動先を求める純関数。Qt 非依存。
-// 行ドラッグで視覚順 (visual) ≠ 論理順 (logical) に並べ替え済みのテーブルで New/Copy すると、
-// 挿入行は Qt の section 挿入規則で選択行と無関係な視覚位置に現れる。これを選択行の視覚直下へ
-// moveSection するための移動先 visual index を返す。
-//
-//   inserted_visual: 挿入直後の新規行の現在 visual index
-//   ref_visual     : 直上に置きたい選択行の現在 visual index
-//   (両者は別の行なので inserted_visual != ref_visual を前提)
-//
-// QHeaderView::moveSection(from, to) は「visual from の section を取り除き、残り列の中で
-// visual to の位置へ挿し込む」意味論。選択行の直後 (ref_visual+1) に入れたいが、取り除く行が
-// 選択行より上 (inserted_visual < ref_visual) の場合は除去で選択行が 1 つ繰り上がるため、
-// 移動先は ref_visual のまま。選択行より下 (inserted_visual > ref_visual) から動かす場合のみ
-// +1 する。これで inserted_visual の位置に依らず「選択行の視覚直下」に収まる。
-inline int insert_move_target_visual(int inserted_visual, int ref_visual)
-{
-  return ref_visual + (inserted_visual > ref_visual ? 1 : 0);
-}
-
 // 文字列を strict に double に parse し、有限性を確認する純関数 (Codex review #139 medium 対応)。
 // std::stod は "1abc" を 1 として返し NaN/Inf も throw しないため、validation と save で
 // 同じ parser を使うために helper にする。min check は呼び出し側の責任。
@@ -343,6 +324,25 @@ inline std::vector<std::string> split_sentence(std::string sentence, std::string
   words.push_back(last_word);
 
   return words;
+}
+
+// PoiEditorPanel の New/Copy 行挿入 (#434) の視覚移動先を求める純関数。Qt 非依存。
+// 行ドラッグで視覚順 (visual) ≠ 論理順 (logical) に並べ替え済みのテーブルで New/Copy すると、
+// 挿入行は Qt の section 挿入規則で選択行と無関係な視覚位置に現れる。これを選択行の視覚直下へ
+// moveSection するための移動先 visual index を返す。
+//
+//   inserted_visual: 挿入直後の新規行の現在 visual index
+//   ref_visual     : 直上に置きたい選択行の現在 visual index
+//   (両者は別の行なので inserted_visual != ref_visual を前提)
+//
+// QHeaderView::moveSection(from, to) は「visual from の section を取り除き、残り列の中で
+// visual to の位置へ挿し込む」意味論。選択行の直後 (ref_visual+1) に入れたいが、取り除く行が
+// 選択行より上 (inserted_visual < ref_visual) の場合は除去で選択行が 1 つ繰り上がるため、
+// 移動先は ref_visual のまま。選択行より下 (inserted_visual > ref_visual) から動かす場合のみ
+// +1 する。これで inserted_visual の位置に依らず「選択行の視覚直下」に収まる。
+inline int insert_move_target_visual(int inserted_visual, int ref_visual)
+{
+  return ref_visual + (inserted_visual > ref_visual ? 1 : 0);
 }
 
 }  // namespace mapoi_rviz_plugins::detail

--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor_helpers.hpp
@@ -34,6 +34,25 @@ constexpr int kColTags = 3;
 constexpr int kColDescription = 4;
 constexpr int kColCount = 5;
 
+// PoiEditorPanel の New/Copy 行挿入 (#434) の視覚移動先を求める純関数。Qt 非依存。
+// 行ドラッグで視覚順 (visual) ≠ 論理順 (logical) に並べ替え済みのテーブルで New/Copy すると、
+// 挿入行は Qt の section 挿入規則で選択行と無関係な視覚位置に現れる。これを選択行の視覚直下へ
+// moveSection するための移動先 visual index を返す。
+//
+//   inserted_visual: 挿入直後の新規行の現在 visual index
+//   ref_visual     : 直上に置きたい選択行の現在 visual index
+//   (両者は別の行なので inserted_visual != ref_visual を前提)
+//
+// QHeaderView::moveSection(from, to) は「visual from の section を取り除き、残り列の中で
+// visual to の位置へ挿し込む」意味論。選択行の直後 (ref_visual+1) に入れたいが、取り除く行が
+// 選択行より上 (inserted_visual < ref_visual) の場合は除去で選択行が 1 つ繰り上がるため、
+// 移動先は ref_visual のまま。選択行より下 (inserted_visual > ref_visual) から動かす場合のみ
+// +1 する。これで inserted_visual の位置に依らず「選択行の視覚直下」に収まる。
+inline int insert_move_target_visual(int inserted_visual, int ref_visual)
+{
+  return ref_visual + (inserted_visual > ref_visual ? 1 : 0);
+}
+
 // 文字列を strict に double に parse し、有限性を確認する純関数 (Codex review #139 medium 対応)。
 // std::stod は "1abc" を 1 として返し NaN/Inf も throw しないため、validation と save で
 // 同じ parser を使うために helper にする。min check は呼び出し側の責任。

--- a/mapoi_rviz_plugins/src/poi_editor_table.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_table.cpp
@@ -316,7 +316,9 @@ void PoiEditorPanel::ApplyInsertRow(int row, const std::vector<QString> & texts,
     // ずれず、visualIndex(visual_ref_row) で選択行の現在 visual を得られる。moveSection は
     // sectionMoved を発火するが applying_undo_ 中なので RowMoved slot は早期 return し
     // 二重コマンド化しない (この guard ブロック内で実行するのが要件)。
-    if (visual_ref_row >= 0) {
+    // visual_ref_row < row も条件で強制する (ヘッダ記載の事前条件)。満たさない呼び出しは
+    // 挿入で参照行の logical がずれ誤った行の直下へ移動し得るため、視覚移動なしへ縮退させる。
+    if (visual_ref_row >= 0 && visual_ref_row < row) {
       auto * vheader = ui_->PoiTable->verticalHeader();
       const int inserted_visual = vheader->visualIndex(row);
       const int ref_visual = vheader->visualIndex(visual_ref_row);

--- a/mapoi_rviz_plugins/src/poi_editor_table.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_table.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <QFileDialog>
+#include <QHeaderView>  // verticalHeader()->visualIndex / moveSection (#434, ApplyInsertRow の視覚移動)
 #include <QScopedValueRollback>
 #include <QShortcut>
 #include <QUndoCommand>
@@ -85,22 +86,30 @@ private:
 
 // 行追加 (New) / 複製 (Copy) 共通。redo = row_ に texts_ の行を挿入、undo = row_ を削除。
 // New は "new_poi" 既定行、Copy は複製元行のテキストを texts_ に持つ (生成側で構築)。
+//
+// visual_ref_ (#434): 選択行の logical index。redo() で ApplyInsertRow に渡し、視覚順を
+// 並べ替え済みのテーブルでも新規行を選択行の視覚直下へ moveSection する。視覚移動は redo 経路
+// (ApplyInsertRow) に置くため、undo→redo のやり直しでも同じ視覚位置に再現される。undo は
+// ApplyRemoveRow が挿入した section をそのまま除去するため、視覚移動の明示的な逆適用は不要
+// (残り行の相対視覚順は removeRow で保たれる)。選択なし (New で -1) は視覚移動しない。
 class InsertRowCommand : public QUndoCommand
 {
 public:
-  InsertRowCommand(PoiEditorPanel * panel, int row, RowTexts texts, const QString & label)
-  : panel_(panel), row_(row), texts_(std::move(texts))
+  InsertRowCommand(PoiEditorPanel * panel, int row, RowTexts texts, const QString & label,
+                   int visual_ref)
+  : panel_(panel), row_(row), texts_(std::move(texts)), visual_ref_(visual_ref)
   {
     setText(label);
   }
 
   void undo() override { panel_->ApplyRemoveRow(row_); }
-  void redo() override { panel_->ApplyInsertRow(row_, texts_); }
+  void redo() override { panel_->ApplyInsertRow(row_, texts_, visual_ref_); }
 
 private:
   PoiEditorPanel * panel_;
   int row_;
   RowTexts texts_;
+  int visual_ref_;
 };
 
 // 行削除 (Delete)。redo = row_ を削除、undo = row_ に texts_ を挿入 (削除前の全 cell
@@ -112,6 +121,9 @@ private:
 // visualIndex のキャプチャ + moveSection 逆適用が要るが、複合エッジ (並び替え+削除+undo) の
 // 頻度に対して複雑化が見合わないため割り切る。保存後の UpdatePoiTable 再構築で visual =
 // logical に正規化される点は従来通り。
+// なお New/Copy の挿入は #434 で選択行の視覚直下へ揃えるようにしたが、これは RemoveRowCommand の
+// undo (再挿入) には及ぼさない — ApplyInsertRow を visual_ref_row = -1 (既定) で呼ぶため、上記の
+// 削除 undo の視覚挙動 (既定に戻る) はこれまで通り。
 class RemoveRowCommand : public QUndoCommand
 {
 public:
@@ -279,7 +291,7 @@ void PoiEditorPanel::ApplySetCell(int row, int col, const QString & text)
   UpdatePoiCount();
 }
 
-void PoiEditorPanel::ApplyInsertRow(int row, const std::vector<QString> & texts)
+void PoiEditorPanel::ApplyInsertRow(int row, const std::vector<QString> & texts, int visual_ref_row)
 {
   // 行挿入 (New/Copy の redo、Delete の undo)。insertRow は cellChanged を確実には
   // 発火しないが、setItem 経由の cellChanged が飛ぶ可能性があるため applying_undo_ で
@@ -296,6 +308,24 @@ void PoiEditorPanel::ApplyInsertRow(int row, const std::vector<QString> & texts)
         texts.begin() + std::min(texts.size(), static_cast<size_t>(kColCount)));
       shadow_row.resize(kColCount);
       shadow_.insert(shadow_.begin() + row, std::move(shadow_row));
+    }
+    // #434: New/Copy 経路 (visual_ref_row >= 0) は、視覚順を並べ替え済みのテーブルでも
+    // 新規行が選択行の視覚直下に来るよう moveSection する。Qt は挿入 section の視覚位置を
+    // 選択行と無関係に決めるため、挿入後の実 visual index を読んで移動先を計算する。
+    // visual_ref_row (= 選択行 logical) は row = 選択行+1 なので insertRow で index が
+    // ずれず、visualIndex(visual_ref_row) で選択行の現在 visual を得られる。moveSection は
+    // sectionMoved を発火するが applying_undo_ 中なので RowMoved slot は早期 return し
+    // 二重コマンド化しない (この guard ブロック内で実行するのが要件)。
+    if (visual_ref_row >= 0) {
+      auto * vheader = ui_->PoiTable->verticalHeader();
+      const int inserted_visual = vheader->visualIndex(row);
+      const int ref_visual = vheader->visualIndex(visual_ref_row);
+      if (inserted_visual >= 0 && ref_visual >= 0) {
+        const int target = detail::insert_move_target_visual(inserted_visual, ref_visual);
+        if (inserted_visual != target) {
+          vheader->moveSection(inserted_visual, target);
+        }
+      }
     }
   }
   table_dirty_ = true;
@@ -409,9 +439,11 @@ void PoiEditorPanel::NewButton()
   };
   // コマンド化 (#407)。redo() = ApplyInsertRow が実際の挿入・dirty set・shadow 更新を行う。
   // insertRow / setItem は cellChanged を確実には発火しないため dirty はヘルパー側で明示 set (#399)。
+  // current_row (#434): 選択行の logical index を渡し、視覚順並べ替え済みでも新規行を選択行の
+  // 視覚直下へ揃える。選択なし (current_row == -1) は視覚移動せず従来挙動を維持する。
   if (undo_stack_) {
     undo_stack_->push(new InsertRowCommand(this, new_row, std::move(texts),
-      QObject::tr("add row")));
+      QObject::tr("add row"), current_row));
   }
 }
 
@@ -421,10 +453,12 @@ void PoiEditorPanel::CopyButton()
   if (current_row < 0) return;
   int new_row = current_row + 1;
   // 複製元行の全 cell テキストを持ってコマンド化 (#407)。redo() = ApplyInsertRow。
+  // current_row (#434): 複製元 (選択行) の logical index を渡し、複製行を選択行の視覚直下へ
+  // 揃える。ここでは current_row >= 0 が保証済み (上のガード) なので必ず視覚移動する。
   RowTexts texts = CaptureRowTexts(ui_->PoiTable, current_row);
   if (undo_stack_) {
     undo_stack_->push(new InsertRowCommand(this, new_row, std::move(texts),
-      QObject::tr("copy row")));
+      QObject::tr("copy row"), current_row));
   }
 }
 

--- a/mapoi_rviz_plugins/test/test_poi_editor_helpers.cpp
+++ b/mapoi_rviz_plugins/test/test_poi_editor_helpers.cpp
@@ -22,6 +22,9 @@ using mapoi_rviz_plugins::detail::calc_yaw;
 using mapoi_rviz_plugins::detail::join;
 using mapoi_rviz_plugins::detail::split_sentence;
 
+// New/Copy の視覚移動先計算 (#434)
+using mapoi_rviz_plugins::detail::insert_move_target_visual;
+
 // --- split_and_trim ---
 
 TEST(SplitAndTrim, BasicTwoParts)
@@ -400,4 +403,37 @@ TEST(SplitSentence, RoundTripWithJoin)
   EXPECT_EQ(split_sentence(join(tags, ", "), ", "), tags);
   const std::string joined = "a, b, c";
   EXPECT_EQ(join(split_sentence(joined, ", "), ", "), joined);
+}
+
+// --- insert_move_target_visual (#434) ---
+
+TEST(InsertMoveTargetVisual, InsertedBelowRefKeepsRefPosition)
+{
+  // 新規行が選択行より下 (inserted > ref) にある場合: moveSection で取り除いても選択行の
+  // 位置は不変なので、直後 (ref+1) が移動先。例: 選択行 visual 0、挿入行 visual 3 → 1。
+  EXPECT_EQ(insert_move_target_visual(3, 0), 1);
+  EXPECT_EQ(insert_move_target_visual(2, 1), 2);
+}
+
+TEST(InsertMoveTargetVisual, InsertedAboveRefShiftsRefUp)
+{
+  // 新規行が選択行より上 (inserted < ref) にある場合: 取り除くと選択行が 1 つ繰り上がるため、
+  // 移動先は ref のまま (= 繰り上がった選択行の直後)。例: 選択行 visual 2、挿入行 visual 0 → 2。
+  EXPECT_EQ(insert_move_target_visual(0, 2), 2);
+  EXPECT_EQ(insert_move_target_visual(1, 3), 3);
+}
+
+TEST(InsertMoveTargetVisual, AdjacentBelowIsNoOpTarget)
+{
+  // 既に選択行の直下 (inserted == ref+1) にある場合、移動先も同じ値 = 実質 no-op。
+  // 並べ替え未実施 (visual==logical) の New/Copy がこのケースに落ちて挙動不変になる。
+  EXPECT_EQ(insert_move_target_visual(2, 1), 2);  // inserted は移動不要
+  EXPECT_EQ(insert_move_target_visual(1, 0), 1);
+}
+
+TEST(InsertMoveTargetVisual, RefAtBottomStaysAtBottom)
+{
+  // 選択行が視覚最下段 (ref) で挿入行がその上にある場合、移動先 = ref (最下段) となり
+  // 範囲外にならない (N+1 行なら最大 visual index = N = ref)。
+  EXPECT_EQ(insert_move_target_visual(0, 3), 3);
 }


### PR DESCRIPTION
Closes #434

## 目的

行ドラッグ並べ替え後 (visual 順 ≠ logical 順) に New/Copy すると、新規行が選択行の直下でなく離れた位置に出現していた。挿入位置が `currentRow()+1` (logical) で計算され、visual→logical の変換が挿入経路に無かったため。Save は visual 順で永続化するため、誤認による連打で重複行が YAML に書かれる実害があった。

## 変更

- `ApplyInsertRow` に `visual_ref_row` (既定 -1) を追加し、`>= 0` の時は挿入後に新規行を選択行の視覚直下へ `moveSection`。New/Copy 経路が選択行の logical index を渡す
- 視覚移動は redo 経路 (`ApplyInsertRow`) に置き、undo→redo のやり直しでも同じ視覚位置に再現。undo は `ApplyRemoveRow` が section をそのまま除去し残り行の相対視覚順が保たれるため、明示的な逆適用は不要
- **行削除 undo の再挿入は既定値 (-1) のまま** = #426 の既知制限 (削除 undo で視覚位置が既定に戻る) は不変。コメントに対比を明記
- `moveSection(from, to)` の remove-then-insert 意味論による +1 補正 (挿入行が選択行より下の時のみ +1) を純関数 `insert_move_target_visual` に切り出し、gtest 4 件でピン留め
- moveSection は `applying_undo_` ガード内で実行し、`sectionMoved`→`RowMoved` の二重コマンド化を防止

## 検証

- humble / jazzy 両 Docker で colcon build + colcon test (237 tests, +4) 通過
- 論理確認: 選択なし New (視覚移動なし・従来挙動) / 並べ替え未実施 (target 一致で no-op・挙動不変) / 選択行が視覚最下段 (範囲外にならない)