### PR TITLE
fix(rviz): Undo で値が基準へ戻ったセルの緑着色を解除 (#445)

### DIFF
--- a/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
+++ b/mapoi_rviz_plugins/include/mapoi_rviz_plugins/poi_editor.hpp
@@ -110,6 +110,15 @@ protected:
   // TagFilterChanged の全再構築後に RebuildShadowModel で取り直す (行 index 前提を揃える)。
   std::vector<std::vector<QString>> shadow_;
 
+  // 編集済みマーク (緑着色) の基準スナップショット (#445)。「緑 = clean 状態 (最後の全再構築 /
+  // 保存時点) とテキストが異なるセル」に意味を揃えるための比較基準。shadow_ が「直前値
+  // (cellChanged 差分検出用、編集のたび更新)」なのに対し、こちらは clean 状態のまま保つ。
+  // RebuildShadowModel で shadow_ と同時に取り直し、保存成功時は保存内容 (= shadow_) へ
+  // 同期、行挿入/削除 (ApplyInsertRow/ApplyRemoveRow) で行単位に index を揃える (挿入行の
+  // 基準は挿入時テキスト = 従来の「挿入行は無着色」挙動を維持)。外部変更検出用の
+  // baseline_path_/baseline_content_ (ファイル内容スナップショット) とは別物。
+  std::vector<std::vector<QString>> clean_texts_;
+
   // Tag filter: store all POIs to restore when filter is cleared
   std::vector<mapoi_interfaces::msg::PointOfInterest> all_pois_;
 
@@ -198,10 +207,19 @@ protected:
   // Undo/Redo 基盤の初期化と shadow model の (再) 構築 (#407)。定義は poi_editor_table.cpp。
   // SetupUndoRedo: QUndoStack 生成・ショートカット配線・cleanChanged↔dirty 連携。onInitialize
   //   から一度だけ呼ぶ (テーブル系 connect 後・初回 UpdatePoiTable 前)。
-  // RebuildShadowModel: shadow_ を現在のテーブル内容で作り直す。全再構築 (UpdatePoiTable /
-  //   TagFilterChanged) の末尾で呼び、cellChanged 差分計算の基準を揃える。
+  // RebuildShadowModel: shadow_ (と着色基準 clean_texts_、#445) を現在のテーブル内容で
+  //   作り直す。全再構築 (UpdatePoiTable / TagFilterChanged) の末尾で呼び、cellChanged
+  //   差分計算・着色判定の基準を揃える。
   void SetupUndoRedo();
   void RebuildShadowModel();
+  // 編集済みマーク (緑着色) の再計算 (#445)。セル テキストを clean_texts_ と比較し、一致なら
+  // 着色解除 (既定背景)・不一致なら緑にする。通常編集 (TableChanged) と undo/redo 適用
+  // (ApplySetCell) の両経路から呼ぶ。定義は poi_editor_table.cpp。
+  void RefreshCellEditMark(int row, int col);
+  // 全セルの編集済みマークを解除する (#445)。undo stack が clean へ戻った時
+  // (cleanChanged(true)) に呼び、テキスト比較では検出できない行並べ替え (RowMoved) 由来の
+  // 行着色もまとめて掃除する。定義は poi_editor_table.cpp。
+  void ClearAllEditMarks();
   void UpdatePoiCount();
   void PopulateTagFilter();
   void LoadTagDefinitions();

--- a/mapoi_rviz_plugins/src/poi_editor_save.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_save.cpp
@@ -177,6 +177,10 @@ void PoiEditorPanel::SaveButton()
   table_dirty_ = false;
   baseline_path_ = save_path;
   baseline_content_ = out.c_str();
+  // 着色基準 (#445) も保存内容 (= 現在のテーブル内容をミラーする shadow_) へ同期する。
+  // 1.5 秒後の UpdatePoiTable 再構築 (RebuildShadowModel) を待たずに、保存直後の編集が
+  // 「保存値との差分」で正しく着色されるようにする (baseline_content_ の即時更新と同旨)。
+  clean_texts_ = shadow_;
 
   // Undo/Redo (#407): 保存成功 = 履歴境界として undo stack を clear する (PR #426 review)。
   // setClean で履歴を残しても、1.5 秒後の UpdatePoiTable 全再構築で stack は消えるため

--- a/mapoi_rviz_plugins/src/poi_editor_save.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_save.cpp
@@ -180,7 +180,11 @@ void PoiEditorPanel::SaveButton()
   // 着色基準 (#445) も保存内容 (= 現在のテーブル内容をミラーする shadow_) へ同期する。
   // 1.5 秒後の UpdatePoiTable 再構築 (RebuildShadowModel) を待たずに、保存直後の編集が
   // 「保存値との差分」で正しく着色されるようにする (baseline_content_ の即時更新と同旨)。
+  // 緑着色の解除も下の undo_stack_->clear() の cleanChanged(true) 経由に頼らず明示する
+  // (QUndoStack::clear は既に clean な stack では cleanChanged を emit しないため、
+  // 経路依存を残さない — PR #447 review)。二重実行は冪等で無害。
   clean_texts_ = shadow_;
+  ClearAllEditMarks();
 
   // Undo/Redo (#407): 保存成功 = 履歴境界として undo stack を clear する (PR #426 review)。
   // setClean で履歴を残しても、1.5 秒後の UpdatePoiTable 全再構築で stack は消えるため

--- a/mapoi_rviz_plugins/src/poi_editor_table.cpp
+++ b/mapoi_rviz_plugins/src/poi_editor_table.cpp
@@ -20,6 +20,7 @@
 #include <utility>    // std::move (コマンドへのテキスト move)
 #include <vector>
 
+#include <QBrush>  // 編集済みマークの着色/解除 (#445, RefreshCellEditMark / ClearAllEditMarks)
 #include <QFileDialog>
 #include <QHeaderView>  // verticalHeader()->visualIndex / moveSection (#434, ApplyInsertRow の視覚移動)
 #include <QScopedValueRollback>
@@ -230,6 +231,11 @@ void PoiEditorPanel::SetupUndoRedo()
   // 時だけ dirty=false にする (既存 dirty set は不変のまま連携させる)。
   connect(undo_stack_, &QUndoStack::cleanChanged, this, [this](bool clean) {
     if (clean) {
+      // clean へ戻った = テーブルは基準状態 (#445)。編集済みマークを全解除する。undo で
+      // 戻った場合、行並べ替え (RowMoved) 由来の行着色はテキスト比較 (RefreshCellEditMark)
+      // では検出できないため、ここでまとめて掃除する。保存成功・全再構築の stack clear
+      // 経由でも走るが無害 (どちらも着色なしへ向かう状態)。
+      ClearAllEditMarks();
       table_dirty_ = false;
     }
   });
@@ -247,6 +253,43 @@ void PoiEditorPanel::RebuildShadowModel()
     for (int c = 0; c < cols; ++c) {
       auto * item = ui_->PoiTable->item(r, c);
       shadow_[r][c] = item ? item->text() : QString();
+    }
+  }
+  // 着色基準 (#445) も同時に取り直す。全再構築直後のテーブルは clean 状態 (無着色) であり、
+  // ここを基準に「テキストが基準と異なるセルだけ緑」を判定する。
+  clean_texts_ = shadow_;
+}
+
+void PoiEditorPanel::RefreshCellEditMark(int row, int col)
+{
+  // 「緑 = clean 基準とテキストが異なるセル」(#445)。基準に一致したら既定背景へ戻す
+  // (QBrush() は「brush 未設定」= スタイル既定色に委ねる)。基準が無い範囲 (通常は無いが
+  // 防御的に) は従来どおり緑側に倒す。setBackground は同値なら dataChanged を発火しない
+  // (Qt 5.12+ の setData 同値 early-return) ため冪等。
+  auto * item = ui_->PoiTable->item(row, col);
+  if (!item) {
+    return;
+  }
+  bool matches_clean = false;
+  if (row >= 0 && row < static_cast<int>(clean_texts_.size()) &&
+      col >= 0 && col < static_cast<int>(clean_texts_[row].size())) {
+    matches_clean = (clean_texts_[row][col] == item->text());
+  }
+  item->setBackground(matches_clean ? QBrush() : QBrush(Qt::green));
+}
+
+void PoiEditorPanel::ClearAllEditMarks()
+{
+  // setBackground は cellChanged (dataChanged) を発火し得るため、applying_undo_ を立てて
+  // TableChanged の再処理 (dirty 再 set・SaveButton 文言更新・コマンド化) を抑制する。
+  const QScopedValueRollback<bool> guard(applying_undo_, true);
+  const int rows = ui_->PoiTable->rowCount();
+  const int cols = ui_->PoiTable->columnCount();
+  for (int r = 0; r < rows; ++r) {
+    for (int c = 0; c < cols; ++c) {
+      if (auto * item = ui_->PoiTable->item(r, c)) {
+        item->setBackground(QBrush());
+      }
     }
   }
 }
