### PR TITLE
fix(rviz): MapoiPanel 下部の余剰スペースを spacer で吸収 (#446)

### DIFF
--- a/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
+++ b/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
@@ -178,6 +178,19 @@
      </item>
     </layout>
    </item>
+   <item>
+    <spacer name="bottomSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
+++ b/mapoi_rviz_plugins/src/ui/mapoi_panel.ui
@@ -183,6 +183,9 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>0</width>


### PR DESCRIPTION
Closes #446

## 変更内容

`mapoi_panel.ui` の縦レイアウト末尾に垂直 spacer (`bottomSpacer`) を追加。パネルの余剰高さを最下部で吸収し、ウィジェット群を上詰め・最小間隔に保つ。

これまでは stretch / spacer が無く、ドックの余剰スペースが可変高ウィジェット (QLabel 群) に分配されるため、ステータスラベル (NavStatus / RouteProgress / CommandRejected) と Nav/Loc バックエンドステータス行の間隔が広がって見えていた。

- C++ 側の変更なし (`setupUi` のみで後付けウィジェットが無いことを確認済み)
- sizeHint は 0x0 (spacer は余剰吸収のみが目的で、最小高さを追加しない)

## 検証

- humble / jazzy 両 Docker で colcon build + test: 249 tests, 0 failures