### PR TITLE
fix(webui): UI トグル ☰ の点灯を UI 表示中 = 青に反転 (#449)

### DIFF
--- a/mapoi_webui/tests/web/e2e/ui-settings.e2e.js
+++ b/mapoi_webui/tests/web/e2e/ui-settings.e2e.js
@@ -35,19 +35,20 @@ test.describe('UI 表示コントロール (#323 / #324)', () => {
     const toggleBtn = page.locator('#btn-ui-toggle');
     expect(await displayOf(page, 'header')).not.toBe('none');
     expect(await displayOf(page, '#poi-panel')).not.toBe('none');
-    // アイコンは固定の ☰ (#390、swap しない)。状態は aria-pressed と title で示す
+    // アイコンは固定の ☰ (#390、swap しない)。状態は aria-pressed と title で示し、
+    // pressed = UI 表示中 (#449) なので既定 (表示) で青
     await expect(toggleBtn.locator('.ui-control-glyph')).toHaveText('☰');
-    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
     await expect(toggleBtn).toHaveAttribute('title', 'Hide UI (U)');
 
     await toggleBtn.click();
     expect(await bodyHasClass(page, 'ui-hidden')).toBe(true);
     expect(await displayOf(page, 'header')).toBe('none');
     expect(await displayOf(page, '#poi-panel')).toBe('none');
-    // UI を復帰できるようコントロール自身は残し、pressed (青) + title が「戻す」側へ同期
+    // UI を復帰できるようコントロール自身は残し、非表示中は消灯 + title が「戻す」側へ同期
     expect(await displayOf(page, '#ui-controls')).not.toBe('none');
     await expect(toggleBtn.locator('.ui-control-glyph')).toHaveText('☰');
-    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'true');
+    await expect(toggleBtn).toHaveAttribute('aria-pressed', 'false');
     await expect(toggleBtn).toHaveAttribute('title', 'Show UI (U)');
 
     await toggleBtn.click();

--- a/mapoi_webui/web/index.html
+++ b/mapoi_webui/web/index.html
@@ -27,7 +27,8 @@
       <!-- 地図上にフロートする UI 一括表示/非表示トグル (#324)。ui-hidden 時も残る
            ので UI を復帰できる。アイコンは固定の ☰ (Gmail/YouTube の sidebar トグルと
            同じ流儀、#390)。状態は swap でなく aria-pressed (青ハイライト) とパネル自体の
-           有無で示す — 当初の eye/eye-off swap (#324) は「アイコンが状態か操作か」の
+           有無で示し、pressed は「UI 表示中」(#449、ロックの「既定状態で点灯」と統一)
+           — 当初の eye/eye-off swap (#324) は「アイコンが状態か操作か」の
            両義性に加え、地図文脈では marker/レイヤー可視と誤読され得るため置換。
            ◑/⚙ グリフはダークモード/アプリ設定と誤読されるため不採用 (#324)。
            overlay / 不透明度の設定はパネル内 Display section (#323)。配線は ui-settings.js。 -->
@@ -64,7 +65,7 @@
           <span class="ui-control-glyph" aria-hidden="true">&#8630;</span>
         </button>
         <button id="btn-ui-toggle" type="button" class="ui-control-btn"
-                aria-pressed="false" title="Hide UI (U)" aria-label="Toggle UI visibility">
+                aria-pressed="true" title="Hide UI (U)" aria-label="Toggle UI visibility">
           <span class="ui-control-glyph" aria-hidden="true">&#9776;</span>
         </button>
         <!-- Help overlay (#391) を開く。ui-hidden 中も #ui-controls は残る仕様なので、

--- a/mapoi_webui/web/js/ui-settings.js
+++ b/mapoi_webui/web/js/ui-settings.js
@@ -173,9 +173,11 @@
 
     // アイコンは固定の ☰ (#390、index.html 側)。状態は aria-pressed (青ハイライト) と
     // title だけを同期し、icon swap はしない — Gmail/YouTube の sidebar トグルと同じ流儀。
+    // pressed は「UI 表示中」(#449): ☰ は「UI を出す」記号として読まれるため
+    // 表示中 = 青が直感に合い、ロックボタンの「既定状態で点灯」とも揃う。
     function syncToggleBtn() {
       if (!toggleBtn) return;
-      toggleBtn.setAttribute('aria-pressed', settings.hidden ? 'true' : 'false');
+      toggleBtn.setAttribute('aria-pressed', settings.hidden ? 'false' : 'true');
       toggleBtn.title = settings.hidden ? 'Show UI (U)' : 'Hide UI (U)';
     }
 


### PR DESCRIPTION
Closes #449

## 変更内容

UI 一括非表示トグル (☰、`#btn-ui-toggle`) の `aria-pressed` の意味を反転し、**UI 表示中 = 青 (pressed)** にする。

- `web/js/ui-settings.js` `syncToggleBtn()`: `settings.hidden ? 'true' : 'false'` → `settings.hidden ? 'false' : 'true'`
- `web/index.html`: 初期値 `aria-pressed="false"` → `"true"` (既定 = 表示 = 点灯) + 設計コメント更新
- `tests/web/e2e/ui-settings.e2e.js`: aria-pressed 期待値を反転
- tooltip (Hide UI (U) / Show UI (U)) は従来どおり状態に追従 (変更なし)

## 背景

☰ は「メニュー/UI を出す」記号として読まれるため、従来の「非表示中に青」は直感と逆に見えた (実機確認フィードバック)。ロックボタンの「既定状態で点灯」と揃え、起動時の見た目を一貫させる。

## テスト

- vitest unit: 100 passed (aria-pressed は pure helper 外のため変更なし)
- Playwright e2e: 74 passed (全 suite)

WebUI のみの変更で C++ ビルドへの影響なし。