@@ -272,10 +315,9 @@ void PoiEditorPanel::ApplySetCell(int row, int col, const QString & text)
       } else {
         ui_->PoiTable->setItem(row, col, new QTableWidgetItem(text));
       }
-      // 編集済みの視覚マーク (通常編集の green 着色に合わせる)。
-      if (auto * item = ui_->PoiTable->item(row, col)) {
-        item->setBackground(Qt::green);
-      }
+      // 編集済みの視覚マーク (#445): clean 基準との比較で着色/解除する。undo で値が基準へ
+      // 戻ったセルは緑が解除され、redo で再び基準から離れれば緑に戻る。
+      RefreshCellEditMark(row, col);
       // shadow を書き換え後の値に同期する (次の cellChanged 差分計算の基準を更新)。
       if (row < static_cast<int>(shadow_.size()) &&
           col < static_cast<int>(shadow_[row].size())) {
@@ -312,12 +354,17 @@ void PoiEditorPanel::ApplyInsertRow(int row, const std::vector<QString> & texts,
     for (int col = 0; col < kColCount && col < static_cast<int>(texts.size()); ++col) {
       ui_->PoiTable->setItem(row, col, new QTableWidgetItem(texts[col]));
     }
-    // shadow に行を挿入して以降の差分計算の基準を保つ。
+    // shadow に行を挿入して以降の差分計算の基準を保つ。着色基準 (#445) にも同じ行を挿入して
+    // index を揃える。挿入行の着色基準 = 挿入時テキストとし、従来の「挿入行は無着色」挙動を
+    // 保ちつつ、以後のその行の編集・undo を比較で判定できるようにする。
+    std::vector<QString> row_texts(texts.begin(),
+      texts.begin() + std::min(texts.size(), static_cast<size_t>(kColCount)));
+    row_texts.resize(kColCount);
     if (row >= 0 && row <= static_cast<int>(shadow_.size())) {
-      std::vector<QString> shadow_row(texts.begin(),
-        texts.begin() + std::min(texts.size(), static_cast<size_t>(kColCount)));
-      shadow_row.resize(kColCount);
-      shadow_.insert(shadow_.begin() + row, std::move(shadow_row));
+      shadow_.insert(shadow_.begin() + row, row_texts);
+    }
+    if (row >= 0 && row <= static_cast<int>(clean_texts_.size())) {
+      clean_texts_.insert(clean_texts_.begin() + row, std::move(row_texts));
     }
     // #434: New/Copy 経路 (visual_ref_row >= 0) は、視覚順を並べ替え済みのテーブルでも
     // 新規行が選択行の視覚直下に来るよう moveSection する。Qt は挿入 section の視覚位置を
@@ -359,6 +406,10 @@ void PoiEditorPanel::ApplyRemoveRow(int row)
     }
     if (row >= 0 && row < static_cast<int>(shadow_.size())) {
       shadow_.erase(shadow_.begin() + row);
+    }
+    // 着色基準 (#445) からも同じ行を落として index を揃える。
+    if (row >= 0 && row < static_cast<int>(clean_texts_.size())) {
+      clean_texts_.erase(clean_texts_.begin() + row);
     }
   }
   table_dirty_ = true;
@@ -402,7 +453,9 @@ void PoiEditorPanel::TableChanged(int row, int column)
   }
 
   if(is_table_color_){
-    ui_->PoiTable->item(row, column)->setBackground(Qt::green);
+    // 編集済みの視覚マーク (#445): 無条件の緑でなく clean 基準との比較で着色/解除する。
+    // 手入力で元の値に戻した場合も緑が解除される (undo と意味を揃える)。
+    RefreshCellEditMark(row, column);
     // ユーザー編集の dirty マーク (#399)。UpdatePoiTable / TagFilterChanged の再構築中は
     // is_table_color_=false で setItem 由来の cellChanged が飛ぶため、既存の green 着色ガードに
     // 相乗りしてユーザー編集だけを拾う (再構築由来の cellChanged では dirty を立てない)。


### PR DESCRIPTION
Closes #445

## 変更内容

「緑 = clean 状態 (最後の全再構築 / 保存時点) とテキストが異なるセル」に着色の意味を揃える。

- shadow model (#407) と並行して着色基準 `clean_texts_` を追加 (`RebuildShadowModel` で同時に取り直し)
- `ApplySetCell` (undo/redo 適用) と `TableChanged` (通常編集) の着色を無条件緑 → 基準比較に変更 (`RefreshCellEditMark`): 一致 = 着色解除 (既定背景)、不一致 = 緑。**undo でセル値が戻れば緑も戻り、redo で再着色される**。手入力で元の値に戻した場合も解除される
- `cleanChanged(clean=true)` で全セルのマークを解除 (`ClearAllEditMarks`)。全て undo して clean へ戻った時、テキスト比較では検出できない行並べ替え (RowMoved) 由来の行着色もまとめて掃除する
- 行挿入/削除 (`ApplyInsertRow`/`ApplyRemoveRow`) で基準を行単位に同期 (挿入行の基準 = 挿入時テキスト。従来の「挿入行は無着色」を維持しつつ以後の編集/undo を判定可能に)
- 保存成功時は基準を保存内容 (= shadow) へ即時同期 (1.5 秒後の再構築を待たない。`baseline_content_` の即時更新と同旨)

## 割り切り (issue 記載どおり)

- 行並べ替え単体の undo は clean 到達時にまとめて着色解除される (dirty が残る状態で move だけ undo した行の緑は clean まで残る)

## 検証

- humble / jazzy 両 Docker で colcon build + test: 249 tests, 0 failures
- 再入安全性: `ClearAllEditMarks` / `RefreshCellEditMark` の setBackground は cellChanged を発火し得るが、前者は `applying_undo_` guard 下、後者は同値 early-return (Qt 5.12+) + shadow 差分ゼロで収束